### PR TITLE
Set port to 3000 in browserless npm install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In order to run Browserless, you'll need:
 2. `cd browserless`
 3. `npm install`
 4. `npm run dev`
-5. Visit `http://localhost:8080/` to use the interactive debugger.
+5. Visit `http://localhost:3000/` to use the interactive debugger.
 
 # Live Debugger
 


### PR DESCRIPTION
8080 didn't work for me, 3000 did and it seems to be 3000 everywhere else