### PR TITLE
build: remove `node-fetch` and `request` libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
         "@types/mocha": "^10.0.1",
         "@types/multer": "^1.3.7",
         "@types/node": "^20.6.0",
-        "@types/node-fetch": "^2.6.4",
-        "@types/request": "^2.48.2",
         "@types/rimraf": "^3.0.0",
         "@types/shortid": "0.0.29",
         "archiver": "^6.0.1",
@@ -48,7 +46,6 @@
         "mocha": "^10.2.0",
         "mocha-chai-jest-snapshot": "^1.1.3",
         "multer": "1.4.5-lts.1",
-        "node-fetch": "^2.7.0",
         "node-pdftk": "^2.0.0",
         "playwright-1.33": "npm:playwright-core@1.33.0",
         "playwright-1.34": "npm:playwright-core@1.34.3",
@@ -60,7 +57,6 @@
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "queue": "^6.0.0",
-        "request": "^2.83.0",
         "rimraf": "^3.0.0",
         "selenium-webdriver": "^4.12.0",
         "sharp": "^0.32.5",
@@ -87,7 +83,7 @@
         "zx": "^7.2.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "optionalDependencies": {
         "heapdump": "^0.3.15"
@@ -1206,10 +1202,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/caseless": {
-      "version": "0.12.2",
-      "license": "MIT"
-    },
     "node_modules/@types/chai": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
@@ -1387,15 +1379,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
       "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -1435,28 +1418,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/request": {
-      "version": "2.48.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      }
-    },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.1",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/@types/rimraf": {
       "version": "3.0.2",
       "license": "MIT",
@@ -1487,10 +1448,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.1",
-      "license": "MIT"
     },
     "node_modules/@types/which": {
       "version": "3.0.0",
@@ -1751,6 +1708,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2022,20 +1980,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2087,17 +2031,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.4.1",
@@ -2200,13 +2133,6 @@
       "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -2431,10 +2357,6 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "4.3.8",
@@ -2932,16 +2854,6 @@
         "cssom": "0.3.x"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -3151,14 +3063,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3818,10 +3722,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "license": "BSD-2-Clause",
@@ -3839,13 +3739,6 @@
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
       }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4080,25 +3973,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -4328,13 +4202,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -4455,24 +4322,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4621,19 +4470,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5142,10 +4978,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -5395,10 +5227,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5415,12 +5243,9 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5451,19 +5276,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jszip": {
@@ -6291,13 +6103,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
@@ -6627,10 +6432,6 @@
       "version": "1.2.0",
       "license": "MIT"
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6908,10 +6709,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -7298,66 +7095,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/require-directory": {
@@ -8041,29 +7778,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -8570,10 +8284,6 @@
         "node": "*"
       }
     },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -8785,13 +8495,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.3.2",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8802,18 +8505,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vm2": {
@@ -10075,9 +9766,6 @@
         "@types/node": "*"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2"
-    },
     "@types/chai": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.6.tgz",
@@ -10248,15 +9936,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
       "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
-    "@types/node-fetch": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
-      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
     "@types/prettier": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
@@ -10296,25 +9975,6 @@
         "@types/node": "*"
       }
     },
-    "@types/request": {
-      "version": "2.48.8",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.1",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/rimraf": {
       "version": "3.0.2",
       "requires": {
@@ -10342,9 +10002,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.1"
     },
     "@types/which": {
       "version": "3.0.0",
@@ -10499,6 +10156,7 @@
     },
     "ajv": {
       "version": "6.12.6",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10693,15 +10351,6 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0"
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -10738,12 +10387,6 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0"
-    },
-    "aws4": {
-      "version": "1.11.0"
     },
     "axe-core": {
       "version": "4.4.1",
@@ -10818,12 +10461,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
       "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -10973,9 +10610,6 @@
       "version": "1.0.30001352",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
       "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA=="
-    },
-    "caseless": {
-      "version": "0.12.0"
     },
     "chai": {
       "version": "4.3.8",
@@ -11317,12 +10951,6 @@
         "cssom": "0.3.x"
       }
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -11452,13 +11080,6 @@
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
     },
     "ee-first": {
       "version": "1.1.1"
@@ -11950,9 +11571,6 @@
         "url-value-parser": "^2.0.0"
       }
     },
-    "extend": {
-      "version": "3.0.2"
-    },
     "extract-zip": {
       "version": "2.0.1",
       "requires": {
@@ -11961,9 +11579,6 @@
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0"
     },
     "fast-deep-equal": {
       "version": "3.1.3"
@@ -12137,17 +11752,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "forever-agent": {
-      "version": "0.6.1"
-    },
-    "form-data": {
-      "version": "3.0.1",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -12303,12 +11907,6 @@
         }
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -12393,16 +11991,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0"
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
     },
     "has": {
       "version": "1.0.3",
@@ -12500,14 +12088,6 @@
             "debug": "^4.3.4"
           }
         }
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -12832,9 +12412,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
     },
-    "isstream": {
-      "version": "0.1.2"
-    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -13032,9 +12609,6 @@
         "argparse": "^2.0.1"
       }
     },
