### PR TITLE
chore: add `viewport` option to /content

### DIFF
--- a/functions/content.js
+++ b/functions/content.js
@@ -29,6 +29,7 @@ module.exports = async function content({ page, context }) {
     setExtraHTTPHeaders = null,
     setJavaScriptEnabled = null,
     userAgent = null,
+    viewport = null,
     waitFor,
   } = context;
 
@@ -74,6 +75,10 @@ module.exports = async function content({ page, context }) {
 
   if (userAgent) {
     await page.setUserAgent(userAgent);
+  }
+
+  if (viewport) {
+    await page.setViewport(viewport);
   }
 
   const response =

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -178,6 +178,7 @@ export const content = Joi.object().keys({
   setJavaScriptEnabled,
   url: Joi.string().required(),
   userAgent,
+  viewport,
   waitFor,
 });
 


### PR DESCRIPTION
This PR adds a `viewport` option to /content, which works identical to other API endpoints.

## Example

``` json
{
  "url": "https://whatismyviewport.com/",
  "waitFor": 1000,
  "viewport": { "width": 400, "height": 400 }
}
```

yields

``` html
[...]
<h1 class="App__title">Your viewport size is:</h1>
[...]
<p class="Dimensions">
  <span id="lol_w">400</span>
  ×
  <span id="lol_h">400</span>
</p>
[...]

```