### PR TITLE
Let the scrape enpoint interceptors decide if the request continues

### DIFF
--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -299,7 +299,13 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
           method: req.method(),
           url: req.url(),
         });
-        req.continue();
+        if (!(
+          rejectRequestPattern.length ||
+          requestInterceptors.length ||
+          rejectResourceTypes.length
+        )) {
+          req.continue();
+        }
       });
 
       page.on('response', (res) => {


### PR DESCRIPTION
When using both `debugOpts.network` and `rejectResourceTypes` (or `rejectRequestPattern` or `requestInterceptors`) on the scrape endpoint, the interception for `debugOpts.network` will determine that the outbound will continue. This will cause the error `Error: Request is already handled!` when the interception for `rejectResourceTypes` aborts or continues the request.

This PR will ignore the `req.continue()` at `debugOpts.network` if one of the `rejectResourceTypes`,  `rejectRequestPattern` or `requestInterceptors` options is used.