### PR TITLE
Full support for running under a proxy

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -142,9 +142,7 @@ export const HOST: string | undefined = process.env.HOST;
 export const PORT: number = parseNumber(process.env.PORT, 8080);
 export const SOCKET_CLOSE_METHOD = parseSocketBehavior(process.env.SOCKET_CLOSE_METHOD);
 
-// Host and port for /session calls to build URLs to.
-// Useful for when browserless is behind a proxy
-export const PROXY_HOST: string | undefined = process.env.PROXY_HOST;
-export const PROXY_PORT: string | undefined = process.env.PROXY_PORT;
-export const PROXY_SSL: boolean = parseJSONParam(process.env.PROXY_SSL, false);
+// PROXY URL is used for browserless to build appropriate URLs when it's behind a proxy
+// (must be a fully-qualified URL)
+export const PROXY_URL: string | undefined = process.env.PROXY_URL;
 export const MAX_PAYLOAD_SIZE: string = process.env.MAX_PAYLOAD_SIZE || '5mb';

--- a/src/tests/integration/__snapshots__/websockets.spec.ts.snap
+++ b/src/tests/integration/__snapshots__/websockets.spec.ts.snap
@@ -9,9 +9,9 @@ Array [
   "type",
   "url",
   "webSocketDebuggerUrl",
-  "browserId",
-  "browserWSEndpoint",
   "port",
+  "browserId",
   "trackingId",
+  "browserWSEndpoint",
 ]
 `;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -44,6 +44,7 @@ export interface ISession {
   port: string;
   trackingId: string | null;
   browserWSEndpoint: string;
+  browserId: string;
 }
 
 export interface IWindowSize {
@@ -266,7 +267,7 @@ export interface IWebdriverStartNormalized {
   params: IBrowserlessSessionOptions;
 }
 
-export interface IJSONList {
+export interface IDevtoolsJSON {
   description: string;
   devtoolsFrontendUrl: string;
   id: string;


### PR DESCRIPTION
Fixes running under a proxy/nginx/lb by supporting a single `PROXY_URL`. Browserless takes care of parsing out the URL, applying ports, SSL, and the appropriate protocol. Format is in HTTP:

```
PROXY_URL=http://my-proxy.biz.com/some/path
```