### PR TITLE
Fixes prebooting of Chrome in cases of explicitly set to `undefined` …

### DIFF
--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -538,7 +538,7 @@ export class PuppeteerProvider {
   }
 
   private getChrome(opts: chromeHelper.ILaunchOptions): Promise<chromeHelper.IBrowser> {
-    const canUseChromeSwarm = this.config.prebootChrome && _.isEqual(opts, chromeHelper.defaultLaunchArgs);
+    const canUseChromeSwarm = this.config.prebootChrome && _.isEqual(_.omitBy(opts, _.isUndefined), _.omitBy(chromeHelper.defaultLaunchArgs, _.isUndefined));
     sysdebug(`Using pre-booted chrome: ${canUseChromeSwarm}`);
     const priorChrome = canUseChromeSwarm && this.chromeSwarm.shift();
 


### PR DESCRIPTION
…properties

This evaluates to false: `_.isEqual({a:undefined}, {})`

Somewhere else in the code, `trackingId` was being set to `undefined`, which caused a similar issue.  This removes `undefined` properties before `_.isEqual` comparison to circumvent the issue.