### PR TITLE
Wait for close before killing the process

### DIFF
--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -10,7 +10,7 @@ import * as url from 'url';
 
 import { Features } from './features';
 import { browserHook, pageHook } from './hooks';
-import { fetchJson, getDebug, getUserDataDir, rimraf } from './utils';
+import { fetchJson, getDebug, getUserDataDir, rimraf, sleep } from './utils';
 
 import {
   IBrowser,
@@ -513,7 +513,11 @@ export const closeBrowser = async (browser: IBrowser) => {
     }
 
     runningBrowsers = runningBrowsers.filter((b) => b._wsEndpoint !== browser._wsEndpoint);
-    await browser.close().catch(_.noop);
+    await Promise.race([
+      browser.close().catch(_.noop),
+      // In case browser.close hangs, timeout after 5 seconds
+      sleep(5000),
+    ])
     browser.removeAllListeners();
   } catch (error) {
     debug(`Browser close emitted an error ${error.message}`);

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -513,7 +513,7 @@ export const closeBrowser = async (browser: IBrowser) => {
     }
 
     runningBrowsers = runningBrowsers.filter((b) => b._wsEndpoint !== browser._wsEndpoint);
-    browser.close().catch(_.noop);
+    await browser.close().catch(_.noop);
     browser.removeAllListeners();
   } catch (error) {
     debug(`Browser close emitted an error ${error.message}`);


### PR DESCRIPTION
Our process was receiving the following error:
```
events.js:292
throw er; // Unhandled 'error' event
      ^
Error: This socket has been ended by the other party
at Socket.writeAfterFIN [as write] (net.js:454:14)
at PipeTransport.send (/usr/src/app/node_modules/puppeteer/lib/PipeTransport.js:44:21)
at Connection._rawSend (/usr/src/app/node_modules/puppeteer/lib/Connection.js:86:21)
at Connection.send (/usr/src/app/node_modules/puppeteer/lib/Connection.js:72:21)
at gracefullyCloseChrome (/usr/src/app/node_modules/puppeteer/lib/Launcher.js:194:20)
at Browser.close (/usr/src/app/node_modules/puppeteer/lib/Browser.js:255:31)
at Browser.<anonymous> (/usr/src/app/node_modules/puppeteer/lib/helper.js:111:23)
at Object.exports.closeBrowser (/usr/src/app/build/chrome-helper.js:314:17)
at closeChrome (/usr/src/app/build/puppeteer-provider.js:371:32)
at PuppeteerProvider.cleanUpJob (/usr/src/app/build/puppeteer-provider.js:396:9)
Emitted 'error' event on Socket instance at:
at emitErrorNT (net.js:1340:8)
at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  code: 'EPIPE'
}
```
I suspect what was happening was that the browser was being killed while the close was happening and this was resulting in an unhandled exception from puppeteer.