### PR TITLE
DEFAULT_PLAYWRIGHT env variable for PREBOOT_CHROME mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,15 @@
       "port": 9229
     },
     {
+      "name": "Launch debug",
+      "request": "launch",
+      "runtimeArgs": ["run-script", "dev"],
+      "runtimeExecutable": "npm",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "pwa-node",
+      "outputCapture": "std"
+  },
+    {
       "type": "node",
       "request": "launch",
       "name": "Launch Program",

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -37,6 +37,7 @@ import {
   PORT,
   PROXY_URL,
   WORKSPACE_DIR,
+  DEFAULT_PLAYWRIGHT,
 } from './config';
 import { PLAYWRIGHT_ROUTE } from './constants';
 import { Features } from './features';
@@ -351,7 +352,7 @@ export const defaultLaunchArgs = {
   pauseOnConnect: false,
   slowMo: undefined,
   userDataDir: DEFAULT_USER_DATA_DIR,
-  playwright: false,
+  playwright: DEFAULT_PLAYWRIGHT,
   stealth: DEFAULT_STEALTH,
   meta: null,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -149,6 +149,10 @@ export const DEFAULT_STEALTH: boolean = parseJSONParam(
   process.env.DEFAULT_STEALTH,
   false,
 );
+export const DEFAULT_PLAYWRIGHT: boolean = parseJSONParam(
+  process.env.DEFAULT_PLAYWRIGHT,
+  false,
+);
 export const DEFAULT_USER_DATA_DIR: string | undefined = process.env
   .DEFAULT_USER_DATA_DIR
   ? untildify(process.env.DEFAULT_USER_DATA_DIR)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -526,7 +526,10 @@ export const canPreboot = (
   incoming: ILaunchOptions,
   defaults: ILaunchOptions,
 ) => {
-  if (incoming.playwright) {
+  if (
+    !_.isUndefined(incoming.playwright) &&
+    incoming.playwright !== defaults.playwright
+  ) {
     return false;
   }
 


### PR DESCRIPTION
implement DEFAULT_PLAYWRIGHT env variable for start playwright in PREBOOT_CHROME and KEEP_ALIVE mode

fix defaultLaunchArgs that using on init start chrome