-    "jsbn": {
-      "version": "0.1.1"
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -13045,11 +12619,9 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
-    "json-schema": {
-      "version": "0.4.0"
-    },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -13068,15 +12640,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      }
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
       }
     },
     "jszip": {
@@ -13695,9 +13258,6 @@
     "normalize-path": {
       "version": "3.0.0"
     },
-    "oauth-sign": {
-      "version": "0.9.0"
-    },
     "object-assign": {
       "version": "4.1.1"
     },
@@ -13931,9 +13491,6 @@
     "pend": {
       "version": "1.2.0"
     },
-    "performance-now": {
-      "version": "2.1.0"
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -14103,9 +13660,6 @@
       "requires": {
         "event-stream": "=3.3.4"
       }
-    },
-    "psl": {
-      "version": "1.8.0"
     },
     "pump": {
       "version": "3.0.0",
@@ -14343,53 +13897,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
         "functions-have-names": "^1.2.3"
-      }
-    },
-    "request": {
-      "version": "2.88.2",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        }
       }
     },
     "require-directory": {
@@ -14870,20 +14377,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -15220,9 +14713,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "tweetnacl": {
-      "version": "0.14.5"
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -15362,9 +14852,6 @@
     "utils-merge": {
       "version": "1.0.1"
     },
-    "uuid": {
-      "version": "3.3.2"
-    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -15372,14 +14859,6 @@
     },
     "vary": {
       "version": "1.1.2"
-    },
-    "verror": {
-      "version": "1.10.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "vm2": {
       "version": "3.9.19",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Chrome-as-a-service on your own hardware or in the cloud.",
   "repository": "browserless/chrome",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "main": "build/index.js",
   "files": [
@@ -144,8 +144,6 @@
     "@types/mocha": "^10.0.1",
     "@types/multer": "^1.3.7",
     "@types/node": "^20.6.0",
-    "@types/node-fetch": "^2.6.4",
-    "@types/request": "^2.48.2",
     "@types/rimraf": "^3.0.0",
     "@types/shortid": "0.0.29",
     "archiver": "^6.0.1",
@@ -170,7 +168,6 @@
     "mocha": "^10.2.0",
     "mocha-chai-jest-snapshot": "^1.1.3",
     "multer": "1.4.5-lts.1",
-    "node-fetch": "^2.7.0",
     "node-pdftk": "^2.0.0",
     "playwright-1.33": "npm:playwright-core@1.33.0",
     "playwright-1.34": "npm:playwright-core@1.34.3",
@@ -182,7 +179,6 @@
     "puppeteer-extra": "^3.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "queue": "^6.0.0",
-    "request": "^2.83.0",
     "rimraf": "^3.0.0",
     "selenium-webdriver": "^4.12.0",
     "sharp": "^0.32.5",

--- a/src/browserless.ts
+++ b/src/browserless.ts
@@ -12,7 +12,6 @@ import httpProxy from 'http-proxy';
 import _ from 'lodash';
 
 import client from 'prom-client';
-import request from 'request';
 
 import { getBrowsersRunning } from './chrome-helper';
 import { Features } from './features';
@@ -35,6 +34,7 @@ import * as util from './utils';
 import { WebDriver } from './webdriver-provider';
 
 const debug = util.getDebug('server');
+const request = (url: string, cb: any) => fetch(url).then(cb).catch(_.noop);
 
 const twentyFourHours = 1000 * 60 * 60 * 24;
 const thirtyMinutes = 30 * 60 * 1000;

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -13,7 +13,6 @@ import url from 'url';
 import chromeDriver from 'chromedriver';
 import getPort from 'get-port';
 import _ from 'lodash';
-import fetch from 'node-fetch';
 // @ts-ignore no types
 import { BrowserServer } from 'playwright-core';
 import puppeteer, { Browser, Page } from 'puppeteer';

--- a/src/tests/integrations/debugger.spec.ts
+++ b/src/tests/integrations/debugger.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fetch from 'node-fetch';
 
 import { BrowserlessServer } from '../../browserless';
 import { IBrowserlessOptions } from '../../types.d';

--- a/src/tests/integrations/http.spec.ts
+++ b/src/tests/integrations/http.spec.ts
@@ -1,6 +1,5 @@
 import chai, { expect } from 'chai';
 import { jestSnapshotPlugin } from 'mocha-chai-jest-snapshot';
-import fetch from 'node-fetch';
 
 import { BrowserlessServer } from '../../browserless';
 import { IBrowserlessOptions } from '../../types.d';
@@ -99,7 +98,11 @@ describe('Browserless Chrome HTTP', () => {
     });
     await browserless.startServer();
 
-    return fetch(`http://abc@127.0.0.1:${params.port}/json`).then(
+    const headers = new Headers({
+      Authorization: `Basic ${btoa('abc')}`,
+    });
+
+    return fetch(`http://127.0.0.1:${params.port}/json`, { headers }).then(
       (res: any) => {
         expect(res.headers['set-cookie']).toMatchSnapshot();
       },
@@ -1650,7 +1653,7 @@ describe('Browserless Chrome HTTP', () => {
     const lighthouseTimeout = 60000;
     const params = {
       ...defaultParams(),
-      connectionTimeout: 60000
+      connectionTimeout: 60000,
     };
 
     it('allows requests', async () => {

--- a/src/tests/integrations/websockets.spec.ts
+++ b/src/tests/integrations/websockets.spec.ts
@@ -1,6 +1,5 @@
 import chai, { expect } from 'chai';
 import { jestSnapshotPlugin } from 'mocha-chai-jest-snapshot';
-import fetch from 'node-fetch';
 import { chromium } from 'playwright-core';
 import puppeteer from 'puppeteer';
 import rimraf from 'rimraf';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,6 @@ import ip from 'ip';
 import { Schema } from 'joi';
 import _ from 'lodash';
 
-import fetch from 'node-fetch';
 import { CDPSession, Page } from 'puppeteer';
 
 import rmrf from 'rimraf';


### PR DESCRIPTION
This PR removes `node-fetch` and `request` in favor of Node's native `fetch` API. The project's engine was updated to `>=18.0.0` for this reason.

This fixes https://github.com/browserless/chrome/issues/3438