### PR TITLE
Handle unexpected websocket errors

### DIFF
--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -300,6 +300,10 @@ export class PuppeteerProvider {
 
     jobdebug(`${jobId}: ${req.url}: Inbound WebSocket request.`);
 
+    socket.on('error', (err: Error) => {
+      jobdebug(`${jobId}: A socket error has occurred: ${err.stack}`);
+    });
+
     // Catch actual running pages and route them appropriately
     if (route.includes('/devtools/page') && !route.includes(utils.jsonProtocolPrefix)) {
       const session = await chromeHelper.findSessionForPageUrl(route);


### PR DESCRIPTION
Hey, I'm applying this change because we've experienced several websocket errors under special conditions. We're trying to host browserless chrome on our Kubernetes cluster and we connect to it via puppeteer with a node.js client, also running on k8s. For some reason, I have no idea why, when there is heavy load on browserless (it starts to reject with 429s), some websocket connections are closed with an error. This causes browserless to crash and it cannot recover until we lower the load. Strangely enough, this only happens when both browserless and our client are running on k8s, running the client or both apps elsewhere does not cause this problem.

Here's an example from the logs with my change: 

```
2020-01-28T08:33:10.281Z browserless:job 86IJ2OVRO398Y0Y3CTCWT2AMMPW09IZN: /: Inbound WebSocket request.
2020-01-28T08:33:10.281Z browserless:job 86IJ2OVRO398Y0Y3CTCWT2AMMPW09IZN: Adding new job to queue.
2020-01-28T08:33:10.281Z browserless:server undefined: Recording queued stat.
2020-01-28T08:33:10.282Z browserless:job UFCPQZRWD8TWK0FVXRX0PTL863JYONHN: /: Inbound WebSocket request.
2020-01-28T08:33:10.282Z browserless:job UFCPQZRWD8TWK0FVXRX0PTL863JYONHN: Adding new job to queue.
2020-01-28T08:33:10.282Z browserless:server undefined: Recording queued stat.
2020-01-28T08:33:10.599Z browserless:job HJM2JVT3JRFUN8F7PITBPV1AGT0CEWUQ: /: Inbound WebSocket request.
2020-01-28T08:33:10.599Z browserless:job HJM2JVT3JRFUN8F7PITBPV1AGT0CEWUQ: Too many concurrent and queued requests, rejecting with 429.
2020-01-28T08:33:10.600Z browserless:server /: Too Many Requests
2020-01-28T08:33:10.601Z browserless:job HJM2JVT3JRFUN8F7PITBPV1AGT0CEWUQ: A socket error has occurred: Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:200:27)
2020-01-28T08:33:11.795Z browserless:job Q2GDH5QO37JJCLLQCRKE02WFL180KMH6: /: Inbound WebSocket request.
2020-01-28T08:33:11.799Z browserless:job Q2GDH5QO37JJCLLQCRKE02WFL180KMH6: Too many concurrent and queued requests, rejecting with 429.
2020-01-28T08:33:11.799Z browserless:server /: Too Many Requests
2020-01-28T08:33:11.804Z browserless:job F93KXCP35L8ZJVD1T7UP05UE9B3HAMTT: /: Inbound WebSocket request.
2020-01-28T08:33:11.804Z browserless:job F93KXCP35L8ZJVD1T7UP05UE9B3HAMTT: Too many concurrent and queued requests, rejecting with 429.
2020-01-28T08:33:11.804Z browserless:server /: Too Many Requests
```

As you can see, one of the sockets, that has a rejected job produces an error, but not all of them. It seems to me, that the client or k8s itself for some reason causes the connection to break, but, as it seems to only happen to already rejected connections, I would say, that simply handling the unexpected error is enough to fix this problem.