### PR TITLE
Add in puppeteer 13.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
       "chromeRevision": "901912",
       "platform": "linux/amd64,linux/arm64"
     },
+    "puppeteer-13.1.3": {
+      "puppeteer": "13.1.3",
+      "chromeRevision": "950341",
+      "platform": "linux/amd64"
+    },
     "puppeteer-14.4.1": {
       "puppeteer": "14.4.1",
       "chromeRevision": "991974",
@@ -80,6 +85,7 @@
     "puppeteer-18.0.5",
     "puppeteer-16.2.0",
     "puppeteer-14.4.1",
+    "puppeteer-13.1.3",
     "puppeteer-10.4.0",
     "puppeteer-9.1.1",
     "puppeteer-1.20.0",


### PR DESCRIPTION
Chromium bundled with puppeteer in versions later than this has some troubles with canvas rendering. This introduce 13.1.3 back into production builds so users can continue to use it until later revisions are more performant again (hopefully).