### PR TITLE
upgrade to Ubuntu 23.04

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:lunar
 
 ENV NODE_VERSION v18.12.0
 ENV NVM_DIR /usr/src/.nvm


### PR DESCRIPTION
I'm experiencing errors in the current Ubuntu version:

```
root@1a66edbe6f38:/home/node/app# apt-get update
Ign:1 http://archive.canonical.com/ubuntu kinetic InRelease
Hit:2 http://security.ubuntu.com/ubuntu kinetic-security InRelease
Err:3 http://archive.canonical.com/ubuntu kinetic Release
  404  Not Found [IP: 185.125.188.87 80]
Hit:4 http://archive.ubuntu.com/ubuntu kinetic InRelease
Hit:5 http://archive.ubuntu.com/ubuntu kinetic-updates InRelease
Hit:6 http://archive.ubuntu.com/ubuntu kinetic-backports InRelease
Reading package lists... Done
E: The repository 'http://archive.canonical.com/ubuntu kinetic Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
root@1a66edbe6f38:/home/node/app#
```

guessing upgrading to the latest ubuntu fix the issue.