### PR TITLE
Reverse scrape endpoint rejectResourceTypes and rejectRequestPattern check

### DIFF
--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -361,8 +361,8 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
 
       page.on('request', (req) => {
         if (
-          !!rejectRequestPattern.find((pattern) => req.url().match(pattern)) ||
-          rejectResourceTypes.includes(req.resourceType())
+          rejectResourceTypes.includes(req.resourceType()) ||
+          !!rejectRequestPattern.find((pattern) => req.url().match(pattern))
         ) {
           logger.debug(`Aborting request ${req.method()}: ${req.url()}`);
           return req.abort();


### PR DESCRIPTION
The rejectResourceTypes is less resource intensive. 

This check is also done for data:image url. Which is fine for smaller ones, but it is a problem for 64kb and multiple request patterns to check. If you are already blocking the image resource type, the check by request pattern is not required.