### PR TITLE
feat: add perf budget support to /stats endpoint

### DIFF
--- a/functions/stats.js
+++ b/functions/stats.js
@@ -7,13 +7,23 @@ const DEFAULT_AUDIT_CONFIG = {
 }
 
 module.exports = async ({ browser, context }) => {
-  const { url, config = DEFAULT_AUDIT_CONFIG } = context;
+  const { 
+    url,
+    config = DEFAULT_AUDIT_CONFIG,
+    budgets 
+  } = context;
 
-  const { lhr } = await lighthouse(url, {
+  const options = {
     port: (new URL(browser.wsEndpoint())).port,
     output: 'json',
     logLevel: canLog ? 'info' : 'silent',
-  }, config);
+  };
+
+  if (budgets) {
+    options.budgets = budgets;
+  }
+
+  const { lhr } = await lighthouse(url, options, config);
 
   return {
     data: lhr,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -128,5 +128,6 @@ export const fn = Joi.object().keys({
 });
 
 export const stats = Joi.object().keys({
+  budgets:  Joi.array().items(Joi.object()).optional(),
   url: Joi.string().required(),
 });


### PR DESCRIPTION
The stats endpoint currently uses lighthouse to get stats about a website, this pull requests adds the ability for a performance budget to be sent to the endpoint which lighthouse will use to enrich the response.

The purpose to adding this is so that my open source project https://www.performancebudget.io is able to test performance budgets of websites

adds this section:

<img width="961" alt="Screenshot 2019-09-16 at 13 26 57" src="https://user-images.githubusercontent.com/630034/64957839-b034a180-d885-11e9-90a5-599dc2017a21.png">
