### PR TITLE
feat: adding PREBOOT_WARM flag

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -159,8 +159,8 @@ export const PREBOOT_CHROME: boolean = parseJSONParam(
   process.env.PREBOOT_CHROME,
   false,
 );
-export const PREBOOT_WARM: number = parseNumber(
-  process.env.PREBOOT_WARM,
+export const PREBOOT_QUANTITY: number = parseNumber(
+  process.env.PREBOOT_QUANTITY,
   0,
 );
 export const PRINT_GET_STARTED_LINKS: boolean = parseJSONParam(

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,10 @@ export const PREBOOT_CHROME: boolean = parseJSONParam(
   process.env.PREBOOT_CHROME,
   false,
 );
+export const PREBOOT_WARM: number = parseNumber(
+  process.env.PREBOOT_WARM,
+  0,
+);
 export const PRINT_GET_STARTED_LINKS: boolean = parseJSONParam(
   process.env.PRINT_GET_STARTED_LINKS,
   true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ const browserless = new BrowserlessServer({
   metricsJSONPath: config.METRICS_JSON_PATH,
   port: config.PORT,
   prebootChrome: config.PREBOOT_CHROME,
-  prebootWarm: config.PREBOOT_WARM,
+  prebootQuantity: config.PREBOOT_QUANTITY,
   queuedAlertURL: config.QUEUE_ALERT_URL,
   rejectAlertURL: config.REJECT_ALERT_URL,
   singleRun: config.SINGLE_RUN,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ const browserless = new BrowserlessServer({
   metricsJSONPath: config.METRICS_JSON_PATH,
   port: config.PORT,
   prebootChrome: config.PREBOOT_CHROME,
+  prebootWarm: config.PREBOOT_WARM,
   queuedAlertURL: config.QUEUE_ALERT_URL,
   rejectAlertURL: config.REJECT_ALERT_URL,
   singleRun: config.SINGLE_RUN,

--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -62,7 +62,7 @@ export class PuppeteerProvider {
 
   public async startChromeInstances() {
     if (this.config.prebootChrome) {
-      const initialInstances = this.config.prebootWarm || this.config.maxConcurrentSessions;
+      const initialInstances = this.config.prebootQuantity || this.config.maxConcurrentSessions;
 
       sysdebug(
         `Starting chrome swarm: ${initialInstances} chrome instances starting`,

--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -62,15 +62,17 @@ export class PuppeteerProvider {
 
   public async startChromeInstances() {
     if (this.config.prebootChrome) {
+      const initialInstances = this.config.prebootWarm || this.config.maxConcurrentSessions;
+
       sysdebug(
-        `Starting chrome swarm: ${this.config.maxConcurrentSessions} chrome instances starting`,
+        `Starting chrome swarm: ${initialInstances} chrome instances starting`,
       );
 
-      if (this.config.maxConcurrentSessions > 10) {
+      if (initialInstances > 10) {
         process.setMaxListeners(this.config.maxConcurrentSessions + 3);
       }
 
-      const launching = [...Array(this.config.maxConcurrentSessions)].map(() =>
+      const launching = [...Array(initialInstances)].map(() =>
         this.launchChrome(chromeHelper.defaultLaunchArgs, true),
       );
 

--- a/src/tests/integrations/__snapshots__/http.spec.ts.snap
+++ b/src/tests/integrations/__snapshots__/http.spec.ts.snap
@@ -25,7 +25,7 @@ Array [
   "metricsJSONPath",
   "port",
   "prebootChrome",
-  "prebootWarm",
+  "prebootQuantity",
   "queuedAlertURL",
   "rejectAlertURL",
   "sessionCheckFailURL",

--- a/src/tests/integrations/__snapshots__/http.spec.ts.snap
+++ b/src/tests/integrations/__snapshots__/http.spec.ts.snap
@@ -25,6 +25,7 @@ Array [
   "metricsJSONPath",
   "port",
   "prebootChrome",
+  "prebootWarm",
   "queuedAlertURL",
   "rejectAlertURL",
   "sessionCheckFailURL",

--- a/src/tests/integrations/utils.ts
+++ b/src/tests/integrations/utils.ts
@@ -33,6 +33,7 @@ export const defaultParams = (): IBrowserlessOptions => ({
   metricsJSONPath: null,
   port: getPort(),
   prebootChrome: false,
+  prebootWarm: 0,
   queuedAlertURL: null,
   rejectAlertURL: null,
   sessionCheckFailURL: null,

--- a/src/tests/integrations/utils.ts
+++ b/src/tests/integrations/utils.ts
@@ -33,7 +33,7 @@ export const defaultParams = (): IBrowserlessOptions => ({
   metricsJSONPath: null,
   port: getPort(),
   prebootChrome: false,
-  prebootWarm: 0,
+  prebootQuantity: 0,
   queuedAlertURL: null,
   rejectAlertURL: null,
   sessionCheckFailURL: null,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -183,6 +183,7 @@ export interface IChromeServiceConfiguration {
   maxConcurrentSessions: number;
   maxQueueLength: number;
   prebootChrome: boolean;
+  prebootWarm: number;
   functionExternals: string[];
   functionEnableIncognitoMode: boolean;
   functionBuiltIns: string[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -183,7 +183,7 @@ export interface IChromeServiceConfiguration {
   maxConcurrentSessions: number;
   maxQueueLength: number;
   prebootChrome: boolean;
-  prebootWarm: number;
+  prebootQuantity: number;
   functionExternals: string[];
   functionEnableIncognitoMode: boolean;
   functionBuiltIns: string[];


### PR DESCRIPTION
This PR addresses and fixes https://github.com/browserless/chrome/issues/3344.

By default, the `PREBOOT` flag creates a swarm of browser instances with a length of `MAX_CONCURRENT_SESSIONS`. Sometimes you don't want to have as many pre-opened browsers sitting idle. Say you have a max of 10 concurrent sessions, but use only 5 concurrent browsers in reality. Then you'll have 5 browsers more than you need, using resources and sitting idle unnecessarily.

This introduces a `PREBOOT_WARM` flag that allows to set the number of pre-booted browser instances, which allows better resource management.