### PR TITLE
Build: bump playwright to 1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,10 @@
         "multer": "1.4.5-lts.1",
         "node-fetch": "^2.6.7",
         "node-pdftk": "^2.0.0",
-        "playwright-1.22": "npm:playwright-core@1.22.2",
         "playwright-1.23": "npm:playwright-core@1.23.3",
         "playwright-1.24": "npm:playwright-core@1.24.2",
         "playwright-1.25": "npm:playwright-core@1.25.2",
+        "playwright-1.26": "npm:playwright-core@1.26.1",
         "playwright-core": "^1.27.0",
         "prom-client": "^14.1.0",
         "puppeteer": "^18.2.1",
@@ -6119,18 +6119,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/playwright-1.22": {
-      "name": "playwright-core",
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/playwright-1.23": {
       "name": "playwright-core",
       "version": "1.23.3",
@@ -6160,6 +6148,18 @@
       "version": "1.25.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
       "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==",
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-1.26": {
+      "name": "playwright-core",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
       "bin": {
         "playwright": "cli.js"
       },
@@ -12497,11 +12497,6 @@
         }
       }
     },
-    "playwright-1.22": {
-      "version": "npm:playwright-core@1.22.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
-      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q=="
-    },
     "playwright-1.23": {
       "version": "npm:playwright-core@1.23.3",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.3.tgz",
@@ -12516,6 +12511,11 @@
       "version": "npm:playwright-core@1.25.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.2.tgz",
       "integrity": "sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A=="
+    },
+    "playwright-1.26": {
+      "version": "npm:playwright-core@1.26.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
+      "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA=="
     },
     "playwright-core": {
       "version": "1.27.0",

--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
   },
   "playwrightVersions": {
     "default": "playwright-core",
-    "1.26": "playwright-core",
+    "1.27": "playwright-core",
+    "1.26": "playwright-1.26",
     "1.25": "playwright-1.25",
     "1.24": "playwright-1.24",
-    "1.23": "playwright-1.23",
-    "1.22": "playwright-1.22"
+    "1.23": "playwright-1.23"
   },
   "releaseVersions": [
     "puppeteer-18.0.5",
@@ -128,10 +128,10 @@
     "multer": "1.4.5-lts.1",
     "node-fetch": "^2.6.7",
     "node-pdftk": "^2.0.0",
-    "playwright-1.22": "npm:playwright-core@1.22.2",
     "playwright-1.23": "npm:playwright-core@1.23.3",
     "playwright-1.24": "npm:playwright-core@1.24.2",
     "playwright-1.25": "npm:playwright-core@1.25.2",
+    "playwright-1.26": "npm:playwright-core@1.26.1",
     "playwright-core": "^1.27.0",
     "prom-client": "^14.1.0",
     "puppeteer": "^18.2.1",


### PR DESCRIPTION
This PR drops Playwright 1.22 and adds 1.27 as default. It also improves the unit test for Playwright versioning: now all compatible versions in the package are tested