### PR TITLE
fix: remove dbus autolaunch to stop orphaned dbus-daemon processes

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -23,7 +23,6 @@ ENV NODE_ENV=production
 ENV DEBUG_COLORS=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PLAYWRIGHT_BROWSERS_PATH=/usr/local/bin/playwright-browsers
-ENV DBUS_SESSION_BUS_ADDRESS=autolaunch:
 
 RUN mkdir -p $APP_DIR $NVM_DIR && \
   groupadd -r blessuser && useradd --uid ${BLESS_USER_ID} -r -g blessuser -G audio,video blessuser && \
@@ -50,8 +49,6 @@ RUN apt-get update \
   ssh \
   wget \
   xvfb \
-  dbus \
-  dbus-x11 \
   libwebp-dev \
   python3 python3-pip python3-setuptools \
   # Font packages


### PR DESCRIPTION
## Summary
- Remove `ENV DBUS_SESSION_BUS_ADDRESS=autolaunch:` from the base Dockerfile
- Remove the now-unused `dbus` and `dbus-x11` apt packages

Fixes #5302.

## Root cause
`autolaunch:` instructs any D-Bus client without a session bus to fork one via `dbus-launch`. Every Chromium launch spawns its own detached `dbus-daemon` that outlives Chromium, plus an `at-spi-bus-launcher` activated on the same bus. Over a long-running container these orphans accumulate into the hundreds.

## Why removal is the right fix
- browserless always launches Chrome with `--remote-debugging-port`, which bypasses Chromium's dbus code path entirely.
- No Chromium dbus-consuming feature (keyring, notifications, at-spi, UPower, etc.) is relevant to a headless automation server.
- Nothing in the repo references dbus outside this Dockerfile — the packages are unused.

## Test plan
- [ ] All docker images (`base`, `chromium`, `chrome`) build successfully
- [ ] After ~20 sessions in a running container, `ps -ef | grep -cE 'dbus-daemon|at-spi-bus-launcher'` returns 0
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5311" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image by removing unused system dependencies and environment variable configurations to reduce image size and improve deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->