### PR TITLE
Fix README.md docs of using puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ const browser = await puppeteer.launch();
 
 **After**
 ```js
-await puppeteer.connect({ browserWSEndpoint: 'ws://localhost:3000' });
+const browser = await puppeteer.connect({ browserWSEndpoint: 'ws://localhost:3000' });
 ```
 
 # Webdriver (selenium)


### PR DESCRIPTION
The docs were missing the needed `const browser = `. Here you can see a proper example https://docs.browserless.io/docs/works.html