### PR TITLE
fix: lowering /screencast timeout for unit test

### DIFF
--- a/src/tests/integrations/http.spec.ts
+++ b/src/tests/integrations/http.spec.ts
@@ -855,7 +855,7 @@ describe('Browserless Chrome HTTP', () => {
       const params = defaultParams();
       const browserless = start({
         ...params,
-        connectionTimeout: 2500,
+        connectionTimeout: 50,
       });
 
       await browserless.startServer();


### PR DESCRIPTION
The /screencast `times out requests` unit test fails, as its timeout is too big and more often that not kills the session in the middle of the screencast, which throws an exception. This PR lowers that timeout