### PR TITLE
Set the userDataDir and allow downstream modules to close before GC'ing

### DIFF
--- a/scripts/deploy-base.js
+++ b/scripts/deploy-base.js
@@ -6,13 +6,13 @@ const VERSION = process.env.VERSION;
 
 if (!VERSION) {
   throw new Error(
-    `Expected a $VERSION env variable to tag the ${BASE} repo, but none was found.`
+    `Expected a $VERSION env variable to tag the ${BASE} repo, but none was found.`,
   );
 }
 
 const buildBase = async () => {
   await $`docker buildx build --push --platform ${TARGET_ARCH.join(
-    ','
+    ',',
   )} -t ${BASE}:latest -t ${BASE}:${VERSION} ./base`;
 };
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -15,7 +15,7 @@ const BASE_VERSION = process.env.BASE_VERSION;
 
 if (!BASE_VERSION) {
   throw new Error(
-    `Expected a $BASE_VERSION env variable to tag the ${REPO} repo, but none was found.`
+    `Expected a $BASE_VERSION env variable to tag the ${REPO} repo, but none was found.`,
   );
 }
 
@@ -30,7 +30,7 @@ const deployVersion = async (tags, pptrVersion) => {
 
   if (!versionInfo) {
     throw new Error(
-      `Couldn't locate version info for puppeteer version ${pptrVersion}. Did you forget to add it to the package.json?`
+      `Couldn't locate version info for puppeteer version ${pptrVersion}. Did you forget to add it to the package.json?`,
     );
   }
 
@@ -67,15 +67,18 @@ const deployVersion = async (tags, pptrVersion) => {
   const res = await fetch(`http://127.0.0.1:${port}/json/version`);
   const versionJson = await res.json();
   const debuggerVersion = versionJson['WebKit-Version'].match(
-    /\s\(@(\b[0-9a-f]{5,40}\b)/
+    /\s\(@(\b[0-9a-f]{5,40}\b)/,
   )[1];
 
   await Promise.all([
-    fs.writeFile('browser.json', JSON.stringify({
-      ...versionJson,
-      puppeteerVersion,
-      debuggerVersion,
-    })),
+    fs.writeFile(
+      'browser.json',
+      JSON.stringify({
+        ...versionJson,
+        puppeteerVersion,
+        debuggerVersion,
+      }),
+    ),
     browser.close(),
   ]);
 
@@ -101,11 +104,11 @@ const deployVersion = async (tags, pptrVersion) => {
 
   await $`git add --force hosts.json browser.json`.catch(noop);
   await $`git commit --quiet -m "DEPLOY.js committing files for tag ${patchBranch}"`.catch(
-    noop
+    noop,
   );
   await $`git tag --force ${patchBranch}`;
   await $`git push origin ${patchBranch} --force --quiet --no-verify &> /dev/null`.catch(
-    noop
+    noop,
   );
 
   // git reset for next update
@@ -135,6 +138,6 @@ const deployVersion = async (tags, pptrVersion) => {
           console.log(`Error in build (${version}): `, error);
           process.exit(1);
         }),
-    Promise.resolve()
+    Promise.resolve(),
   );
 })();

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -546,9 +546,11 @@ export const launchChrome = async (
     await mkDataDir(explodedPath);
     opts.userDataDir = explodedPath;
     launchArgs.args.push(`--user-data-dir=${explodedPath}`);
+    launchArgs.userDataDir = explodedPath;
   } else {
     browserlessDataDir = opts.userDataDir || (await getUserDataDir());
     launchArgs.args.push(`--user-data-dir=${browserlessDataDir}`);
+    launchArgs.userDataDir = browserlessDataDir;
   }
 
   // Only use debugging pipe when headless except for playwright which
@@ -781,7 +783,24 @@ export const closeBrowser = (browser: IBrowser) => {
       debug(
         `Sending SIGKILL signal to browser process ${browser._browserProcess.pid}`,
       );
-      browser._browserServer.close();
+
+      // Allow listeners to close before we garbage collect, which
+      // puppeteer-extra packages need
+      Promise.race([
+        new Promise((r) => browser.process().once('close', r)),
+        browser._browserServer.close(),
+        sleep(1000).then(() => debug('sleep-1000')),
+      ]).then(() => {
+        debug(`Garbage collecting and removing listeners`);
+        browser._pages.forEach((page) => {
+          page.removeAllListeners();
+          // @ts-ignore force any garbage collection by nulling the page(s)
+          page = null;
+        });
+        browser.removeAllListeners();
+        // @ts-ignore force any garbage collection by nulling the browser
+        browser = null;
+      });
 
       if (browser._browserProcess.pid) {
         treeKill(browser._browserProcess.pid, 'SIGKILL');
@@ -790,15 +809,6 @@ export const closeBrowser = (browser: IBrowser) => {
       if (browser._browserlessDataDir) {
         removeDataDir(browser._browserlessDataDir);
       }
-
-      browser._pages.forEach((page) => {
-        page.removeAllListeners();
-        // @ts-ignore force any garbage collection by nulling the page(s)
-        page = null;
-      });
-      browser.removeAllListeners();
-      // @ts-ignore force any garbage collection by nulling the browser
-      browser = null;
     });
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -700,7 +700,5 @@ export const getCDPClient = (page: Page): CDPSession => {
   // @ts-ignore using internal CDP client
   const c = page._client;
 
-  return typeof c === 'function' ?
-    c.call(page) :
-    c;
+  return typeof c === 'function' ? c.call(page) : c;
 };


### PR DESCRIPTION
- Set the `userDataDir` option when launching as downstream modules sometimes check it (puppeteer-extra packages).
- Wait for events to complete before nulling out objects and detaching listeners.