### PR TITLE
fix: fixing Chrome revision import in env file

### DIFF
--- a/env.js
+++ b/env.js
@@ -59,8 +59,9 @@ const PUPPETEER_CHROMIUM_REVISION = (() => {
   if (puppeteer._preferredRevision) {
     return puppeteer._preferredRevision;
   }
-
-  return require('puppeteer/lib/cjs/revisions').PUPPETEER_REVISIONS.chromium;
+  
+  const pptr = require('./node_modules/puppeteer/lib/cjs/puppeteer/revisions');
+  return pptr.PUPPETEER_REVISIONS.chromium;
 })();
 
 /*

--- a/package.json
+++ b/package.json
@@ -56,19 +56,19 @@
       "chromeRevision": "901912",
       "platform": "linux/amd64,linux/arm64"
     },
-    "puppeteer-13.6.0": {
-      "puppeteer": "13.6.0",
-      "chromeRevision": "982053",
+    "puppeteer-14.4.1": {
+      "puppeteer": "14.4.1",
+      "chromeRevision": "991974",
       "platform": "linux/amd64,linux/arm64"
     },
     "chrome-stable": {
-      "puppeteer": "13.6.0",
-      "chromeRevision": "982053",
+      "puppeteer": "14.4.1",
+      "chromeRevision": "991974",
       "platform": "linux/amd64"
     }
   },
   "releaseVersions": [
-    "puppeteer-13.6.0",
+    "puppeteer-14.4.1",
     "puppeteer-10.4.0",
     "puppeteer-9.1.1",
     "puppeteer-7.1.0",
@@ -122,7 +122,7 @@
     "node-pdftk": "^2.0.0",
     "playwright-core": "^1.20.1",
     "prom-client": "^14.0.0",
-    "puppeteer": "^14.3.0",
+    "puppeteer": "^14.4.1",
     "puppeteer-extra": "^3.1.15",
     "puppeteer-extra-plugin-stealth": "^2.6.5",
     "queue": "^6.0.0",

--- a/src/apis/download.ts
+++ b/src/apis/download.ts
@@ -6,7 +6,7 @@ import { Page } from 'puppeteer';
 import rimraf from 'rimraf';
 
 import { WORKSPACE_DIR } from '../config';
-import { id, readdir, sleep } from '../utils';
+import { id, getCDPClient, readdir, sleep } from '../utils';
 
 export const before = async ({ page }: { page: Page }) => {
   const downloadPath = path.join(
@@ -14,9 +14,8 @@ export const before = async ({ page }: { page: Page }) => {
     `.browserless.download.${id()}`,
   );
   await mkdir(downloadPath);
-
-  // @ts-ignore
-  await page._client.send('Page.setDownloadBehavior', {
+  const client = getCDPClient(page);
+  await client.send('Page.setDownloadBehavior', {
     behavior: 'allow',
     downloadPath,
   });

--- a/src/apis/screencast.ts
+++ b/src/apis/screencast.ts
@@ -3,13 +3,12 @@ import path from 'path';
 
 import { WORKSPACE_DIR } from '../config';
 import { IBefore } from '../types.d';
-import { id } from '../utils';
+import { id, getCDPClient } from '../utils';
 
 import { after as downloadAfter } from './download';
 
 export const before = async ({ page, code, debug, browser }: IBefore) => {
-  // @ts-ignore reaching into private methods
-  const client = page._client;
+  const client = getCDPClient(page);
   const renderer = await browser.newPage();
   const downloadPath = path.join(
     WORKSPACE_DIR,
@@ -19,8 +18,7 @@ export const before = async ({ page, code, debug, browser }: IBefore) => {
   const downloadName = id() + '.webm';
   let screencastAPI: any;
 
-  // @ts-ignore
-  await renderer._client.send('Page.setDownloadBehavior', {
+  await client.send('Page.setDownloadBehavior', {
     behavior: 'allow',
     downloadPath,
   });
@@ -127,7 +125,7 @@ export const before = async ({ page, code, debug, browser }: IBefore) => {
 
     client.on(
       'Page.screencastFrame',
-      ({ data, sessionId }: { data: string; sessionId: string }) => {
+      ({ data, sessionId }: { data: string; sessionId: number }) => {
         renderer.evaluateHandle(
           (screencastAPI, data) => screencastAPI.draw(data),
           screencastAPI,

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -164,7 +164,13 @@ const setupPage = async ({
     return;
   }
 
-  const client = _.get(page, '_client', _.noop);
+  // @ts-ignore forcing functionality via page._client
+  const client = page._client;
+
+  if (!client) {
+    throw new Error(`Error setting up page, CDP client doesn't exist!`);
+  }
+
   const id = _.get(page, '_target._targetId', 'Unknown');
 
   await pageHook({ page, meta });

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -56,6 +56,7 @@ import {
   fetchJson,
   getDebug,
   getUserDataDir,
+  getCDPClient,
   injectHostIntoSession,
   mkDataDir,
   rimraf,
@@ -164,8 +165,7 @@ const setupPage = async ({
     return;
   }
 
-  // @ts-ignore forcing functionality via page._client
-  const client = page._client;
+  const client = getCDPClient(pptrPage);
 
   if (!client) {
     throw new Error(`Error setting up page, CDP client doesn't exist!`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ import { Schema } from 'joi';
 import _ from 'lodash';
 
 import fetch from 'node-fetch';
+import { CDPSession, Page } from 'puppeteer';
 
 import rmrf from 'rimraf';
 
@@ -693,4 +694,13 @@ export const injectHostIntoSession = (
     devtoolsFrontendUrl,
     webSocketDebuggerUrl,
   };
+};
+
+export const getCDPClient = (page: Page): CDPSession => {
+  // @ts-ignore using internal CDP client
+  const c = page._client;
+
+  return typeof c === 'function' ?
+    c.call(page) :
+    c;
 };


### PR DESCRIPTION
PRs are broken as the CI builds the docker, and it tries to import `node_modules/puppeteer/lib/cjs/revisions`, which doesn't exist. This PR fixes this