### PR TITLE
chore: update playwright to 1.58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "joi": "^18.0.2",
         "lighthouse": "^13.0.1",
         "micromatch": "^4.0.8",
-        "playwright-1.53": "npm:playwright-core@1.53.2",
         "playwright-1.54": "npm:playwright-core@1.54.2",
         "playwright-1.55": "npm:playwright-core@1.55.1",
         "playwright-1.56": "npm:playwright-core@1.56.1",
@@ -5550,19 +5549,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright-1.53": {
-      "name": "playwright-core",
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/playwright-1.54": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "joi": "^18.0.2",
     "lighthouse": "^13.0.1",
     "micromatch": "^4.0.8",
-    "playwright-1.53": "npm:playwright-core@1.53.2",
     "playwright-1.54": "npm:playwright-core@1.54.2",
     "playwright-1.55": "npm:playwright-core@1.55.1",
     "playwright-1.56": "npm:playwright-core@1.56.1",
@@ -110,8 +109,7 @@
     "1.57": "playwright-1.57",
     "1.56": "playwright-1.56",
     "1.55": "playwright-1.55",
-    "1.54": "playwright-1.54",
-    "1.53": "playwright-1.53"
+    "1.54": "playwright-1.54"
   },
   "engines": {
     "node": ">=24",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Playwright testing dependencies: primary Playwright dependency advanced to 1.58.0, added an alias to retain compatibility with 1.57, and removed the outdated 1.53 mapping. These changes improve test stability, make version management more flexible across configurations, and support smoother upgrade paths for development and CI testing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->