### PR TITLE
Add custom viewport support to PDF endpoint

### DIFF
--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -59,6 +59,7 @@ module.exports = async function pdf({ page, context }) {
     authenticate = null,
     cookies = [],
     emulateMedia,
+    viewport,
     html,
     options,
     url = null,
@@ -100,6 +101,10 @@ module.exports = async function pdf({ page, context }) {
 
   if (cookies.length) {
     await page.setCookie(...cookies);
+  }
+
+  if (viewport) {
+    await page.setViewport(viewport);
   }
 
   if (url !== null) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -123,6 +123,7 @@ export const pdf = Joi.object().keys({
   ),
   setExtraHTTPHeaders,
   url: Joi.string(),
+  viewport,
   waitFor,
 }).xor('url', 'html');
 

--- a/src/tests/integration/http.spec.ts
+++ b/src/tests/integration/http.spec.ts
@@ -645,7 +645,7 @@ describe('Browserless Chrome HTTP', () => {
       const body = {
         url: 'https://example.com',
         viewport: {
-          deviceScaleFactor: 3,
+          deviceScaleFactor: 1.2,
           height: 0,
           width: 0,
         },

--- a/src/tests/integration/http.spec.ts
+++ b/src/tests/integration/http.spec.ts
@@ -1097,6 +1097,33 @@ describe('Browserless Chrome HTTP', () => {
           expect(res.status).toBe(200);
         });
     });
+
+    it('allows custom viewport options', async () => {
+      const params = defaultParams();
+      const browserless = start(params);
+
+      await browserless.startServer();
+
+      const body = {
+        html: '<h1>Hello!</h1>',
+        viewport: {
+          deviceScaleFactor: 3,
+          height: 0,
+          width: 0,
+        },
+      };
+
+      return fetch(`http://127.0.0.1:${params.port}/pdf`, {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+        .then((res) => {
+          expect(res.status).toBe(200);
+        });
+    });
   });
 
   describe('/content', () => {


### PR DESCRIPTION
This PR adds support for custom viewport options to the PDF function.

**Why?**
When rendering a PDF, images and canvas elements can be rasterized in a lower resolution than you'd expect; from what I've read it would be rasterized at 72dpi, and then scaled up to 300dpi for the pdf, leading to pixelation in images and canvas-based charts. Allowing custom viewport allows, essentially, altering the DPI of images and rasterized canvases for better quality PDFs

Example - HTML5 Canvas-based Chart in PDF:

| Without custom viewport | <img width="334" alt="image" src="https://user-images.githubusercontent.com/3261554/68348909-7da17980-014f-11ea-8ae1-f232fdc539ba.png"> |
|:--- | --- |
| Veiwport with `deviceScaleFactor: 2` | <img width="332" alt="image" src="https://user-images.githubusercontent.com/3261554/68349006-c0fbe800-014f-11ea-8941-32fd49fecdd0.png"> |
| Viewport with `deviceScaleFactor: 3` | <img width="328" alt="image" src="https://user-images.githubusercontent.com/3261554/68349042-da049900-014f-11ea-9962-3811b7e6c597.png"> |