### PR TITLE
Add a catch on goto so that it can proceed with a best attempt

### DIFF
--- a/functions/content.js
+++ b/functions/content.js
@@ -1,3 +1,4 @@
+/* global setTimeout, module */
 /*
  * content function
  *

--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -1,3 +1,4 @@
+/* global setTimeout, module, require */
 /*
  * pdf function
  *
@@ -10,7 +11,7 @@
  *    html: '<div>example</div>
  *    options: {
  *      ...
- *      see https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions for available options
+ *      see https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.pdfoptions.md for available options
  *    }
  *  },
  * });
@@ -139,13 +140,13 @@ module.exports = async function pdf({ page, context }) {
       : await page.setContent(html, gotoOptions);
 
   if (addStyleTag.length) {
-    for (tag in addStyleTag) {
+    for (const tag in addStyleTag) {
       await page.addStyleTag(addStyleTag[tag]);
     }
   }
 
   if (addScriptTag.length) {
-    for (script in addScriptTag) {
+    for (const script in addScriptTag) {
       await page.addScriptTag(addScriptTag[script]);
     }
   }

--- a/functions/scrape.js
+++ b/functions/scrape.js
@@ -10,6 +10,7 @@
  *  },
  * });
  */
+const noop = () => {};
 
 async function waitForElement(selector, timeout = 30000) {
   return new Promise((resolve) => {
@@ -122,7 +123,7 @@ module.exports = async function scrape({ page, context }) {
     await page.setUserAgent(userAgent);
   }
 
-  const response = await page.goto(url, gotoOptions);
+  const response = await page.goto(url, gotoOptions).catch(() => null);
 
   if (addStyleTag.length) {
     for (tag in addStyleTag) {

--- a/functions/scrape.js
+++ b/functions/scrape.js
@@ -1,3 +1,4 @@
+/* global setTimeout, document, MutationObserver, clearTimeout, module */
 /*
  * scrape function
  *
@@ -10,7 +11,6 @@
  *  },
  * });
  */
-const noop = () => {};
 
 async function waitForElement(selector, timeout = 30000) {
   return new Promise((resolve) => {
@@ -126,13 +126,13 @@ module.exports = async function scrape({ page, context }) {
   const response = await page.goto(url, gotoOptions).catch(() => null);
 
   if (addStyleTag.length) {
-    for (tag in addStyleTag) {
+    for (const tag in addStyleTag) {
       await page.addStyleTag(addStyleTag[tag]);
     }
   }
 
   if (addScriptTag.length) {
-    for (script in addScriptTag) {
+    for (const script in addScriptTag) {
       await page.addScriptTag(addScriptTag[script]);
     }
   }

--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -1,3 +1,4 @@
+/* global setTimeout, module, require */
 /*
  * screenshot function
  *
@@ -11,7 +12,9 @@
  *    quality: 50,
  *    fullPage: false,
  *    omitBackground: true,
- * },
+ *    ...
+ *    see https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.screenshotoptions.md for available options
+ *   },
  * });
  *
  * @param args - object - An object with a puppeteer page object, and context.
@@ -94,13 +97,13 @@ module.exports = async function screenshot({ page, context } = {}) {
       : await page.setContent(html, gotoOptions);
 
   if (addStyleTag.length) {
-    for (tag in addStyleTag) {
+    for (const tag in addStyleTag) {
       await page.addStyleTag(addStyleTag[tag]);
     }
   }
 
   if (addScriptTag.length) {
-    for (script in addScriptTag) {
+    for (const script in addScriptTag) {
       await page.addScriptTag(addScriptTag[script]);
     }
   }

--- a/functions/stats-child.js
+++ b/functions/stats-child.js
@@ -1,3 +1,4 @@
+/* global process, require */
 const lighthouse = require('lighthouse');
 
 const send = (msg) => process.send && process.send(msg);

--- a/functions/stats.js
+++ b/functions/stats.js
@@ -1,5 +1,8 @@
-const path = require('path');
+/* global require, module, __dirname, setTimeout, clearTimeout */
+
 const { fork } = require('child_process');
+const path = require('path');
+
 const kill = require('tree-kill');
 
 const DEFAULT_AUDIT_CONFIG = {


### PR DESCRIPTION
When a goto call fails, and debug information is requests, having a 4xx response isn't very helpful since this API returns network/screenshots/html and more.

This PR introduces a changes where the core goto call is caught and responds with `null` when it times-out. This is potentially breaking as the response no longer 4xx's and, instead, returns some useful JSON information.