### PR TITLE
Leaves about:blank page open since otherwise browser closes

### DIFF
--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -549,7 +549,8 @@ export class PuppeteerProvider {
     sysdebug('Clearing browser for reuse');
 
     const openPages = await browser.pages();
-    openPages.forEach((page) => page.close());
+    // Close all tabs except the beginning "about:blank" tab as closing that would inadvertently lead to the browser being closed
+    openPages.slice(1).forEach((page) => page.close());
     this.chromeSwarm.push(Promise.resolve(browser));
 
     return sysdebug(`Chrome swarm: ${this.chromeSwarmSize} online`);


### PR DESCRIPTION
The browser kept getting closed even though it was attempting to be re-used.  The issue seems to be that the reuse logic closes all of the pages (including a placeholder about:blank), which leads Chrome to close the browser.