### PR TITLE
build: removing body-parser in favor of express native parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@types/shortid": "0.0.29",
         "archiver": "^5.0.0",
         "bluebird": "^3.5.5",
-        "body-parser": "^1.18.2",
         "browserless-debugger": "^1.0.2",
         "chromedriver": "^100.0.0",
         "cookie": "^0.4.0",
@@ -1713,23 +1712,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz",
-      "integrity": "sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
@@ -1749,46 +1731,6 @@
       },
       "peerDependencies": {
         "eslint": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.17.0.tgz",
-      "integrity": "sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-      "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1884,23 +1826,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.18.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz",
-      "integrity": "sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -10802,16 +10727,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz",
-      "integrity": "sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz",
@@ -10820,27 +10735,6 @@
       "requires": {
         "@typescript-eslint/utils": "5.18.0",
         "debug": "^4.3.2",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.17.0.tgz",
-      "integrity": "sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz",
-      "integrity": "sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       }
     },
@@ -10899,16 +10793,6 @@
             "eslint-visitor-keys": "^3.0.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz",
-      "integrity": "sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "eslint-visitor-keys": "^3.0.0"
       }
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@types/shortid": "0.0.29",
     "archiver": "^5.0.0",
     "bluebird": "^3.5.5",
-    "body-parser": "^1.18.2",
     "browserless-debugger": "^1.0.2",
     "chromedriver": "^100.0.0",
     "cookie": "^0.4.0",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -2,8 +2,7 @@ import { mkdir } from 'fs/promises';
 import path from 'path';
 
 import archiver from 'archiver';
-import bodyParser from 'body-parser';
-import { Request, Response, Router } from 'express';
+import express, { Request, Response, Router } from 'express';
 import _ from 'lodash';
 import multer from 'multer';
 
@@ -50,17 +49,17 @@ const scrape = fnLoader('scrape');
 const pdf = fnLoader('pdf');
 const stats = fnLoader('stats');
 
-const jsonParser = bodyParser.json({
+const jsonParser = express.json({
   limit: MAX_PAYLOAD_SIZE,
   type: ['application/json'],
 });
 
-const jsParser = bodyParser.text({
+const jsParser = express.text({
   limit: MAX_PAYLOAD_SIZE,
   type: ['text/plain', 'application/javascript'],
 });
 
-const htmlParser = bodyParser.text({
+const htmlParser = express.text({
   limit: MAX_PAYLOAD_SIZE,
   type: ['text/plain', 'text/html'],
 });


### PR DESCRIPTION
`body-parser` [was deprecated](https://github.com/expressjs/body-parser/blob/1.19.0/index.js#L93), and this removes the dependency an uses `express`' native method.