### PR TITLE
/usr/bin/env: ‘node\r’: No such file or directory

### DIFF
--- a/scripts/get-meta.js
+++ b/scripts/get-meta.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 /*
   This script sucks out versioning information out from Chrome
   so that we can label builds nicely in docker and facilitate


### PR DESCRIPTION
Build crash when on windows.

```
/usr/bin/env: ‘node\r’: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! syscall spawn
npm ERR! file sh
npm ERR! errno ENOENT
npm ERR! browserless-chrome@1.32.0 meta: `./scripts/get-meta.js`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the browserless-chrome@1.32.0 meta script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```