### PR TITLE
fix(tests): use browserless.io in chromium performance tests

### DIFF
--- a/src/routes/chromium/tests/performance.spec.ts
+++ b/src/routes/chromium/tests/performance.spec.ts
@@ -22,7 +22,7 @@ describe('/chromium/performance API', function () {
     const metrics = new Metrics();
     await start({ config, metrics });
     const body = {
-      url: 'https://one.one.one.one',
+      url: 'https://browserless.io',
     };
 
     await fetch(
@@ -148,7 +148,7 @@ describe('/chromium/performance API', function () {
   it('allows requests without token when auth token is not set', async () => {
     await start();
     const body = {
-      url: 'https://one.one.one.one',
+      url: 'https://browserless.io',
     };
 
     await fetch('http://localhost:3000/chromium/performance', {


### PR DESCRIPTION
## Summary
- Two `/chromium/performance API` tests that audit `https://one.one.one.one` have been failing in `test-chromium` and `test-multi` on every PR since 2026-04-07, blocking all dependabot merges.
- In CI, Lighthouse never fires FCP on `one.one.one.one`; it hangs past mocha's 45s timeout, the handler throws, the response becomes `text/plain`, and the `application/json` content-type assertion fails.
- Locally (macOS arm64, same playwright-core 1.59.1 + chromium 1217) all 6 tests pass cleanly against `one.one.one.one`, so the site itself is fine — it's specifically unreliable from CI's network.
- The adjacent `allows setting config` test already audits `https://browserless.io` from the same CI job and completes in ~10s, so swap the two failing tests to the same URL.

## What this changes
- `src/routes/chromium/tests/performance.spec.ts`: two test bodies now use `https://browserless.io` instead of `https://one.one.one.one`.
- Leaves the other two `one.one.one.one` usages (the `times out request` and `rejects requests` tests) alone — they assert on 408/rejection and never need a successful Lighthouse run.
- No route/source changes. Two-line diff.

## Evidence from CI logs (PR #5309, 2026-04-13 `test-chromium` job)
```
05:45:23.854  Navigating to https://one.one.one.one/     ← never completes
05:45:53.048  Connecting to browser                       ← Lighthouse gave up
05:45:54.143  Navigating to https://browserless.io/       ← same Chromium, same network
05:46:03.676  Analyzing and running audits                ← success
05:46:06.997  Navigating to https://one.one.one.one/      ← hangs again
```

## Test plan
- [ ] `test-chromium / Test (v24.14.1)` passes on this PR
- [ ] `test-multi / Test (v24.14.1)` passes on this PR
- [ ] The three other `test-*` jobs still pass
- [ ] Once this lands, rebase an existing dependabot PR (e.g. #5309) on top of `main` and confirm its CI now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test data values for performance testing scenarios. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->