### PR TITLE
build: fixing Puppeteer version to 20.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "playwright-1.34": "npm:playwright-core@1.34.3",
         "playwright-core": "^1.35.0",
         "prom-client": "^14.2.0",
-        "puppeteer": "^20.7.1",
+        "puppeteer": "20.7.1",
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "queue": "^6.0.0",
@@ -6675,9 +6675,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0.tgz",
-      "integrity": "sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA==",
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -13765,9 +13765,9 @@
       "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw=="
     },
     "playwright-core": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0.tgz",
-      "integrity": "sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA=="
+      "version": "1.35.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg=="
     },
     "prebuild-install": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "playwright-1.34": "npm:playwright-core@1.34.3",
     "playwright-core": "^1.35.0",
     "prom-client": "^14.2.0",
-    "puppeteer": "^20.7.1",
+    "puppeteer": "20.7.1",
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "queue": "^6.0.0",
@@ -204,11 +204,6 @@
     "simple-git-hooks": "^2.8.1",
     "yargs": "^17.7.2",
     "zx": "^7.2.2"
-  },
-  "overrides": {
-    "playwright-1.21": {
-      "jpeg-js": "0.4.4"
-    }
   },
   "mocha": {
     "extension": [


### PR DESCRIPTION
This PR sets Puppeteer v20.7.1 as fixed, so new PRs can be opened without browserless trying to pull an unreleased chromedriver revision