### PR TITLE
Fix/socket write node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=1.17.0
+ARG BASE_VERSION=latest
 FROM browserless/base:${BASE_VERSION}
 
 # Build Args

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -511,13 +511,15 @@ export class BrowserlessServer {
       debug(
         `${req.url}: ${message}. Behavior of "http" set, writing response and closing.`,
       );
-      const httpResponse = util.dedent(`${header}
-        Content-Type: text/plain; charset=UTF-8
-        Content-Encoding: UTF-8
-        Accept-Ranges: bytes
-        Connection: keep-alive
-
-        ${message}`);
+      const httpResponse = [
+        header,
+        'Content-Type: text/plain; charset=UTF-8',
+        'Content-Encoding: UTF-8',
+        'Accept-Ranges: bytes',
+        'Connection: keep-alive',
+        '\r\n',
+        message,
+      ].join('\r\n');
 
       socket.write(httpResponse);
       socket.end();


### PR DESCRIPTION
Fixes the `HPE_CR_EXPECTED` being thrown by the `ws` module in node 16. This is due to node's behavior in node@16.16 being more strict in how it interprets header values and browserless needing to set the CR properly.

Bumps the `browserless/chrome` dockerfile back to latest as well.