### PR TITLE
feat: adding enconding option to `/screenshot`

### DIFF
--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -140,6 +140,12 @@ module.exports = async function screenshot({ page, context } = {}) {
     'x-response-port': response?.remoteAddress().port,
   };
 
+  let contentType = options.type ? options.type : 'png';
+
+  if (options.encoding && options.encoding === 'base64') {
+    contentType = 'text';
+  }
+
   if (manipulate) {
     const sharp = require('sharp');
     const chain = sharp(data);
@@ -163,13 +169,13 @@ module.exports = async function screenshot({ page, context } = {}) {
     return {
       data: await chain.toBuffer(),
       headers,
-      type: options.type ? options.type : 'png',
+      type: contentType,
     };
   }
 
   return {
     data,
     headers,
-    type: options.type ? options.type : 'png',
+    type: contentType,
   };
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -151,6 +151,7 @@ export const screenshot = Joi.object()
       omitBackground: Joi.boolean(),
       quality: Joi.number().min(0).max(100),
       type: Joi.string().valid('jpeg', 'png'),
+      encoding: Joi.string().valid('binary', 'base64'),
     }),
     rejectRequestPattern,
     rejectResourceTypes,

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -643,6 +643,12 @@ export default {
                   format: 'binary',
                 },
               },
+              'text/plain': {
+                schema: {
+                  type: 'string',
+                  format: 'base64',
+                },
+              },
             },
           },
         },


### PR DESCRIPTION
This PR fixes issue https://github.com/browserless/chrome/issues/2016