### PR TITLE
chore: build v2.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-# [Latest](https://github.com/browserless/chrome/compare/v2.46.0...main)
+# [Latest](https://github.com/browserless/browserless/compare/v2.47.0...main)
+
+# [v2.47.0](https://github.com/browserless/browserless/compare/v2.46.0...v2.47.0)
+- Dependency updates.
+- Updates NPM to `11.12.1`.
+- Adds support for Playwright 1.59.
+- Fix: include content type in generic error handling.
+- Fix: remove dbus autolaunch to stop orphaned dbus-daemon processes.
+- Supports the following libraries and browsers:
+  - puppeteer-core: `24.40.0`
+  - playwright-core: `1.59.1`, `1.58.2`, `1.57.0`, `1.56.1`, and `1.55.1`.
+  - Chromium: `145.0.7632.0`
+  - Chrome: `147.0.7727.55` (amd64 only)
+  - Firefox: `146.0.1`
+  - Webkit: `26.0`
+  - Edge: `147.0.3912.60` (amd64 only)
 
 # [v2.46.0](https://github.com/browserless/browserless/compare/v2.45.0...v2.46.0)
 - Dependency updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserless.io/browserless",
-      "version": "2.46.0",
+      "version": "2.47.0",
       "license": "SSPL",
       "dependencies": {
         "@hapi/bourne": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hapi/bourne": "^3.0.0",
         "@hapi/hoek": "^11.0.4",
-        "@typescript-eslint/eslint-plugin": "8.58.2",
         "debug": "^4.4.1",
         "del": "^8.0.1",
         "file-type": "^22.0.1",
@@ -21,10 +20,10 @@
         "joi": "^18.1.2",
         "lighthouse": "^13.1.0",
         "micromatch": "^4.0.8",
-        "playwright-1.54": "npm:playwright-core@1.54.2",
         "playwright-1.55": "npm:playwright-core@1.55.1",
         "playwright-1.56": "npm:playwright-core@1.56.1",
         "playwright-1.57": "npm:playwright-core@1.57.0",
+        "playwright-1.58": "npm:playwright-core@1.58.2",
         "playwright-core": "1.59.1",
         "puppeteer-core": "24.40.0",
         "puppeteer-extra": "^3.3.6",
@@ -5273,19 +5272,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright-1.54": {
-      "name": "playwright-core",
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/playwright-1.55": {
       "name": "playwright-core",
       "version": "1.55.1",
@@ -5317,6 +5303,19 @@
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
       "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright-1.58": {
+      "name": "playwright-core",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "joi": "^18.1.2",
     "lighthouse": "^13.1.0",
     "micromatch": "^4.0.8",
-    "playwright-1.54": "npm:playwright-core@1.54.2",
     "playwright-1.55": "npm:playwright-core@1.55.1",
     "playwright-1.56": "npm:playwright-core@1.56.1",
     "playwright-1.57": "npm:playwright-core@1.57.0",
+    "playwright-1.58": "npm:playwright-core@1.58.2",
     "playwright-core": "1.59.1",
     "puppeteer-core": "24.40.0",
     "puppeteer-extra": "^3.3.6",
@@ -104,11 +104,10 @@
   },
   "playwrightVersions": {
     "default": "playwright-core",
-    "1.58": "playwright-core",
+    "1.58": "playwright-1.58",
     "1.57": "playwright-1.57",
     "1.56": "playwright-1.56",
-    "1.55": "playwright-1.55",
-    "1.54": "playwright-1.54"
+    "1.55": "playwright-1.55"
   },
   "engines": {
     "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "playwrightVersions": {
     "default": "playwright-core",
+    "1.59": "playwright-core",
     "1.58": "playwright-1.58",
     "1.57": "playwright-1.57",
     "1.56": "playwright-1.56",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "license": "SSPL",
   "description": "The browserless platform",
   "author": "browserless.io",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Playwright 1.59 and updated browser engine versions (Chromium, Chrome, Firefox, WebKit, Edge)

* **Bug Fixes**
  * Error handling now includes content type
  * Prevented orphaned dbus-daemon processes

* **Chores**
  * Bumped release to 2.47.0
  * Updated NPM to 11.12.1
  * Updated puppeteer-core to 24.40.0
  * Dropped support for Playwright 1.54
<!-- end of auto-generated comment: release notes by coderabbit.ai -->