### PR TITLE
[bugfix] Prevent selenium from filling disk with --user-data-dirs

### DIFF
--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -375,22 +375,21 @@ export class BrowserlessServer {
 
     if (isStarting) {
       const ret = req as IWebdriverStartHTTP;
-      const { parsed, raw } = await util.normalizeWebdriverStart(req);
+      const { body, params } = await util.normalizeWebdriverStart(req);
 
-      if (!parsed) {
+      if (!body) {
         res.writeHead && res.writeHead(400, { 'Content-Type': 'text/plain' });
         return res.end('Bad Request');
       }
 
-      if (this.config.token && !util.isWebdriverAuthorized(req, parsed, this.config.token)) {
+      if (this.config.token && !util.isWebdriverAuthorized(req, body, this.config.token)) {
         res.writeHead && res.writeHead(403, { 'Content-Type': 'text/plain' });
         return res.end('Unauthorized');
       }
 
-      ret.body = parsed;
-      ret.raw = raw;
+      ret.body = body;
 
-      return this.webdriver.start(ret, res);
+      return this.webdriver.start(ret, res, params);
     }
 
     if (isClosing) {

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -375,19 +375,20 @@ export class BrowserlessServer {
 
     if (isStarting) {
       const ret = req as IWebdriverStartHTTP;
-      const postBody = await util.normalizeWebdriverStart(req);
+      const { parsed, raw } = await util.normalizeWebdriverStart(req);
 
-      if (!postBody) {
+      if (!parsed) {
         res.writeHead && res.writeHead(400, { 'Content-Type': 'text/plain' });
         return res.end('Bad Request');
       }
 
-      if (this.config.token && !util.isWebdriverAuthorized(req, postBody, this.config.token)) {
+      if (this.config.token && !util.isWebdriverAuthorized(req, parsed, this.config.token)) {
         res.writeHead && res.writeHead(403, { 'Content-Type': 'text/plain' });
         return res.end('Unauthorized');
       }
 
-      ret.body = postBody;
+      ret.body = parsed;
+      ret.raw = raw;
 
       return this.webdriver.start(ret, res);
     }

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -14,6 +14,7 @@ import { fetchJson, getDebug, getUserDataDir, rimraf } from './utils';
 
 import {
   IBrowser,
+  IBrowserlessSessionOptions,
   ILaunchOptions,
   IWindowSize,
   ISession,
@@ -407,13 +408,10 @@ export const launchChromeDriver = async ({
   blockAds = false,
   trackingId = null,
   pauseOnConnect = false,
+  browserlessDataDir = null,
   windowSize,
-}: {
-  blockAds: boolean,
-  trackingId: null | string,
-  pauseOnConnect: boolean,
-  windowSize?: IWindowSize
-}) => {
+  isUsingTempDataDir,
+}: IBrowserlessSessionOptions) => {
   return new Promise<IChromeDriver>(async (resolve, reject) => {
     const port = await getPort();
     let iBrowser = null;
@@ -437,8 +435,8 @@ export const launchChromeDriver = async ({
           iBrowser = await setupBrowser({
             blockAds,
             browser,
-            browserlessDataDir: null,
-            isUsingTempDataDir: false,
+            browserlessDataDir,
+            isUsingTempDataDir,
             prebooted: false,
             keepalive: null,
             pauseOnConnect,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -242,4 +242,5 @@ export interface IWorkspaceItem {
 
 export interface IWebdriverStartHTTP extends IHTTPRequest {
   body: any;
+  raw: string;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -242,5 +242,18 @@ export interface IWorkspaceItem {
 
 export interface IWebdriverStartHTTP extends IHTTPRequest {
   body: any;
-  raw: string;
+}
+
+export interface IBrowserlessSessionOptions {
+  blockAds: boolean;
+  trackingId: string | null;
+  pauseOnConnect: boolean;
+  windowSize?: IWindowSize;
+  isUsingTempDataDir: boolean;
+  browserlessDataDir: string | null;
+}
+
+export interface IWebdriverStartNormalized {
+  body: any;
+  params: IBrowserlessSessionOptions;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -235,7 +235,7 @@ const safeParse = (maybeJson: any) => {
   }
 };
 
-export const normalizeWebdriverStart = async (req: IncomingMessage): Promise<any> => {
+export const normalizeWebdriverStart = async (req: IncomingMessage): Promise<{ raw: string; parsed: any; }> => {
   const body = await readRequestBody(req);
   const parsed = safeParse(body);
 
@@ -289,7 +289,7 @@ export const normalizeWebdriverStart = async (req: IncomingMessage): Promise<any
   req.headers['content-length'] = stringifiedBody.length.toString();
   attachBodyToRequest(req, stringifiedBody);
 
-  return parsed;
+  return { parsed, raw: stringifiedBody };
 };
 
 const attachBodyToRequest = (req: IncomingMessage, body: any) => {

--- a/src/webdriver-provider.ts
+++ b/src/webdriver-provider.ts
@@ -46,7 +46,7 @@ export class WebDriver {
     const job: IJob = Object.assign(
       (done: IDone) => {
         req.removeListener('close', earlyClose);
-        this.launchChrome(req.body)
+        this.launchChrome(req)
           .then((chromeDriver) => {
             const proxy: any = httpProxy.createProxyServer({
               changeOrigin: true,
@@ -215,13 +215,14 @@ export class WebDriver {
     return session;
   }
 
-  private launchChrome(body: any, retries = 1): Promise<IChromeDriver> {
-    const blockAds = body.desiredCapabilities['browserless.blockAds'];
-    const trackingId = body.desiredCapabilities['browserless.trackingId'];
-    const pauseOnConnect = body.desiredCapabilities['browserless.pause'];
-    const launchArgs: string[] = _.get(body, 'desiredCapabilities["goog:chromeOptions"].args', []);
+  private launchChrome(req: IWebdriverStartHTTP, retries = 1): Promise<IChromeDriver> {
+    const blockAds = req.body.desiredCapabilities['browserless.blockAds'];
+    const trackingId = req.body.desiredCapabilities['browserless.trackingId'];
+    const pauseOnConnect = req.body.desiredCapabilities['browserless.pause'];
+    const launchArgs: string[] = _.get(req.body, 'desiredCapabilities["goog:chromeOptions"].args', []);
     const windowSizeArg = launchArgs.find((arg) => arg.includes('window-size='));
     const windowSizeParsed = windowSizeArg && windowSizeArg.split('=')[1].split(',');
+
     let windowSize;
 
     if (Array.isArray(windowSizeParsed)) {
@@ -243,7 +244,7 @@ export class WebDriver {
 
         if (retries) {
           debug(`Retrying launch of ChromeDriver`);
-          return this.launchChrome(body, retries - 1);
+          return this.launchChrome(req, retries - 1);
         }
 
         debug(`Retries exhausted, throwing`);

--- a/src/webdriver-provider.ts
+++ b/src/webdriver-provider.ts
@@ -9,6 +9,7 @@ import { getDebug } from './utils';
 import {
   IChromeDriver,
   IWebdriverStartHTTP,
+  IWebdriverStartNormalized,
   IWebDriverSession,
   IWebDriverSessions,
   IDone,
@@ -30,7 +31,7 @@ export class WebDriver {
   // Since Webdriver commands happen over HTTP, and aren't
   // maintained, we treat with the initial session request
   // with some special circumstances and use it inside our queue
-  public start(req: IWebdriverStartHTTP, res: ServerResponse) {
+  public start(req: IWebdriverStartHTTP, res: ServerResponse, params: IWebdriverStartNormalized['params']) {
     debug(`Inbound webdriver request`);
 
     if (!this.queue.hasCapacity) {
@@ -46,7 +47,7 @@ export class WebDriver {
     const job: IJob = Object.assign(
       (done: IDone) => {
         req.removeListener('close', earlyClose);
-        this.launchChrome(req)
+        this.launchChrome(params)
           .then((chromeDriver) => {
             const proxy: any = httpProxy.createProxyServer({
               changeOrigin: true,
@@ -215,36 +216,14 @@ export class WebDriver {
     return session;
   }
 
-  private launchChrome(req: IWebdriverStartHTTP, retries = 1): Promise<IChromeDriver> {
-    const blockAds = req.body.desiredCapabilities['browserless.blockAds'];
-    const trackingId = req.body.desiredCapabilities['browserless.trackingId'];
-    const pauseOnConnect = req.body.desiredCapabilities['browserless.pause'];
-    const launchArgs: string[] = _.get(req.body, 'desiredCapabilities["goog:chromeOptions"].args', []);
-    const windowSizeArg = launchArgs.find((arg) => arg.includes('window-size='));
-    const windowSizeParsed = windowSizeArg && windowSizeArg.split('=')[1].split(',');
-
-    let windowSize;
-
-    if (Array.isArray(windowSizeParsed)) {
-      const [ width, height ] = windowSizeParsed;
-      windowSize = {
-        width: +width,
-        height: +height,
-      };
-    }
-
-    return chromeHelper.launchChromeDriver({
-      blockAds,
-      pauseOnConnect,
-      trackingId,
-      windowSize,
-    })
+  private launchChrome(params: IWebdriverStartNormalized['params'], retries = 1): Promise<IChromeDriver> {
+    return chromeHelper.launchChromeDriver(params)
       .catch((error) => {
         debug(`Issue launching ChromeDriver, error:`, error);
 
         if (retries) {
           debug(`Retrying launch of ChromeDriver`);
-          return this.launchChrome(req, retries - 1);
+          return this.launchChrome(params, retries - 1);
         }
 
         debug(`Retries exhausted, throwing`);


### PR DESCRIPTION
Selenium's temporary --user-data-dir can often fill disk space on machines. This change allows browserless to inject its own user-data-dir, and cleans it up, so that we don't have this issue.

Also adds more unit-tests for the web-driver start normalizing behavior