### PR TITLE
Use node slim image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ ENV USE_CHROME_STABLE=${USE_CHROME_STABLE}
 ENV WORKSPACE_DIR=$APP_DIR/workspace
 
 RUN mkdir -p $APP_DIR $WORKSPACE_DIR
-
-# Run everything after as non-privileged user.
-USER node
 WORKDIR $APP_DIR
 
 # Install app dependencies
@@ -49,5 +46,8 @@ RUN if [ "$USE_CHROME_STABLE" = "true" ]; then \
 
 # Expose the web-socket and HTTP ports
 EXPOSE 3000
+
+# Run everything after as non-privileged user.
+USER node
 
 CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PUPPETEER_CHROMIUM_REVISION
 ARG PUPPETEER_VERSION
 
 # Application parameters and variables
-ENV APP_DIR=/usr/src/app
+ENV APP_DIR=/home/node/app
 ENV CONNECTION_TIMEOUT=60000
 ENV CHROME_PATH=/usr/bin/google-chrome
 ENV HOST=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV WORKSPACE_DIR=$APP_DIR/workspace
 
 RUN mkdir -p $APP_DIR $WORKSPACE_DIR
 
+# Run everything after as non-privileged user.
+USER node
 WORKDIR $APP_DIR
 
 # Install app dependencies
@@ -43,11 +45,7 @@ RUN if [ "$USE_CHROME_STABLE" = "true" ]; then \
   fi &&\
   npm i puppeteer@$PUPPETEER_VERSION;\
   npm run postinstall &&\
-  npm run build &&\
-  chown -R blessuser:blessuser $APP_DIR
-
-# Run everything after as non-privileged user.
-USER blessuser
+  npm run build
 
 # Expose the web-socket and HTTP ports
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,10 @@ RUN if [ "$USE_CHROME_STABLE" = "true" ]; then \
   npm run postinstall &&\
   npm run build
 
-# Expose the web-socket and HTTP ports
-EXPOSE 3000
-
 # Run everything after as non-privileged user.
 USER node
+
+# Expose the web-socket and HTTP ports
+EXPOSE 3000
 
 CMD ["./start.sh"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -73,10 +73,5 @@ RUN apt-get -qq update && \
   fc-cache -f -v &&\
   apt-get -qq clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Add the browserless user (blessuser)
-RUN groupadd -r blessuser && useradd -r -g blessuser -G audio,video blessuser \
-  && mkdir -p /home/blessuser/Downloads \
-  && chown -R blessuser:blessuser /home/blessuser
-
 # Install deps necessary to build
 RUN npm install -g typescript @types/node

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM node:14-slim
 
 COPY fonts.conf /etc/fonts/local.conf
 
@@ -69,9 +69,6 @@ RUN apt-get -qq update && \
   xdg-utils \
   wget \
   xvfb \
-  curl &&\
-  curl --silent --location https://deb.nodesource.com/setup_14.x | bash - &&\
-  apt-get -y -qq install nodejs &&\
   apt-get -y -qq install build-essential &&\
   fc-cache -f -v &&\
   apt-get -qq clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
The official Node.js has installed the binary so you don't need to install it.

Also, the image exposes an unprivileged user `node`

https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user

The tests are failing because the image is done using the current-based image.