### PR TITLE
[Feature] Add disable javascript property to /pdf, /screenshot & /content APIs

### DIFF
--- a/functions/content.js
+++ b/functions/content.js
@@ -24,6 +24,7 @@ module.exports = async function content ({ page, context }) {
     requestInterceptors = [],
     cookies = [],
     setExtraHTTPHeaders = null,
+    setJavaScriptEnabled = null,
     waitFor,
   } = context;
 
@@ -33,6 +34,10 @@ module.exports = async function content ({ page, context }) {
 
   if (setExtraHTTPHeaders) {
     await page.setExtraHTTPHeaders(setExtraHTTPHeaders);
+  }
+
+  if (setJavaScriptEnabled !== null) {
+    await page.setJavaScriptEnabled(setJavaScriptEnabled);
   }
 
   if (rejectRequestPattern.length || requestInterceptors.length) {

--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -69,6 +69,7 @@ module.exports = async function pdf({ page, context }) {
     rejectRequestPattern = [],
     requestInterceptors = [],
     setExtraHTTPHeaders,
+    setJavaScriptEnabled = null,
     waitFor,
   } = context;
 
@@ -78,6 +79,10 @@ module.exports = async function pdf({ page, context }) {
 
   if (setExtraHTTPHeaders) {
     await page.setExtraHTTPHeaders(setExtraHTTPHeaders);
+  }
+
+  if (setJavaScriptEnabled !== null) {
+    await page.setJavaScriptEnabled(setJavaScriptEnabled);
   }
 
   if (rejectRequestPattern.length || requestInterceptors.length) {

--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -29,6 +29,7 @@ module.exports = async function screenshot ({ page, context } = {}) {
     rejectRequestPattern = [],
     requestInterceptors = [],
     setExtraHTTPHeaders = null,
+    setJavaScriptEnabled = null,
     viewport,
     waitFor,
   } = context;
@@ -39,6 +40,10 @@ module.exports = async function screenshot ({ page, context } = {}) {
 
   if (setExtraHTTPHeaders) {
     await page.setExtraHTTPHeaders(setExtraHTTPHeaders);
+  }
+
+  if (setJavaScriptEnabled !== null) {
+    await page.setJavaScriptEnabled(setJavaScriptEnabled);
   }
 
   if (rejectRequestPattern.length || requestInterceptors.length) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -15,6 +15,8 @@ const authenticate = Joi.object().keys({
 
 const setExtraHTTPHeaders = Joi.object().unknown();
 
+const setJavaScriptEnabled = Joi.boolean();
+
 const rejectRequestPattern = Joi.array().items(Joi.string()).default([]);
 
 const requestInterceptors = Joi.array().items(Joi.object().keys({
@@ -71,6 +73,7 @@ export const screenshot = Joi.object().keys({
   rejectRequestPattern,
   requestInterceptors,
   setExtraHTTPHeaders,
+  setJavaScriptEnabled,
   url: Joi.string(),
   viewport,
   waitFor,
@@ -83,6 +86,7 @@ export const content = Joi.object().keys({
   rejectRequestPattern,
   requestInterceptors,
   setExtraHTTPHeaders,
+  setJavaScriptEnabled,
   url: Joi.string().required(),
   waitFor,
 });
@@ -122,6 +126,7 @@ export const pdf = Joi.object().keys({
     'Can prevent page crashes but is slower, consumes more memory, and returns a larger PDF.',
   ),
   setExtraHTTPHeaders,
+  setJavaScriptEnabled,
   url: Joi.string(),
   viewport,
   waitFor,


### PR DESCRIPTION
As promised, here's a pull request to implement Puppeteer's [`page.setJavaScriptEnabled`](https://pptr.dev/#?product=Puppeteer&version=v2.0.0&show=api-pagesetjavascriptenabledenabled) property in the aforementioned APIs.

I've added it as a top level property in `schema.ts` and I used Puppeteer's exact name for the sake of consistency. The method is only called if the user sets this boolean explicitly, so existing behavior should not be affected.

All tests pass (bar one, where it times out on loading example.com, but it also failed on `master` and I expected it is a system configuration issue, as I'm on Linux with a weird window manager), so that should all be fine. I haven't added any new unit tests, let me know if this is expected and where you'd like me to add them.

I did manually test using `https://www.enable-javascript.com/` and the feature seems to work fine on all of the APIs this is added to.

Feel free to make edits and additions where necessary, and let me know if I can do anything else to get this merged :)

