### PR TITLE
fix(json-version): preserve external webSocketDebuggerUrl for CDP clients

### DIFF
--- a/src/shared/json-version.http.ts
+++ b/src/shared/json-version.http.ts
@@ -31,7 +31,7 @@ export default class ChromiumJSONVersionGetRoute extends HTTPRoute {
   method = Methods.get;
   path = HTTPRoutes.jsonVersion;
   tags = [APITags.browserAPI];
-  async handler(req: Request, res: Response, logger: Logger): Promise<void> {
+  async handler(_req: Request, res: Response, logger: Logger): Promise<void> {
     try {
       if (!this.cachedJSON) {
         const browserManager = this.browserManager();

--- a/src/shared/json-version.http.ts
+++ b/src/shared/json-version.http.ts
@@ -32,15 +32,11 @@ export default class ChromiumJSONVersionGetRoute extends HTTPRoute {
   path = HTTPRoutes.jsonVersion;
   tags = [APITags.browserAPI];
   async handler(req: Request, res: Response, logger: Logger): Promise<void> {
-    const baseUrl = req.parsed.host;
-    const protocol = req.parsed.protocol.includes('s') ? 'wss' : 'ws';
-
     try {
       if (!this.cachedJSON) {
         const browserManager = this.browserManager();
         this.cachedJSON = {
           ...(await browserManager.getVersionJSON(logger)),
-          webSocketDebuggerUrl: `${protocol}://${baseUrl}`,
         };
       }
       return jsonResponse(res, 200, this.cachedJSON);


### PR DESCRIPTION
## Summary
This PR fixes an incorrect `webSocketDebuggerUrl` value returned by `/json/version` when Browserless is deployed behind an external host/proxy.

## Problem
In `src/shared/json-version.http.ts`, the route handler rebuilt `webSocketDebuggerUrl` from the incoming request host/protocol:

- host from `req.parsed.host`
- protocol inferred as `ws`/`wss`

In external/proxied deployments, this can produce an unusable endpoint (for example `ws://0.0.0.0:3000`), which causes remote CDP clients to fail to connect (`Remote CDP websocket not reachable`).

## Root Cause
The route was overriding the debugger URL returned by the browser manager (`getVersionJSON`) with a request-derived URL, even when the manager already had the correct externally reachable websocket endpoint.

## Fix
1. **Stop overriding** `webSocketDebuggerUrl` in `/json/version`.
   - Keep the value returned by `browserManager.getVersionJSON(logger)`.
2. **Minor TypeScript cleanup**
   - Rename unused handler arg `req` -> `_req`.

## Why this is safe
- The change is scoped to `/json/version` response assembly.
- It removes a lossy transformation and preserves the authoritative value from browser manager.
- No behavior changes for unrelated routes.

## Validation
- Reproduced issue in an external deployment where clients consumed `/json/version` for CDP discovery.
- After this patch, `webSocketDebuggerUrl` stays externally valid and CDP clients can connect successfully.

## Files changed
- `src/shared/json-version.http.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed WebSocket debugger URL from JSON response. The cached JSON object no longer includes debug-related information that was previously derived from request details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->