### PR TITLE
fix: stabilize chromium performance tests

### DIFF
--- a/src/routes/chromium/tests/performance.spec.ts
+++ b/src/routes/chromium/tests/performance.spec.ts
@@ -22,10 +22,10 @@ describe('/chromium/performance API', function () {
     const metrics = new Metrics();
     await start({ config, metrics });
     const body = {
-      url: 'https://browserless.io',
+      url: 'https://docs.browserless.io/',
     };
 
-    await fetch(
+    const res = await fetch(
       'http://localhost:3000/chromium/performance?token=browserless',
       {
         body: JSON.stringify(body),
@@ -34,12 +34,14 @@ describe('/chromium/performance API', function () {
         },
         method: 'POST',
       },
-    ).then((res) => {
-      expect(res.headers.get('content-type')).to.equal(
-        'application/json; charset=UTF-8',
-      );
-      expect(res.status).to.equal(200);
-    });
+    );
+    const responseBody = await res.text();
+    expect(res.status, `unexpected status; body: ${responseBody}`).to.equal(
+      200,
+    );
+    expect(res.headers.get('content-type')).to.equal(
+      'application/json; charset=UTF-8',
+    );
   });
 
   it('404s GET requests', async () => {
@@ -70,10 +72,10 @@ describe('/chromium/performance API', function () {
           onlyAudits: ['unminified-css'],
         },
       },
-      url: 'https://browserless.io',
+      url: 'https://docs.browserless.io/',
     };
 
-    await fetch(
+    const res = await fetch(
       'http://localhost:3000/chromium/performance?token=browserless',
       {
         body: JSON.stringify(body),
@@ -82,16 +84,18 @@ describe('/chromium/performance API', function () {
         },
         method: 'POST',
       },
-    ).then(async (res) => {
-      expect(res.headers.get('content-type')).to.equal(
-        'application/json; charset=UTF-8',
-      );
-      expect(res.status).to.equal(200);
+    );
+    const responseBody = await res.text();
+    expect(res.status, `unexpected status; body: ${responseBody}`).to.equal(
+      200,
+    );
+    expect(res.headers.get('content-type')).to.equal(
+      'application/json; charset=UTF-8',
+    );
 
-      const json = await res.json();
-      expect(json).to.have.property('data');
-      expect(json.data.audits).to.have.all.keys('unminified-css');
-    });
+    const json = JSON.parse(responseBody);
+    expect(json).to.have.property('data');
+    expect(json.data.audits).to.have.all.keys('unminified-css');
   });
 
   it('times out request', async () => {
@@ -148,20 +152,22 @@ describe('/chromium/performance API', function () {
   it('allows requests without token when auth token is not set', async () => {
     await start();
     const body = {
-      url: 'https://browserless.io',
+      url: 'https://docs.browserless.io/',
     };
 
-    await fetch('http://localhost:3000/chromium/performance', {
+    const res = await fetch('http://localhost:3000/chromium/performance', {
       body: JSON.stringify(body),
       headers: {
         'content-type': 'application/json',
       },
       method: 'POST',
-    }).then((res) => {
-      expect(res.headers.get('content-type')).to.equal(
-        'application/json; charset=UTF-8',
-      );
-      expect(res.status).to.equal(200);
     });
+    const responseBody = await res.text();
+    expect(res.status, `unexpected status; body: ${responseBody}`).to.equal(
+      200,
+    );
+    expect(res.headers.get('content-type')).to.equal(
+      'application/json; charset=UTF-8',
+    );
   });
 });


### PR DESCRIPTION
## Summary

- The `/chromium/performance API` tests in `src/routes/chromium/tests/performance.spec.ts` were failing CI deterministically (5/5 retries on PR #5334). Lighthouse audits against `https://browserless.io` exceeded the 30s default timeout.
- Swap the three positive-path tests to `https://docs.browserless.io/` (~20KB, no redirect, ~0.4s TTFB) so Lighthouse comfortably finishes in budget.
- Reorder assertions: read the response body once, assert `status === 200` first with the body included in the chai failure message, then assert content-type. The next failure will say `unexpected status; body: <real error>` instead of the cryptic `'text/plain' to equal 'application/json'`.

## Test plan

- [ ] CI `test-chromium` job passes without retries
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
