### PR TITLE
Fixing redoc version on v2

### DIFF
--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -94,5 +94,5 @@
 </head>
 <body>
   <redoc spec-url='docs/swagger.json'></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"></script>
 </body>


### PR DESCRIPTION
redoc released new version `v3` tagged `next`, this `v3` is not working on the docs page, so I suggest to fix it on v2.