### PR TITLE
fix: include content type in generic error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "npm": "^11.7.0"
   },
   "mocha": {
+    "bail": true,
     "extension": [
       "js"
     ],

--- a/src/routes/chrome/tests/scrape.spec.ts
+++ b/src/routes/chrome/tests/scrape.spec.ts
@@ -117,7 +117,8 @@ describe('/chrome/scrape API', function () {
       },
       method: 'POST',
     }).then(async (res) => {
-      expect(await res.text()).to.contain('Timed out waiting for selector');
+      const { error } = await res.json();
+      expect(error).to.include('Timed out waiting for selector');
       expect(res.status).not.to.equal(200);
     });
   });

--- a/src/routes/chromium/tests/pdf.spec.ts
+++ b/src/routes/chromium/tests/pdf.spec.ts
@@ -462,8 +462,8 @@ describe('/chromium/pdf API', function () {
       method: 'POST',
     }).then(async (res) => {
       expect(res.status).to.equal(400);
-      const errorText = await res.text();
-      expect(errorText).to.include(
+      const { error } = await res.json();
+      expect(error).to.include(
         '"fullPage" option cannot be used with "height" or "format" options.',
       );
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -243,9 +243,13 @@ export class HTTPServer extends EventEmitter {
       }
     }
 
-    const body = await readBody(req, this.config.getMaxPayloadSize()).catch(
-      (e) => this.handleErrorRequest(e, res, req),
-    );
+    const body = await readBody(req, this.config.getMaxPayloadSize()).catch(() => undefined );
+
+    // readBody can return null, but not undefined, so if it's undefined, it means there was an error reading the body
+    if (body === undefined) {
+      return this.handleErrorRequest(new Error('Failed to read request body'), res, req);
+    }
+
     req.body = body;
     req.queryParams = queryParamsToObject(req.parsed.searchParams);
 
@@ -473,5 +477,5 @@ export class HTTPServer extends EventEmitter {
   /**
    * Left blank for downstream SDK modules to optionally implement.
    */
-  public stop() {}
+  public stop() { }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -243,11 +243,11 @@ export class HTTPServer extends EventEmitter {
       }
     }
 
-    const body = await readBody(req, this.config.getMaxPayloadSize()).catch(() => undefined );
-
-    // readBody can return null, but not undefined, so if it's undefined, it means there was an error reading the body
-    if (body === undefined) {
-      return this.handleErrorRequest(new Error('Failed to read request body'), res, req);
+    let body;
+    try {
+      body = await readBody(req, this.config.getMaxPayloadSize());
+    } catch (e: any) {
+      return this.handleErrorRequest(e, res, req);
     }
 
     req.body = body;

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,25 +61,27 @@ export class HTTPServer extends EventEmitter {
     );
   }
 
-  protected handleErrorRequest(e: Error, res: Response | stream.Duplex) {
+  protected handleErrorRequest(e: Error, res: Response | stream.Duplex, req?: Request) {
+    const contentType = req?.headers['content-type'] as contentTypes;
+
     if (e instanceof BadRequest) {
-      return writeResponse(res, 400, e.message);
+      return writeResponse(res, 400, e.message, contentType);
     }
 
     if (e instanceof NotFound) {
-      return writeResponse(res, 404, e.message);
+      return writeResponse(res, 404, e.message, contentType);
     }
 
     if (e instanceof Unauthorized) {
-      return writeResponse(res, 401, e.message);
+      return writeResponse(res, 401, e.message, contentType);
     }
 
     if (e instanceof TooManyRequests) {
-      return writeResponse(res, 429, e.message);
+      return writeResponse(res, 429, e.message, contentType);
     }
 
     if (e instanceof Timeout) {
-      return writeResponse(res, 408, e.message);
+      return writeResponse(res, 408, e.message, contentType);
     }
 
     this.logger.error(`Error handling request: ${e}\n${e.stack}`);
@@ -242,7 +244,7 @@ export class HTTPServer extends EventEmitter {
     }
 
     const body = await readBody(req, this.config.getMaxPayloadSize()).catch(
-      (e) => this.handleErrorRequest(e, res),
+      (e) => this.handleErrorRequest(e, res, req),
     );
     req.body = body;
     req.queryParams = queryParamsToObject(req.parsed.searchParams);
@@ -351,7 +353,7 @@ export class HTTPServer extends EventEmitter {
       .then(() => {
         this.logger.trace('HTTP connection complete');
       })
-      .catch((e) => this.handleErrorRequest(e, res));
+      .catch((e) => this.handleErrorRequest(e, res, req));
   }
 
   protected async handleWebSocket(
@@ -446,7 +448,7 @@ export class HTTPServer extends EventEmitter {
         .then(() => {
           this.logger.trace('Websocket connection complete');
         })
-        .catch((e) => this.handleErrorRequest(e, socket));
+        .catch((e) => this.handleErrorRequest(e, socket, req));
     }
 
     this.logger.warn(

--- a/src/server.ts
+++ b/src/server.ts
@@ -246,8 +246,8 @@ export class HTTPServer extends EventEmitter {
     let body;
     try {
       body = await readBody(req, this.config.getMaxPayloadSize());
-    } catch (e: any) {
-      return this.handleErrorRequest(e, res, req);
+    } catch (e: unknown) {
+      return this.handleErrorRequest(e as Error, res, req);
     }
 
     req.body = body;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { getFinalPathSegment } from '@browserless.io/browserless';
+import { ServerResponse } from 'http';
+import { Socket } from 'net';
+import {
+  contentTypes,
+  getFinalPathSegment,
+  writeResponse,
+} from '@browserless.io/browserless';
 
 describe('Utils', () => {
   describe('#getFinalPathSegment', () => {
@@ -57,6 +63,85 @@ describe('Utils', () => {
           'wss://www.browserless.io/some/random/path/segment/&bad=query',
         ),
       ).to.equal('segment');
+    });
+  });
+
+  describe('#writeResponse', () => {
+    const createMockResponse = () => {
+      const socket = new Socket();
+      const res = new ServerResponse({ method: 'GET' } as any);
+      res.assignSocket(socket);
+
+      let writtenHead: { code?: number; headers?: Record<string, string> } = {};
+      let body = '';
+
+      res.writeHead = function (code: number, headers?: any) {
+        writtenHead = { code, headers };
+        return this;
+      } as any;
+
+      res.end = function (data?: any) {
+        body = typeof data === 'string' ? data : '';
+        return this;
+      } as any;
+
+      return { res, getHead: () => writtenHead, getBody: () => body };
+    };
+
+    it('returns plain text by default', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      writeResponse(res, 400, 'Bad request');
+
+      expect(getHead().code).to.equal(400);
+      expect(getHead().headers?.['Content-Type']).to.include('text/plain');
+      expect(getBody()).to.equal('Bad request\n');
+    });
+
+    it('returns plain text when contentType is text', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      writeResponse(res, 404, 'Not found', contentTypes.text);
+
+      expect(getHead().code).to.equal(404);
+      expect(getHead().headers?.['Content-Type']).to.include('text/plain');
+      expect(getBody()).to.equal('Not found\n');
+    });
+
+    it('returns JSON error object when contentType is json', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      writeResponse(res, 400, 'Missing parameter', contentTypes.json);
+
+      expect(getHead().code).to.equal(400);
+      expect(getHead().headers?.['Content-Type']).to.include(
+        'application/json',
+      );
+      const parsed = JSON.parse(getBody().trim());
+      expect(parsed).to.deep.equal({ error: 'Missing parameter' });
+    });
+
+    it('returns JSON for 500 errors when contentType is json', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      writeResponse(res, 500, 'Internal server error', contentTypes.json);
+
+      expect(getHead().code).to.equal(500);
+      expect(getHead().headers?.['Content-Type']).to.include(
+        'application/json',
+      );
+      const parsed = JSON.parse(getBody().trim());
+      expect(parsed).to.deep.equal({ error: 'Internal server error' });
+    });
+
+    it('returns JSON when contentType header includes json with charset', () => {
+      const { res, getHead, getBody } = createMockResponse();
+      writeResponse(
+        res,
+        422,
+        'Validation failed',
+        'application/json; charset=utf-8' as contentTypes,
+      );
+
+      expect(getHead().code).to.equal(422);
+      const parsed = JSON.parse(getBody().trim());
+      expect(parsed).to.deep.equal({ error: 'Validation failed' });
     });
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -75,15 +75,15 @@ describe('Utils', () => {
       let writtenHead: { code?: number; headers?: Record<string, string> } = {};
       let body = '';
 
-      res.writeHead = function (code: number, headers?: any) {
+      res.writeHead = ((code: number, headers?: any) => {
         writtenHead = { code, headers };
-        return this;
-      } as any;
+        return res;
+      }) as any;
 
-      res.end = function (data?: any) {
+      res.end = ((data?: any) => {
         body = typeof data === 'string' ? data : '';
-        return this;
-      } as any;
+        return res;
+      }) as any;
 
       return { res, getHead: () => writtenHead, getBody: () => body };
     };
@@ -134,12 +134,12 @@ describe('Utils', () => {
       const { res, getHead, getBody } = createMockResponse();
       writeResponse(
         res,
-        422,
+        408,
         'Validation failed',
         'application/json; charset=utf-8' as contentTypes,
       );
 
-      expect(getHead().code).to.equal(422);
+      expect(getHead().code).to.equal(408);
       const parsed = JSON.parse(getBody().trim());
       expect(parsed).to.deep.equal({ error: 'Validation failed' });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,7 +176,9 @@ export const writeResponse = (
   const isJSON = contentType.includes(contentTypes.json);
   const isError = httpCode >= 400;
   const httpMessage = codes[httpCode];
-  const CTTHeader = `${contentType}; charset=${encodings.utf8}`;
+  const CTTHeader = contentType.toLowerCase().includes('charset=')
+    ? contentType
+    : `${contentType}; charset=${encodings.utf8}`;
   const body = isJSON && isError
     ? JSON.stringify({ error: message instanceof Error ? message.message : message })
     : message;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,10 +173,11 @@ export const writeResponse = (
     return;
   }
 
-  const isJSON = contentType.includes(contentTypes.json); // contentType can include charset, so we check if it includes the json content type rather than equals
+  const isJSON = contentType.includes(contentTypes.json);
+  const isError = httpCode >= 400;
   const httpMessage = codes[httpCode];
   const CTTHeader = `${contentType}; charset=${encodings.utf8}`;
-  const body = isJSON
+  const body = isJSON && isError
     ? JSON.stringify({ error: message })
     : message;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,14 +173,18 @@ export const writeResponse = (
     return;
   }
 
+  const isJSON = contentType.includes(contentTypes.json); // contentType can include charset, so we check if it includes the json content type rather than equals
   const httpMessage = codes[httpCode];
   const CTTHeader = `${contentType}; charset=${encodings.utf8}`;
+  const body = isJSON
+    ? JSON.stringify({ error: message })
+    : message;
 
   if (isHTTP(writeable)) {
     const response = writeable;
     if (!response.headersSent) {
       response.writeHead(httpMessage.code, { 'Content-Type': CTTHeader });
-      response.end(message + '\n');
+      response.end(body + '\n');
     }
     return;
   }
@@ -192,7 +196,7 @@ export const writeResponse = (
     'Accept-Ranges: bytes',
     'Connection: keep-alive',
     '\r\n',
-    message,
+    body,
   ].join('\r\n');
 
   writeable.write(httpResponse);
@@ -551,7 +555,7 @@ export const queryParamsToObject = (
     {} as ReturnType<typeof queryParamsToObject>,
   );
 
-const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const AsyncFunction = Object.getPrototypeOf(async function () { }).constructor;
 
 const wrapUserFunction = (fn: string) => {
   // Handle async definitions
@@ -638,7 +642,7 @@ export const scrollThroughPage = async (page: Page) => {
   }, viewport.height);
 };
 
-export const noop = (): void => {};
+export const noop = (): void => { };
 
 export const once = <A extends unknown[], R, T>(
   fn: (this: T, ...arg: A) => R,
@@ -732,10 +736,10 @@ export class Timeout extends Error {
 
 export const bestAttemptCatch =
   (bestAttempt: boolean) =>
-  (err: Error): void => {
-    if (bestAttempt) return;
-    throw err;
-  };
+    (err: Error): void => {
+      if (bestAttempt) return;
+      throw err;
+    };
 
 export const parseBooleanParam = (
   params: URLSearchParams,
@@ -867,13 +871,13 @@ export const printLogo = (docsLink: string, debugURL?: string | boolean) => `
 | Full Documentation: https://docs.browserless.io/ ${
   /*prettier-ignore*/
   debugURL ? `
-| Debbuger: ${debugURL}`  : ""
-}
+| Debbuger: ${debugURL}` : ""
+  }
 ---------------------------------------------------------
 ${gradient(
-  '#ff1a8c',
-  '#ffea00',
-)(`
+    '#ff1a8c',
+    '#ffea00',
+  )(`
 
 █▓▒
 ████▒

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,7 +166,7 @@ export const isConnected = (connection: Duplex | ServerResponse): boolean =>
 export const writeResponse = (
   writeable: Duplex | ServerResponse,
   httpCode: keyof typeof codes,
-  message: string,
+  message: string | Error,
   contentType: contentTypes = contentTypes.text,
 ): void => {
   if (!isConnected(writeable)) {
@@ -178,7 +178,7 @@ export const writeResponse = (
   const httpMessage = codes[httpCode];
   const CTTHeader = `${contentType}; charset=${encodings.utf8}`;
   const body = isJSON && isError
-    ? JSON.stringify({ error: message })
+    ? JSON.stringify({ error: message instanceof Error ? message.message : message })
     : message;
 
   if (isHTTP(writeable)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now honor the request Content-Type and consistently return JSON or plain-text error bodies across HTTP and WebSocket flows for common error statuses.
* **Tests**
  * Added/updated tests validating response serialization and Content-Type handling (plain-text, JSON, charset variations, HTTP 500) and updated endpoint tests to assert JSON error payloads.
* **Style**
  * Minor formatting adjustments to printed output and internal formatting.
* **Chores**
  * Test runner configured to stop on first failure (bail).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->