### PR TITLE
build: use the correct chrome version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ COPY . .
 # Install Chrome Stable when specified
 RUN if [ "$USE_CHROME_STABLE" = "true" ]; then \
     cd /tmp &&\
-    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&\
-    dpkg -i google-chrome-stable_current_amd64.deb;\
+    wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb &&\
+    dpkg -i google-chrome-beta_current_amd64.deb;\
   fi
 
 # Build


### PR DESCRIPTION
According to puppeteer@2, it is shipped to be compatible with Chromium 79.0.3942.0 (r706915).

That version corresponds with the beta release

```
Step 13/20 : RUN cd /tmp &&  wget -nv https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb &&  dpkg -i google-chrome-beta_current_amd64.deb
 ---> Running in 0029f7bb161a
2019-12-02 10:15:00 URL:https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb [64737384/64737384] -> "google-chrome-beta_current_amd64.deb" [1]
Selecting previously unselected package google-chrome-beta.
(Reading database ... 40860 files and directories currently installed.)
Preparing to unpack google-chrome-beta_current_amd64.deb ...
Unpacking google-chrome-beta (79.0.3945.56-1) ...
Setting up google-chrome-beta (79.0.3945.56-1) ...
```

More information about release channels at https://www.chromestatus.com/features/schedule



