### PR TITLE
Add pre-request load checks

### DIFF
--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -13,7 +13,7 @@ import * as url from 'url';
 import { Features } from './features';
 import * as util from './utils';
 
-import { ResourceMonitor } from './hardware-monitoring';
+import { getMachineStats } from './hardware-monitoring';
 import { afterRequest, beforeRequest, externalRoutes } from './hooks';
 import { PuppeteerProvider } from './puppeteer-provider';
 import { Queue } from './queue';
@@ -50,7 +50,6 @@ export class BrowserlessServer {
   private config: IBrowserlessOptions;
   private stats: IBrowserlessStats[];
   private httpServer: http.Server;
-  private readonly resourceMonitor: ResourceMonitor;
   private puppeteerProvider: PuppeteerProvider;
   private webdriver: WebDriver;
   private metricsInterval: NodeJS.Timeout;
@@ -73,7 +72,6 @@ export class BrowserlessServer {
       },
     });
 
-    this.resourceMonitor = new ResourceMonitor();
     this.puppeteerProvider = new PuppeteerProvider(opts, this, this.queue);
     this.webdriver = new WebDriver(this.queue);
     this.enableAPIGet = opts.enableAPIGet;
@@ -163,7 +161,7 @@ export class BrowserlessServer {
   }
 
   public async getMetrics() {
-    const { cpu, memory } = await this.resourceMonitor.getMachineStats();
+    const { cpu, memory } = await getMachineStats();
 
     return [...this.stats, {
       ...this.currentStat,
@@ -179,8 +177,7 @@ export class BrowserlessServer {
   }
 
   public async getPressure() {
-    const { cpu, memory } = await this.resourceMonitor
-      .getMachineStats()
+    const { cpu, memory } = await getMachineStats()
       .catch((err) => {
         debug(`Error loading cpu/memory in pressure call ${err}`);
         return { cpu: null, memory: null };
@@ -328,7 +325,7 @@ export class BrowserlessServer {
       new Promise((resolve) => this.httpServer.close(resolve)),
       new Promise((resolve) => {
         this.proxy.close();
-        resolve();
+        resolve(null);
       }),
       this.puppeteerProvider.kill(),
       this.webdriver.kill(),
@@ -504,7 +501,7 @@ export class BrowserlessServer {
   }
 
   private async recordMetrics() {
-    const { cpu, memory } = await this.resourceMonitor.getMachineStats();
+    const { cpu, memory } = await getMachineStats();
 
     this.stats.push(Object.assign({}, {
       ...this.currentStat,

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,7 @@ export const TIMEOUT_ALERT_URL: string | null = process.env.TIMEOUT_ALERT_URL ||
 export const ERROR_ALERT_URL: string | null = process.env.ERROR_ALERT_URL || null;
 
 // Health
+export const PRE_REQUEST_HEALTH_CHECK: boolean = parseJSONParam(process.env.PRE_REQUEST_HEALTH_CHECK, false);
 export const EXIT_ON_HEALTH_FAILURE: boolean = parseJSONParam(process.env.EXIT_ON_HEALTH_FAILURE, false);
 export const MAX_CPU_PERCENT: number = parseNumber(process.env.MAX_CPU_PERCENT, 99);
 export const MAX_MEMORY_PERCENT: number = parseNumber(process.env.MAX_MEMORY_PERCENT, 99);

--- a/src/hardware-monitoring.ts
+++ b/src/hardware-monitoring.ts
@@ -2,29 +2,40 @@ import * as _ from 'lodash';
 import si = require('systeminformation');
 import { getDebug } from './utils';
 import { IResourceLoad } from './types';
+import { MAX_CPU_PERCENT, MAX_MEMORY_PERCENT } from './config';
 
 const log = getDebug('hardware');
 
-export class ResourceMonitor {
+export const getMachineStats = async (): Promise<IResourceLoad> => {
+  const [
+    cpuLoad,
+    memLoad,
+  ] = await Promise.all([
+    si.currentLoad(),
+    si.mem(),
+  ]).catch((err) => {
+    log(`Error checking machine stats`, err);
+    return [null, null];
+  });
 
-  public async getMachineStats(): Promise<IResourceLoad> {
-    const [
-      cpuLoad,
-      memLoad,
-    ] = await Promise.all([
-      si.currentLoad(),
-      si.mem(),
-    ]).catch((err) => {
-      log(`Error checking machine stats`, err);
-      return [null, null];
-    });
+  const cpu = cpuLoad ? cpuLoad.currentload / 100 : null;
+  const memory = memLoad ? memLoad.active / memLoad.total : null;
 
-    const cpu = cpuLoad ? cpuLoad.currentload / 100 : null;
-    const memory = memLoad ? memLoad.active / memLoad.total : null;
+  return {
+    cpu,
+    memory,
+  };
+};
 
-    return {
-      cpu,
-      memory,
-    };
-  }
+export const overloaded = async(): Promise<boolean> => {
+  const { cpu, memory } = await getMachineStats();
+  const cpuInt = cpu && Math.ceil(cpu * 100);
+  const memoryInt = memory && Math.ceil(memory * 100);
+
+  log(`Checking overload status: CPU ${cpuInt}% Memory ${memoryInt}%`);
+
+  const badCPU = cpuInt && (cpuInt >= MAX_CPU_PERCENT);
+  const badMem = memoryInt && (memoryInt >= MAX_MEMORY_PERCENT);
+
+  return !!(badCPU || badMem);
 }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,11 +1,15 @@
 import * as _ from 'lodash';
 import q from 'queue';
+
+import { overloaded } from './hardware-monitoring';
 import * as util from './utils';
 
 import {
   IJob,
   IQueueConfig,
 } from './types';
+
+import { PRE_REQUEST_HEALTH_CHECK } from './config';
 
 export class Queue {
   private queue: q;
@@ -42,6 +46,10 @@ export class Queue {
     }
 
     this.queue.push(job);
+  }
+
+  public async overloaded() {
+    return PRE_REQUEST_HEALTH_CHECK && await overloaded();
   }
 
   public remove(job: IJob) {


### PR DESCRIPTION
New `PRE_REQUEST_HEALTH_CHECK` to enable pre-request health checks for all APIs, Websockets, and Webdriver