### PR TITLE
fix: v2.40.0 changelog section title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Latest](https://github.com/browserless/chrome/compare/v2.40.0...main)
 
-# [v2.39.0](https://github.com/browserless/browserless/compare/v2.39.0...v2.40.0)
+# [v2.40.0](https://github.com/browserless/browserless/compare/v2.39.0...v2.40.0)
 - Dependency updates.
 - Updates NodeJS to `24.13.1`.
 - Updates NPM to `11.9.0`.


### PR DESCRIPTION
this section is incorrectly labelled

claude also pointed it out in the release pr - https://github.com/browserless/browserless/pull/5186#discussion_r2793804546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 2.40.0 now available
  * Debugger URL issue resolved
  * Enhanced compatibility across Chromium, Chrome, Firefox, WebKit, and Edge browsers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->