### PR TITLE
Drop puppeteer 12 in favor of 13 since they use the same chrome-revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,23 +56,23 @@
       "chromeRevision": "901912",
       "platform": "linux/amd64"
     },
-    "puppeteer-12.0.1": {
-      "puppeteer": "12.0.1",
+    "puppeteer-13.0.1": {
+      "puppeteer": "13.0.1",
       "chromeRevision": "938248",
       "platform": "linux/amd64"
     },
     "arm64": {
-      "puppeteer": "12.0.1",
+      "puppeteer": "13.0.1",
       "chromeRevision": "938248",
       "platform": "linux/arm64"
     },
     "chrome-stable": {
-      "puppeteer": "12.0.1",
+      "puppeteer": "13.0.1",
       "chromeRevision": "938248"
     }
   },
   "releaseVersions": [
-    "puppeteer-12.0.1",
+    "puppeteer-13.0.1",
     "puppeteer-10.4.0",
     "puppeteer-9.1.1",
     "puppeteer-7.1.0",


### PR DESCRIPTION
Puppeteer 12 is the same revision as 13, so dropping it in favor of 13.

![image](https://user-images.githubusercontent.com/1499985/148267733-2afca923-24dd-4b26-b737-070b510e93e3.png)
