### PR TITLE
chore: normalizing env vars for windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
+        "cross-env": "^7.0.3",
         "env-cmd": "^10.0.0",
         "eslint": "^8.0.1",
         "eslint-plugin-import": "^2.24.0",
@@ -3057,6 +3058,24 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -12499,6 +12518,15 @@
       "requires": {
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rimraf build",
-    "deploy": "DEBUG=browserless* ./scripts/deploy.js",
-    "deploy-base": "DEBUG=browserless* ./scripts/deploy-base.js",
+    "deploy": "cross-env DEBUG=browserless* ./scripts/deploy.js",
+    "deploy-base": "cross-env DEBUG=browserless* ./scripts/deploy-base.js",
     "dev": "npm run build && env-cmd -f ./.env.dev node build/index.js",
     "start": "node ./build",
-    "test": "DEBUG=quiet jest --runInBand --detectOpenHandles",
+    "test": "cross-env DEBUG=quiet jest --runInBand --detectOpenHandles",
     "external": "rimraf debugger/devtools && node ./scripts/install-external-deps.js",
-    "postinstall": "./scripts/postinstall.js",
+    "postinstall": "node ./scripts/postinstall.js",
     "snyk-protect": "snyk protect",
     "prettier": "prettier --config .prettierrc --write --loglevel error '{src,functions,scripts}/**/*.{js,ts}'",
     "lint": "eslint src --ext .ts --fix"
@@ -142,6 +142,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.1.0",
     "@typescript-eslint/parser": "^5.1.0",
+    "cross-env": "^7.0.3",
     "env-cmd": "^10.0.0",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.24.0",


### PR DESCRIPTION
# Summary

While WSL, Git Bash and others do, Windows doesn't support passing env vars in the form `KEY=val node ./index.js` natively. The project has some npm tasks that pass env vars in this fashion, which make them not able to be ran.

## Changes

- `cross-env` is now used to normalize env vars passing to tasks
- `postinstall` task what added the `node ` prefix, as Windows has no shebang support out of the box