### PR TITLE
Add a latest action + make others stable. pin base version, push latest

### DIFF
--- a/.github/workflows/docker-chrome-stable.yml
+++ b/.github/workflows/docker-chrome-stable.yml
@@ -1,4 +1,4 @@
-name: Chrome CI
+name: Chrome Stable
 
 on: [pull_request]
 

--- a/.github/workflows/docker-chromium-latest.yml
+++ b/.github/workflows/docker-chromium-latest.yml
@@ -1,0 +1,18 @@
+name: Chromium Latest
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build the latest browserless/base image
+      run: docker build -t browserless/base:latest base
+
+    - name: Build the latest browserless/chrome image
+      run: docker build --build-arg BASE_VERSION=latest -t browserless/chrome:latest .
+
+    - name: Test the latest image
+      run: docker run --ipc=host -e CI=true --entrypoint ./test.sh browserless/chrome:latest

--- a/.github/workflows/docker-chromium-stable.yml
+++ b/.github/workflows/docker-chromium-stable.yml
@@ -1,4 +1,4 @@
-name: Chromium CI
+name: Chromium Stable
 
 on: [pull_request]
 

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -34,14 +34,20 @@ jobs:
             browserless/base:latest
           context: ./base
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: |
+            linux/amd64
+            linux/arm64
 
       - name: Build the latest chrome image
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            BASE_VERSION=latest
           builder: ${{ steps.buildx.outputs.name }}
           tags: |
             browserless/chrome:latest
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=latest
+ARG BASE_VERSION=1.17.0
 FROM browserless/base:${BASE_VERSION}
 
 # Build Args


### PR DESCRIPTION
Does the following:

- Creates a new `docker-chromium-latest` build that uses `browserless/base:latest`.
- Renames the prior actions to `*-stable` to emphasize they use the latest stable `browserless/base`.
- When pushing the latest `browserless/chrome` image, ensure we use the `browserless/base:latest` as well.
- "Pins" the default `browserless/base` in `browserless/chrome` to the most recent stable build.