### PR TITLE
fix(redoc): correct CDN path for redoc.standalone.js

### DIFF
--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -94,5 +94,5 @@
 </head>
 <body>
   <redoc spec-url='docs/swagger.json'></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundle/redoc.standalone.js"></script>
 </body>


### PR DESCRIPTION
The Redoc CDN structure changed (`bundles/` → `bundle/`), causing the UI to break. Updated index.html to use the correct script path.