### PR TITLE
fix: allowing to set headless new in the connection URL

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import untildify from 'untildify';
 
 import { Features, isFeature } from './features';
-import { Feature } from './types.d';
+import { Feature, HeadlessType } from './types.d';
 
 const { IS_CHROME_FOR_TESTING } = require('../env');
 
@@ -127,7 +127,7 @@ export const DEFAULT_BLOCK_ADS: boolean = parseJSONParam(
   process.env.DEFAULT_BLOCK_ADS,
   false,
 );
-export const DEFAULT_HEADLESS: boolean | 'new' = parseJSONParam(
+export const DEFAULT_HEADLESS: HeadlessType = parseJSONParam(
   process.env.DEFAULT_HEADLESS,
   IS_CHROME_FOR_TESTING ? ['new'] : true,
 );

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -69,12 +69,14 @@ export interface PuppeteerRequest {
 
 export type PuppeteerLaunchOptions = Parameters<puppeteer.launch>[0];
 
+export type HeadlessType = boolean | 'new';
+
 export interface ILaunchOptions {
   ignoreHTTPSErrors?: boolean;
   slowMo?: number;
   userDataDir?: string;
   dumpio?: boolean;
-  headless?: boolean | 'new';
+  headless?: HeadlessType;
   args?: string[];
   ignoreDefaultArgs?: boolean | string[];
   pauseOnConnect: boolean;
@@ -106,7 +108,7 @@ export interface IRunHTTP {
   after?: (...args: any) => Promise<any>;
   flags?: string[];
   options?: any;
-  headless?: boolean | 'new';
+  headless?: HeadlessType;
   ignoreDefaultArgs?: boolean | string[];
   builtin?: string[];
   envVars?: string[];


### PR DESCRIPTION
Not so long ago, we added support for `headless: "new"`. We, however, didn't modify our internal chrome-launcher to supported. Effectively, it was still binary. This PR addresses this issue