### PR TITLE
Change start.sh cleanup process

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set +e # explicitly don't return on non-zero exit code for any line
 
 # When docker restarts, this file is still there,
 # so we need to kill it just in case
@@ -10,7 +11,6 @@ _kill_procs() {
   kill -TERM $xvfb
 }
 
-# Relay quit commands to processes
 trap _kill_procs SIGTERM SIGINT
 
 Xvfb :99 -screen 0 1024x768x16 -nolisten tcp -nolisten unix &
@@ -21,5 +21,4 @@ export DISPLAY=:99
 dumb-init -- node ./build/index.js $@ &
 node=$!
 
-wait $node
-wait $xvfb
+wait


### PR DESCRIPTION
The current `start.sh` script uses `set -e` and two `wait` calls which are intended (I think) to each return after a `trap` triggers a cleanup function to execute. The problem with this is that `wait` [returns a non-zero (128) exit code when interrupted by `trap`](https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_12_02.html) and `set -e` forces the script to exit upon any command returning a non-zero exit code. So, the second `wait` never triggers.

This PR changes the behavior of the script to continue even if non-zero exit codes are encountered (`set +e`) and `wait` is applied to all sub-processes.

I've tested by adding a print statement below `wait` and everything cleans up nicely.