### PR TITLE
add missing preferCSSPageSize option from puppeteer

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -104,6 +104,7 @@ export const pdf = Joi.object().keys({
       top: Joi.string(),
     }),
     pageRanges: Joi.string(),
+    preferCSSPageSize: Joi.boolean(),
     printBackground: Joi.boolean(),
     scale: Joi.number().min(0),
     width: Joi.any().optional(),


### PR DESCRIPTION
Just adding a missing option from the [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/docs/api.md#pagepdfoptions) for pdf generation.