### PR TITLE
Fix crash due to puppeteer removing the emulateMedia alias.

### DIFF
--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -104,7 +104,10 @@ module.exports = async function pdf({ page, context }) {
   }
 
   if (emulateMedia) {
-    await page.emulateMediaType(emulateMedia);
+    // Run the appropriate emulateMedia method, making sure it's bound properly to the page object
+    // @todo remove when support drops for 3.x.x
+    const emulateMedia = (page.emulateMedia || page.emulateMediaType).bind(page);
+    await emulateMedia(emulateMedia);
   }
 
   if (cookies.length) {

--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -104,7 +104,7 @@ module.exports = async function pdf({ page, context }) {
   }
 
   if (emulateMedia) {
-    await page.emulateMedia(emulateMedia);
+    await page.emulateMediaType(emulateMedia);
   }
 
   if (cookies.length) {


### PR DESCRIPTION
As described in the release notes for puppeteer 5 the emulateMedia function has been removed. It was an alias to emulateMediaType which behaves identically and this fixes the crash when you use emulateMedia in browserless. 

This keeps the browserless API the same as before but maybe you want to change that to emulateMediaType as well to align with puppeteer, but that would introduce a breaking change.