### PR TITLE
Fix: keepalive sessions preventing session calls

### DIFF
--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -310,6 +310,10 @@ const setupBrowser = async ({
 
   await browserHook({ browser, meta });
 
+  process.once('close', () => {
+    debug(`Browser process ${browser._id} has closed, cleaning up.`);
+    closeBrowser(browser);
+  });
   browser.on('targetcreated', async (target) => {
     try {
       const page = await target.page();

--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -424,7 +424,12 @@ export const getDebuggingPages = async (
           throw new Error(`Error finding port in browser endpoint: ${port}`);
         }
 
-        const sessions = await getTargets({ port });
+        const sessions = await getTargets({ port }).catch((e) => {
+          debug(
+            `Error fetching sessions from target: ${e.message} ${e.stack}.`,
+          );
+          return [];
+        });
 
         return sessions.map((session) =>
           injectHostIntoSession(externalURL, browser, session),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,7 +126,7 @@ export const getBasicAuthToken = (req: IncomingMessage): string | undefined => {
 export const asyncWsHandler = (handler: IUpgradeHandler) => {
   return (req: IncomingMessage, socket: net.Socket, head: Buffer) => {
     Promise.resolve(handler(req, socket, head)).catch((error: Error) => {
-      debug(`Error in WebSocket handler: ${error}`);
+      debug(`Error in WebSocket handler: ${error} ${error.stack}`);
       socket.write(
         [
           'HTTP/1.1 400 Bad Request',
@@ -134,9 +134,10 @@ export const asyncWsHandler = (handler: IUpgradeHandler) => {
           'Content-Encoding: UTF-8',
           'Accept-Ranges: bytes',
           'Connection: keep-alive',
-        ].join('\n') + '\n\n',
+          '\r\n',
+          'Bad Request, ' + error.message,
+        ].join('\r\n'),
       );
-      socket.write(Buffer.from('Bad Request, ' + error.message));
       socket.end();
     });
   };


### PR DESCRIPTION
When a kept-alive session exits early (by calling browser.close instead of browser.disconnect or even a proc crash), browerless didn't properly track that process exit. This PR fixes that by both tracking the process exit earlier, and by omitting browsers from GET calls to /session that aren't being responsive.