### PR TITLE
Pin default base version to 1.17.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=latest
+ARG BASE_VERSION=1.17.0
 FROM browserless/base:${BASE_VERSION}
 
 # Build Args


### PR DESCRIPTION
Seems like `latest` of the browserless base version is broken as of now. Going to pin this to 1.17.0 to clean up PRs until we can get to the bottom of it. Possibly in Node 16.16.0.

```sh
# This version works:
# root @ browserless-ci in /usr/src/chrome on git:master x [20:29:19] 
$ docker run  browserless/chrome:latest node -v     
v16.15.1
```

```sh
# This one doesnt:
# root @ browserless-ci in /usr/src/chrome on git:master x [20:32:09] 
$ docker run  browserless/chrome:latest node -v                              
v16.16.0
```