### PR TITLE
add git as dependency

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -qq update && \
   apt-add-repository ppa:malteworld/ppa && apt-get -qq update && apt-get -y -qq --no-install-recommends install \
   dumb-init \
   adobe-flashplugin \
+  git \
   msttcorefonts \
   ffmpeg \
   fonts-noto-color-emoji \


### PR DESCRIPTION
Hello,

npm accepts install a package as a git or github uri, like this

https://github.com/microlinkhq/metascraper/blob/master/packages/metascraper-readability/package.json#L21

for doing that, `git` needs to be installed on the machine; otherwise, it throws an error.

Although I know `git` is not a browserless dependency, I would like to ask if you accept this PR since this pattern is very common on Node.s universe.

Until now, the thing I did was to use the browserless image as a base and install the dependency as soon as possible, but since repositories has been deleted (https://github.com/browserless/chrome/blob/master/base/Dockerfile#L92) is always necessary to upgrade in order to install something, so:

- I can't be installed because you need to `update` first.
- `update` took a lot of time, around 5min.

I feel adding `git` by default can take the benefit to work as expected and no adding a negative penalty into the image time.