### PR TITLE
Revert "Always make a blank page so chrome doesn't close (#2229)"

### DIFF
--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -574,9 +574,9 @@ export class PuppeteerProvider {
 
       if (timeAlive <= this.config.chromeRefreshTime) {
         jobdebug(`${job.id}: Pushing browser back into swarm, clearing pages`);
-        const pages = await browser.pages();
-        await browser.newPage();
+        const [blank, ...pages] = await browser.pages();
         pages.forEach((page) => page.close());
+        blank && blank.goto('about:blank');
         jobdebug(`${job.id}: Cleanup done, pushing into swarm.`);
         return this.chromeSwarm.push(browser);
       }


### PR DESCRIPTION
This reverts commit f21f80f19216118001a00866fdff46a638573e2c.  This commit was causing increased memory usage and increased job execution time by up to 1s.  The memory increase is likely due to an additional page being created in Chrome.  The job execution time increase is because the job now needed to create a page at both the start and end of the job execution.