### PR TITLE
ci: route apt through Azure mirror to avoid archive.ubuntu.com timeouts

### DIFF
--- a/.github/workflows/docker-chrome.yml
+++ b/.github/workflows/docker-chrome.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the Chrome image
         uses: nick-fields/retry@v4

--- a/.github/workflows/docker-chromium.yml
+++ b/.github/workflows/docker-chromium.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the Chromium image
         uses: nick-fields/retry@v4

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the Edge image
         uses: nick-fields/retry@v4

--- a/.github/workflows/docker-firefox.yml
+++ b/.github/workflows/docker-firefox.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the Firefox image
         uses: nick-fields/retry@v4

--- a/.github/workflows/docker-multi.yml
+++ b/.github/workflows/docker-multi.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the multi image
         uses: nick-fields/retry@v4

--- a/.github/workflows/docker-publish-latest.yml
+++ b/.github/workflows/docker-publish-latest.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Publish the latest Base image
         uses: docker/build-push-action@v7
         with:
+          build-args: |
+            APT_MIRROR=azure.archive.ubuntu.com
           builder: ${{ steps.buildx.outputs.name }}
           file: ./docker/base/Dockerfile
           tags: |

--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Publish the Stable Base image
         uses: docker/build-push-action@v7
         with:
+          build-args: |
+            APT_MIRROR=azure.archive.ubuntu.com
           builder: ${{ steps.buildx.outputs.name }}
           file: ./docker/base/Dockerfile
           tags: |

--- a/.github/workflows/docker-webkit.yml
+++ b/.github/workflows/docker-webkit.yml
@@ -17,7 +17,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 30
-          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
+          command: docker build --build-arg NODE_VERSION=${{ matrix.node-version }} --build-arg APT_MIRROR=azure.archive.ubuntu.com -f ./docker/base/Dockerfile -t ghcr.io/browserless/base:${{ matrix.node-version }} .
 
       - name: Build the Webkit image
         uses: nick-fields/retry@v4

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -33,6 +33,13 @@ WORKDIR $APP_DIR
 
 COPY fonts/* /usr/share/fonts/truetype/
 
+# Optional apt mirror override. Defaults preserve upstream archive.ubuntu.com
+# for external builders; CI passes azure.archive.ubuntu.com to avoid timeouts
+# against the default mirror from GitHub-hosted (Azure-backed) runners.
+ARG APT_MIRROR=archive.ubuntu.com
+RUN sed -i "s|archive.ubuntu.com|${APT_MIRROR}|g; s|security.ubuntu.com|${APT_MIRROR}|g" \
+  /etc/apt/sources.list.d/ubuntu.sources
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends software-properties-common \
   && add-apt-repository universe \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -33,12 +33,16 @@ WORKDIR $APP_DIR
 
 COPY fonts/* /usr/share/fonts/truetype/
 
-# Optional apt mirror override. Defaults preserve upstream archive.ubuntu.com
-# for external builders; CI passes azure.archive.ubuntu.com to avoid timeouts
-# against the default mirror from GitHub-hosted (Azure-backed) runners.
-ARG APT_MIRROR=archive.ubuntu.com
-RUN sed -i "s|archive.ubuntu.com|${APT_MIRROR}|g; s|security.ubuntu.com|${APT_MIRROR}|g" \
-  /etc/apt/sources.list.d/ubuntu.sources
+# Optional apt mirror override. Unset by default so external builders keep the
+# upstream archive.ubuntu.com + security.ubuntu.com defaults untouched. CI
+# passes azure.archive.ubuntu.com to avoid timeouts from GitHub-hosted
+# (Azure-backed) runners; when set, both archive and security are routed
+# through it since the Azure mirror carries noble-security as well.
+ARG APT_MIRROR=
+RUN if [ -n "${APT_MIRROR}" ]; then \
+    sed -i "s|archive.ubuntu.com|${APT_MIRROR}|g; s|security.ubuntu.com|${APT_MIRROR}|g" \
+      /etc/apt/sources.list.d/ubuntu.sources; \
+  fi
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends software-properties-common \


### PR DESCRIPTION
## Summary
- Adds `APT_MIRROR` build-arg to `docker/base/Dockerfile` (default `archive.ubuntu.com`, no change for external builders) and rewrites `/etc/apt/sources.list.d/ubuntu.sources` in the base layer. Child images inherit the patched sources automatically.
- CI workflows pass `APT_MIRROR=azure.archive.ubuntu.com` when building the base image, routing all apt traffic (first-stage installs + playwright `--with-deps` installs in child images) through the Azure mirror, which is intra-Azure from GitHub-hosted runners.

## Why
PR #5321's `test-multi` step failed when `playwright install --with-deps webkit` timed out trying to reach `archive.ubuntu.com` across all 8 IPs, and the 5 retry attempts all failed identically — that mirror is regularly flaky from GHA runners. `azure.archive.ubuntu.com` is Canonical's Azure-region mirror and is the documented default for Azure-backed runners.

## Verification
- Confirmed Ubuntu 24.04's deb822 `ubuntu.sources` is the correct target (old `/etc/apt/sources.list` is just a stub).
- Confirmed `azure.archive.ubuntu.com` serves every suite and component the Dockerfile uses (`noble`, `noble-updates`, `noble-backports`, `noble-security` × `main`, `universe`, `restricted`, `multiverse`).
- Built a minimal test Dockerfile with the exact ARG+sed syntax and installed the six font packages that timed out in PR #5321 (`fonts-tlwg-loma-otf`, `fonts-unifont`, `xfonts-encodings`, `xfonts-utils`, `xfonts-cyrillic`, `xfonts-scalable`) — all installed cleanly in ~15s via the Azure mirror.
- arm64 builds are safe: arm64's default `ports.ubuntu.com` URI doesn't match either sed pattern, so the replacement is a no-op (no Azure speedup there, but no regression).

## Test plan
- [ ] Re-run existing docker-* workflows and confirm base image build no longer hits archive.ubuntu.com (look for `azure.archive.ubuntu.com` lines in `apt-get update` output)
- [ ] Verify `test-multi` completes without `Installation process exited with code: 100`
- [ ] Confirm published images (post-merge) still pull/run correctly on amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipelines now support configurable OS package mirrors and have been updated to use Azure's mirror for base image construction.
  * Base image builds will apply the configured mirror when present, improving build resilience, reliability, and performance across publish and CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->