### PR TITLE
build: add some extra fonts

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get -qq update && \
   ffmpeg \
   fonts-noto-color-emoji \
   fonts-noto-cjk \
+  fonts-ipafont-gothic \
+  fonts-wqy-zenhei \
+  fonts-kacst \ 
+  fonts-freefont-ttf \
   fonts-liberation \
   fonts-thai-tlwg \
   fonts-indic \


### PR DESCRIPTION
These fonts are sugged by puppeteer team:
https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker