### PR TITLE
Feat: Puppeteer revisions override

### DIFF
--- a/env.js
+++ b/env.js
@@ -74,7 +74,13 @@ const PUPPETEER_CHROMIUM_REVISION = (() => {
   const pptr = require('./node_modules/puppeteer-core/lib/cjs/puppeteer/revisions');
 
   // For compatibility reasons
-  return pptr.PUPPETEER_REVISIONS.chrome ?? pptr.PUPPETEER_REVISIONS.chromium;
+  const revision =
+    pptr.PUPPETEER_REVISIONS.chrome ?? pptr.PUPPETEER_REVISIONS.chromium;
+
+  // Some Chromium revision used by Puppeteer don't have a Chromedriver
+  // binary, so we override them to the closest available revision
+  const overrides = packageJson.chromedriverBinary.overrides;
+  return overrides[revision] || revision;
 })();
 
 const IS_CHROME_FOR_TESTING = !(
@@ -82,7 +88,9 @@ const IS_CHROME_FOR_TESTING = !(
   PUPPETEER_CHROMIUM_REVISION <= 1108766
 );
 
-const CHROME_BINARY_TYPE = IS_CHROME_FOR_TESTING ? 'chrome-for-testing' : 'chromium';
+const CHROME_BINARY_TYPE = IS_CHROME_FOR_TESTING
+  ? 'chrome-for-testing'
+  : 'chromium';
 
 /*
  * Sometimes we don't use puppeteer's built-in chromium

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "1.31": "playwright-1.31"
   },
   "chromedriverBinary": {
+    "overrides": {
+      "114.0.5735.133": "114.0.5735.90"
+    },
     "chrome-for-testing": {
       "baseUrl": "https://chromedriver.storage.googleapis.com",
       "format": "{BASE_URL}/{REVISION}/{FILENAME}.zip"
@@ -140,7 +143,7 @@
     "@types/lodash": "^4.14.195",
     "@types/mocha": "^10.0.1",
     "@types/multer": "^1.3.7",
-    "@types/node": "^20.3.2",
+    "@types/node": "^20.3.3",
     "@types/node-fetch": "^2.6.4",
     "@types/request": "^2.48.2",
     "@types/rimraf": "^3.0.0",


### PR DESCRIPTION
This PR adds a `chromedriverBinary.overrides` key on `package.json` to override some Puppeteer Chromium revisions. Some Chromium revision used by Puppeteer don't have a Chromedriver binary, so we override them to the closest available revision.