### PR TITLE
PLT-666 feat: support protocolTimeout for function API

### DIFF
--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -544,9 +544,11 @@ export class BrowserManager {
         ? router.defaultLaunchOptions(req)
         : router.defaultLaunchOptions;
 
+    const timeout = req.parsed.searchParams.get('timeout');
     const launchOptions = {
       ...routerOptions,
       ...parsedLaunchOptions,
+      ...(timeout ? { protocolTimeout: +timeout } : {}),
     };
     const proxyServerParam = req.parsed.searchParams.get('--proxy-server');
     if (proxyServerParam) {

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -62,7 +62,10 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
     browser: BrowserInstance,
   ): Promise<void> {
     const config = this.config();
-    const handler = functionHandler(config, logger);
+    const timeout = req.parsed.searchParams.get('timeout');
+    const handler = functionHandler(config, logger, {
+      protocolTimeout: timeout ? +timeout : undefined,
+    });
     const { contentType, payload, page } = await handler(req, browser);
 
     logger.info(`Got function response of "${contentType}"`);

--- a/src/shared/utils/function/client.ts
+++ b/src/shared/utils/function/client.ts
@@ -21,6 +21,7 @@ export class FunctionRunner {
     context: unknown;
     options: {
       downloadPath?: string;
+      protocolTimeout?: number;
     };
   }) {
     console.log(`/function.js: Got endpoint: "${data.browserWSEndpoint}"`);
@@ -31,6 +32,7 @@ export class FunctionRunner {
       headers: {
         Host: '127.0.0.1',
       },
+      protocolTimeout: options.protocolTimeout,
     };
 
     this.browser = (await connect(

--- a/src/shared/utils/function/handler.ts
+++ b/src/shared/utils/function/handler.ts
@@ -34,6 +34,7 @@ interface JSONSchema {
 
 interface HandlerOptions {
   downloadPath?: string;
+  protocolTimeout?: number;
 }
 
 export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>


### PR DESCRIPTION
## Summary
- Pass user's `timeout` query parameter as Puppeteer's `protocolTimeout` for the function API
- Fixes `Runtime.callFunctionOn timed out` errors for long-running functions

## Problem
The function API was hitting the default 180-second CDP protocol timeout, even when users specified a longer `timeout` query parameter. This caused functions that run longer than 180 seconds to fail with the error:
```
Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
```

## Solution
The function API involves two browser connections:
1. **Server-side browser** - launched by browserless, runs `page.evaluate()` in handler.ts
2. **Client-side FunctionRunner** - connects back through WebSocket from browser context

Both connections now receive the `protocolTimeout` from the `timeout` query parameter.

## Test plan
- [x] Build passes: `npm run build`
- [x] Existing function tests pass
- [x] Manual test: POST to `/function?timeout=300000` with a 200-second sleep should complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout configuration support for browser launches. Users can now specify a protocol timeout parameter when launching browsers to control connection timeout behavior during browser operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->