### PR TITLE
Feature: Allow functions to inject some ENV vars into the sandboxed VM

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,10 @@
     "transform": {
       ".(ts)": "ts-jest"
     },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$"
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+    "setupFiles": [
+      "<rootDir>/tests/jest/setEnvVars.js"
+    ]
   },
   "snyk": true
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -186,6 +186,10 @@ export const FUNCTION_BUILT_INS: string[] = parseJSONParam(
   process.env.FUNCTION_BUILT_INS,
   REQUIRED_INTERNALS,
 );
+export const FUNCTION_ENV_VARS: string[] = parseJSONParam(
+  process.env.FUNCTION_ENV_VARS,
+  [],
+);
 export const FUNCTION_ENABLE_INCOGNITO_MODE: boolean = parseJSONParam(
   process.env.FUNCTION_ENABLE_INCOGNITO_MODE,
   false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const browserless = new BrowserlessServer({
   errorAlertURL: config.ERROR_ALERT_URL,
   exitOnHealthFailure: config.EXIT_ON_HEALTH_FAILURE,
   functionBuiltIns: config.FUNCTION_BUILT_INS,
+  functionEnvVars: config.FUNCTION_ENV_VARS,
   functionEnableIncognitoMode: config.FUNCTION_ENABLE_INCOGNITO_MODE,
   functionExternals: config.FUNCTION_EXTERNALS,
   healthFailureURL: config.FAILED_HEALTH_URL,

--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -124,6 +124,7 @@ export class PuppeteerProvider {
     ignoreDefaultArgs = false,
     builtin = this.config.functionBuiltIns,
     external = this.config.functionExternals,
+    envVars = this.config.functionEnvVars,
   }: IRunHTTP) {
     const jobId = utils.id();
     const trackingId = req.query.trackingId;
@@ -159,13 +160,13 @@ export class PuppeteerProvider {
         hook: this.server.sessionCheckFailHook,
       });
     }
-
     const vm = new NodeVM({
       require: {
         builtin,
         external,
         root: './node_modules',
       },
+      env: _.pick(process.env, envVars)
     });
 
     const handler: (args: any) => Promise<any> = vm.run(

--- a/src/tests/integration/__snapshots__/http.spec.ts.snap
+++ b/src/tests/integration/__snapshots__/http.spec.ts.snap
@@ -12,6 +12,7 @@ Array [
   "errorAlertURL",
   "exitOnHealthFailure",
   "functionBuiltIns",
+  "functionEnvVars",
   "functionEnableIncognitoMode",
   "functionExternals",
   "healthFailureURL",

--- a/src/tests/integration/utils.ts
+++ b/src/tests/integration/utils.ts
@@ -17,6 +17,7 @@ export const defaultParams = (): IBrowserlessOptions => ({
   errorAlertURL: null,
   exitOnHealthFailure: false,
   functionBuiltIns: ['url'],
+  functionEnvVars: [],
   functionEnableIncognitoMode: false,
   functionExternals: ['lighthouse'],
   healthFailureURL: null,

--- a/src/tests/jest/setEnvVars.js
+++ b/src/tests/jest/setEnvVars.js
@@ -1,0 +1,1 @@
+process.env.SOME_ENV_VAR_TO_ALLOW_IN_FUNCTIONS = 'bar';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -86,6 +86,7 @@ export interface IRunHTTP {
   headless?: boolean;
   ignoreDefaultArgs?: boolean | string[];
   builtin?: string[];
+  envVars?: string[];
   external?: string[];
 }
 
@@ -159,6 +160,7 @@ export interface IChromeServiceConfiguration {
   functionExternals: string[];
   functionEnableIncognitoMode: boolean;
   functionBuiltIns: string[];
+  functionEnvVars: string[];
   maxMemory: number;
   maxCPU: number;
   keepAlive: boolean;

--- a/test.sh
+++ b/test.sh
@@ -6,4 +6,6 @@ xvfb=$!
 
 export DISPLAY=:1
 
+export SOME_ENV_VAR_TO_ALLOW_IN_FUNCTIONS=true
+
 ./node_modules/.bin/jest --runInBand --forceExit $@ && kill -TERM $xvfb


### PR DESCRIPTION
Hello,

I have a function that creates a PDF and uploads to AWS S3.  I wanted to use ENV variables for the S3 credentials but realized you cannot access the ENV in the function body (for good reason by default!). 

Similar to allowing some built-ins and/or externals, you can now specify which ENV vars you can allow in the function's VM env via the FUNCTION_ENV_VARS env var.

Example:
```
FUNCTION_ENV_VARS=["MY_ENV_VAR1","MY_ENV_VAR2"]
```

I added a test case to ensure the allowed ENV var is indeed available in the function. 