### PR TITLE
Add fonts-urw (Nimbus Sans ~= Helvetica)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get -y -qq --no-install-recommends install \
   fonts-roboto \
   fonts-thai-tlwg \
   fonts-ubuntu \
+  fonts-urw-base35 \
   fonts-wqy-zenhei \
   gconf-service \
   git \


### PR DESCRIPTION
This is Nimbus Sans, a free Helvetica lookalike.

I've got a page that uses this font, which looks completely different when using the browserless/chrome container.

I think Helvetica is a widely used font, so it probably makes sense to include it here too.