### PR TITLE
fix: disabling setting paths for addStyleTag and addScriptTag

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -50,7 +50,6 @@ const addScriptTag = Joi.array()
   .items(
     Joi.object().keys({
       url: Joi.string(),
-      path: Joi.string(),
       content: Joi.string(),
       type: Joi.string(),
     }),
@@ -61,7 +60,6 @@ const addStyleTag = Joi.array()
   .items(
     Joi.object().keys({
       url: Joi.string(),
-      path: Joi.string(),
       content: Joi.string(),
     }),
   )


### PR DESCRIPTION
Puppeteer's `Page.addStyleTag()` and `Page.addScriptTag()` allow setting a `path` property, which is loaded locally. We currently allow this, and asides from being a bit of a security issue, it can run into an error. This PR solves this.

## Example

```json
{
  "url": "https://example.com/",
  "gotoOptions": {
    "waitUntil": "networkidle2"
  },
  "addStyleTag": [
    {"path": "/usr/src/app/styles.css"}
  ]
}
```

### Before

`ENOENT: no such file or directory, open '/usr/src/app/styles.css'`

### After

```json
[
  {
    "message": "\"addStyleTag[0].path\" is not allowed",
    "path": [
      "addStyleTag",
      0,
      "path"
    ],
    "type": "object.unknown",
    "context": {
      "child": "path",
      "label": "addStyleTag[0].path",
      "value": "/usr/src/app/styles.css",
      "key": "path"
    }
  }
]
```