### PR TITLE
Re-enable heapdump

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "extract-zip": "^2.0.1",
     "fs-extra": "^10.0.0",
     "get-port": "^5.0.0",
+    "heapdump": "^0.3.15",
     "http-proxy": "^1.16.2",
     "jest": "^27.0.6",
     "joi": "^17.2.1",

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -313,6 +313,7 @@ export class BrowserlessServer {
         puppeteerProvider: this.puppeteerProvider,
         workspaceDir: this.workspaceDir,
         enableAPIGet: this.enableAPIGet,
+        enableHeapdump: this.config.enableHeapdump,
       });
 
       if (this.config.enableCors) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -170,6 +170,10 @@ export const ENABLE_API_GET: boolean = parseJSONParam(
   false,
 );
 export const TOKEN: string | null = process.env.TOKEN || null;
+export const ENABLE_HEAP_DUMP: boolean = parseJSONParam(
+  process.env.ENABLE_HEAP_DUMP,
+  false,
+);
 export const ALLOW_FILE_PROTOCOL: boolean = parseJSONParam(
   process.env.ALLOW_FILE_PROTOCOL,
   false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ const browserless = new BrowserlessServer({
   disabledFeatures: config.DISABLED_FEATURES,
   enableAPIGet: config.ENABLE_API_GET,
   enableCors: config.ENABLE_CORS,
+  enableHeapdump: config.ENABLE_HEAP_DUMP,
   errorAlertURL: config.ERROR_ALERT_URL,
   exitOnHealthFailure: config.EXIT_ON_HEALTH_FAILURE,
   functionBuiltIns: config.FUNCTION_BUILT_INS,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -73,6 +73,7 @@ interface IGetRoutes {
   workspaceDir: string;
   disabledFeatures: Feature[];
   enableAPIGet: boolean;
+  enableHeapdump: boolean;
 }
 
 export const getRoutes = ({
@@ -83,6 +84,7 @@ export const getRoutes = ({
   workspaceDir,
   disabledFeatures,
   enableAPIGet,
+  enableHeapdump,
 }: IGetRoutes): Router => {
   const router = Router();
   const storage = multer.diskStorage({
@@ -571,6 +573,20 @@ export const getRoutes = ({
         return res.json(pages);
       }),
     );
+  }
+  
+  if (enableHeapdump) {
+    const heapdump = require('heapdump');
+    router.get('/heapdump', (_req, res) => {
+      const heapLocation = path.join(workspaceDir, `heap-${Date.now()}`);
+      heapdump.writeSnapshot(heapLocation, (err: Error) => {
+        if (err) {
+          return res.status(500).send(err.message);
+        }
+
+        return res.sendFile(heapLocation, () => rimraf(heapLocation, _.noop));
+      });
+    });
   }
 
   return router;

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -494,6 +494,9 @@ export default {
                     enableCors: {
                       type: 'boolean',
                     },
+                    enableHeapdump: {
+                      type: 'boolean',
+                    },
                     errorAlertURL: {
                       type: 'string',
                     },

--- a/src/tests/integration/__snapshots__/http.spec.ts.snap
+++ b/src/tests/integration/__snapshots__/http.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
   "disabledFeatures",
   "enableAPIGet",
   "enableCors",
+  "enableHeapdump",
   "errorAlertURL",
   "exitOnHealthFailure",
   "functionBuiltIns",

--- a/src/tests/integration/utils.ts
+++ b/src/tests/integration/utils.ts
@@ -16,6 +16,7 @@ export const defaultParams = (): IBrowserlessOptions => ({
   disabledFeatures: [],
   enableAPIGet: true,
   enableCors: false,
+  enableHeapdump: false,
   errorAlertURL: null,
   exitOnHealthFailure: false,
   functionBuiltIns: ['url'],

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -153,6 +153,7 @@ interface IBrowserlessServerConfiguration {
   workspaceDir: string;
   disabledFeatures: Feature[];
   enableAPIGet: boolean;
+  enableHeapdump: boolean;
   socketBehavior: 'http' | 'close';
 }
 


### PR DESCRIPTION
This re-enables the heapdump feature which was removed as a part of https://github.com/browserless/chrome/pull/953 in the 1.15.0 release