### PR TITLE
feat: support custom lighthouse audit configuration on /stats

### DIFF
--- a/functions/stats.js
+++ b/functions/stats.js
@@ -2,14 +2,18 @@ const lighthouse = require('lighthouse');
 const { URL } = require('url');
 const { canLog } = require('./build/utils');
 
+const DEFAULT_AUDIT_CONFIG = {
+  extends: 'lighthouse:default'
+}
+
 module.exports = async ({ browser, context }) => {
-  const { url } = context;
+  const { url, config = DEFAULT_AUDIT_CONFIG } = context;
 
   const { lhr } = await lighthouse(url, {
     port: (new URL(browser.wsEndpoint())).port,
     output: 'json',
     logLevel: canLog ? 'info' : 'silent',
-  });
+  }, config);
 
   return {
     data: lhr,


### PR DESCRIPTION
Support optional config context property on /stats to allow
customization of lighthouse run. Fallback to lighthouse:default
(existing behavior) if config is not provided.

relates to #317, knksmith57/browserless-lighthouse#2