### PR TITLE
fix(monitoring): cgroup-aware MAX_CPU/MEMORY_PERCENT in Docker

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -175,7 +175,7 @@ export class Config extends EventEmitter {
   protected corsMaxAge = +(process.env.CORS_MAX_AGE ?? '2592000');
   protected maxCpu = +(process.env.MAX_CPU_PERCENT ?? '99');
   protected maxMemory = +(process.env.MAX_MEMORY_PERCENT ?? '99');
-  protected machineStatsSource = (
+  protected machineStatsSource: string = (
     process.env.MACHINE_STATS_SOURCE ?? 'auto'
   ).toLowerCase();
   protected maxPayloadSize = +(process.env.MAX_PAYLOAD_SIZE ?? '10485760'); // Default 10MB

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,6 +175,9 @@ export class Config extends EventEmitter {
   protected corsMaxAge = +(process.env.CORS_MAX_AGE ?? '2592000');
   protected maxCpu = +(process.env.MAX_CPU_PERCENT ?? '99');
   protected maxMemory = +(process.env.MAX_MEMORY_PERCENT ?? '99');
+  protected machineStatsSource = (
+    process.env.MACHINE_STATS_SOURCE ?? 'auto'
+  ).toLowerCase();
   protected maxPayloadSize = +(process.env.MAX_PAYLOAD_SIZE ?? '10485760'); // Default 10MB
   protected healthCheck = !!parseEnvVars(false, 'HEALTH');
   protected failedHealthURL = process.env.FAILED_HEALTH_URL ?? null;
@@ -253,6 +256,15 @@ export class Config extends EventEmitter {
   }
   public getMemoryLimit(): number {
     return this.maxMemory;
+  }
+  public getMachineStatsSource(): 'auto' | 'host' | 'cgroup' {
+    const value = this.machineStatsSource;
+    if (value !== 'auto' && value !== 'host' && value !== 'cgroup') {
+      throw new Error(
+        `Invalid MACHINE_STATS_SOURCE value "${value}". Expected "auto", "host", or "cgroup".`,
+      );
+    }
+    return value;
   }
   public getMaxPayloadSize(): number {
     return this.maxPayloadSize;

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,7 +177,9 @@ export class Config extends EventEmitter {
   protected maxMemory = +(process.env.MAX_MEMORY_PERCENT ?? '99');
   protected machineStatsSource: string = (
     process.env.MACHINE_STATS_SOURCE ?? 'auto'
-  ).toLowerCase();
+  )
+    .trim()
+    .toLowerCase();
   protected maxPayloadSize = +(process.env.MAX_PAYLOAD_SIZE ?? '10485760'); // Default 10MB
   protected healthCheck = !!parseEnvVars(false, 'HEALTH');
   protected failedHealthURL = process.env.FAILED_HEALTH_URL ?? null;

--- a/src/limiter.spec.ts
+++ b/src/limiter.spec.ts
@@ -363,36 +363,39 @@ describe(`Limiter`, () => {
 
   it('rejects via overCapacityFn when MachineStatsSource reports CPU overloaded', async () => {
     const sandbox = Sinon.createSandbox();
-    const config = new Config();
-    config.setConcurrent(5);
-    config.setQueued(5);
-    config.setTimeout(-1);
-    // MAX_CPU_PERCENT defaults to 99; force a low ceiling.
-    sandbox.stub(config, 'getCPULimit').returns(10);
-    sandbox.stub(config, 'getHealthChecksEnabled').returns(true);
+    try {
+      const config = new Config();
+      config.setConcurrent(5);
+      config.setQueued(5);
+      config.setTimeout(-1);
+      // MAX_CPU_PERCENT defaults to 99; force a low ceiling.
+      sandbox.stub(config, 'getCPULimit').returns(10);
+      sandbox.stub(config, 'getHealthChecksEnabled').returns(true);
 
-    const overloadedSource = {
-      name: 'fake-overloaded',
-      read: async () => ({ cpu: 0.95, memory: 0.1 }),
-    };
-    const monitoring = new Monitoring(config, overloadedSource);
-    const metrics = new Metrics();
+      const overloadedSource = {
+        name: 'fake-overloaded',
+        read: async () => ({ cpu: 0.95, memory: 0.1 }),
+      };
+      const monitoring = new Monitoring(config, overloadedSource);
+      const metrics = new Metrics();
 
-    const limiter = new Limiter(config, metrics, monitoring, webHooks, hooks);
-    const overCapacity = sandbox.spy();
-    const handler = sandbox.spy(asyncNoop);
+      const limiter = new Limiter(config, metrics, monitoring, webHooks, hooks);
+      const overCapacity = sandbox.spy();
+      const handler = sandbox.spy(asyncNoop);
 
-    const job = limiter.limit(handler, overCapacity, asyncNoop, noop);
-    let rejected = false;
-    await job().catch(() => {
-      rejected = true;
-    });
+      const job = limiter.limit(handler, overCapacity, asyncNoop, noop);
+      let rejection: Error | undefined;
+      await job().catch((err) => {
+        rejection = err as Error;
+      });
 
-    expect(rejected).to.be.true;
-    expect(overCapacity.calledOnce).to.be.true;
-    expect(handler.called).to.be.false;
-    expect(metrics.get().rejected).to.equal(1);
-
-    sandbox.restore();
+      expect(rejection).to.be.instanceOf(Error);
+      expect(rejection?.message).to.match(/health check/i);
+      expect(overCapacity.calledOnce).to.be.true;
+      expect(handler.called).to.be.false;
+      expect(metrics.get().rejected).to.equal(1);
+    } finally {
+      sandbox.restore();
+    }
   });
 });

--- a/src/limiter.spec.ts
+++ b/src/limiter.spec.ts
@@ -360,4 +360,39 @@ describe(`Limiter`, () => {
         r(undefined);
       });
     }));
+
+  it('rejects via overCapacityFn when MachineStatsSource reports CPU overloaded', async () => {
+    const sandbox = Sinon.createSandbox();
+    const config = new Config();
+    config.setConcurrent(5);
+    config.setQueued(5);
+    config.setTimeout(-1);
+    // MAX_CPU_PERCENT defaults to 99; force a low ceiling.
+    sandbox.stub(config, 'getCPULimit').returns(10);
+    sandbox.stub(config, 'getHealthChecksEnabled').returns(true);
+
+    const overloadedSource = {
+      name: 'fake-overloaded',
+      read: async () => ({ cpu: 0.95, memory: 0.1 }),
+    };
+    const monitoring = new Monitoring(config, overloadedSource);
+    const metrics = new Metrics();
+
+    const limiter = new Limiter(config, metrics, monitoring, webHooks, hooks);
+    const overCapacity = sandbox.spy();
+    const handler = sandbox.spy(asyncNoop);
+
+    const job = limiter.limit(handler, overCapacity, asyncNoop, noop);
+    let rejected = false;
+    await job().catch(() => {
+      rejected = true;
+    });
+
+    expect(rejected).to.be.true;
+    expect(overCapacity.calledOnce).to.be.true;
+    expect(handler.called).to.be.false;
+    expect(metrics.get().rejected).to.equal(1);
+
+    sandbox.restore();
+  });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -1,0 +1,60 @@
+/* eslint-disable no-unused-expressions */
+import { HostSource, readWithTimeout } from '@browserless.io/browserless';
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import si from 'systeminformation';
+
+describe('HostSource', () => {
+  afterEach(() => Sinon.restore());
+
+  it('returns CPU and memory fractions from systeminformation', async () => {
+    Sinon.stub(si, 'currentLoad').resolves({
+      currentLoadUser: 42,
+    } as unknown as si.Systeminformation.CurrentLoadData);
+    Sinon.stub(si, 'mem').resolves({
+      active: 256,
+      total: 1024,
+    } as unknown as si.Systeminformation.MemData);
+
+    const source = new HostSource();
+    const result = await source.read();
+
+    expect(result.cpu).to.equal(0.42);
+    expect(result.memory).to.equal(0.25);
+  });
+
+  it('returns nulls when systeminformation throws', async () => {
+    Sinon.stub(si, 'currentLoad').rejects(new Error('boom'));
+    Sinon.stub(si, 'mem').rejects(new Error('boom'));
+
+    const source = new HostSource();
+    const result = await source.read();
+
+    expect(result.cpu).to.be.null;
+    expect(result.memory).to.be.null;
+  });
+});
+
+describe('readWithTimeout', () => {
+  it('resolves to file contents when readFile resolves in time', async () => {
+    const readFile: Parameters<typeof readWithTimeout>[1] = async () => 'hello';
+    const result = await readWithTimeout('/fake', readFile, 100);
+    expect(result).to.equal('hello');
+  });
+
+  it('rejects when the timeout fires before readFile resolves', async () => {
+    const readFile: Parameters<typeof readWithTimeout>[1] = (_path, signal) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason));
+      });
+
+    let err: Error | undefined;
+    try {
+      await readWithTimeout('/fake', readFile, 20);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).to.exist;
+    expect((err as Error & { name: string }).name).to.equal('TimeoutError');
+  });
+});

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -4,6 +4,7 @@ import {
   CgroupV2Source,
   HostSource,
   Logger,
+  detectMachineStatsSource,
   parseCpuMax,
   parseCpuStatUsageUsec,
   parseCpuV1Quota,
@@ -386,5 +387,52 @@ describe('CgroupV1Source', () => {
     const result = await source.read();
     expect(result.cpu).to.be.closeTo(1.0, 0.001);
     expect(result.memory).to.be.null;
+  });
+});
+
+describe('detectMachineStatsSource', () => {
+  const fileExistsFor = (paths: string[]) => (p: string) => paths.includes(p);
+
+  it('picks CgroupV2Source when /sys/fs/cgroup/cgroup.controllers exists', () => {
+    const source = detectMachineStatsSource(
+      'auto',
+      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
+    );
+    expect(source.name).to.equal('cgroup-v2');
+  });
+
+  it('picks CgroupV1Source when v1 exists and v2 does not', () => {
+    const source = detectMachineStatsSource(
+      'auto',
+      fileExistsFor(['/sys/fs/cgroup/cpu/cpuacct.usage']),
+    );
+    expect(source.name).to.equal('cgroup-v1');
+  });
+
+  it('picks HostSource when no cgroup files exist', () => {
+    const source = detectMachineStatsSource('auto', fileExistsFor([]));
+    expect(source.name).to.equal('host (systeminformation)');
+  });
+
+  it('forces HostSource when preference is "host"', () => {
+    const source = detectMachineStatsSource(
+      'host',
+      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
+    );
+    expect(source.name).to.equal('host (systeminformation)');
+  });
+
+  it('throws when preference is "cgroup" but no cgroup files exist', () => {
+    expect(() =>
+      detectMachineStatsSource('cgroup', fileExistsFor([])),
+    ).to.throw(/cgroup/i);
+  });
+
+  it('forces CgroupV2 when preference is "cgroup" and v2 is present', () => {
+    const source = detectMachineStatsSource(
+      'cgroup',
+      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
+    );
+    expect(source.name).to.equal('cgroup-v2');
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -2,8 +2,10 @@
 import {
   CgroupV1Source,
   CgroupV2Source,
+  Config,
   HostSource,
   Logger,
+  Monitoring,
   detectMachineStatsSource,
   parseCpuMax,
   parseCpuStatUsageUsec,
@@ -453,5 +455,45 @@ describe('detectMachineStatsSource', () => {
       ]),
     );
     expect(source.name).to.equal('cgroup-v2');
+  });
+});
+
+describe('Monitoring source wiring', () => {
+  afterEach(() => {
+    Sinon.restore();
+    delete process.env.MACHINE_STATS_SOURCE;
+  });
+
+  it('logs the chosen source name at construction', () => {
+    const config = new Config();
+    const fakeSource = {
+      name: 'fake',
+      read: async () => ({ cpu: 0.1, memory: 0.2 }),
+    };
+    const logSpy = Sinon.spy();
+
+    const monitoring = new Monitoring(config, fakeSource, logSpy);
+    expect(logSpy.calledOnce).to.be.true;
+    expect(logSpy.firstCall.args[0]).to.match(/source.*fake/i);
+    expect(monitoring).to.exist;
+  });
+
+  it('delegates getMachineStats() to the configured source', async () => {
+    const config = new Config();
+    const fakeSource = {
+      name: 'fake',
+      read: async () => ({ cpu: 0.7, memory: 0.3 }),
+    };
+    const monitoring = new Monitoring(config, fakeSource);
+    const stats = await monitoring.getMachineStats();
+    expect(stats).to.deep.equal({ cpu: 0.7, memory: 0.3 });
+  });
+
+  it('honors MACHINE_STATS_SOURCE=host even on a cgroup host', () => {
+    process.env.MACHINE_STATS_SOURCE = 'host';
+    const config = new Config();
+    const monitoring = new Monitoring(config);
+    // We cannot read protected statsSource; verify behavior via getMachineStats path on dev hosts (HostSource exists). Simply expect construction to succeed.
+    expect(monitoring).to.exist;
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -1,11 +1,14 @@
 /* eslint-disable no-unused-expressions */
 import {
+  CgroupV1Source,
   CgroupV2Source,
   HostSource,
   Logger,
   parseCpuMax,
   parseCpuStatUsageUsec,
+  parseCpuV1Quota,
   parseMemoryMax,
+  parseMemoryV1Limit,
   readWithTimeout,
 } from '@browserless.io/browserless';
 import { expect } from 'chai';
@@ -257,5 +260,80 @@ describe('CgroupV2Source', () => {
     const result = await source.read();
     expect(result.cpu).to.be.closeTo(1.0, 0.001);
     expect(result.memory).to.be.null;
+  });
+});
+
+describe('cgroup v1 parsers', () => {
+  describe('parseCpuV1Quota', () => {
+    it('returns quota/period when bounded', () => {
+      expect(parseCpuV1Quota('200000', '100000')).to.equal(2);
+      expect(parseCpuV1Quota('50000', '100000')).to.equal(0.5);
+    });
+
+    it('returns os.cpus().length when quota is -1 (unbounded)', () => {
+      expect(parseCpuV1Quota('-1', '100000')).to.equal(os.cpus().length);
+    });
+
+    it('returns null for invalid content', () => {
+      expect(parseCpuV1Quota('abc', '100000')).to.be.null;
+      expect(parseCpuV1Quota('100000', '0')).to.be.null;
+    });
+  });
+
+  describe('parseMemoryV1Limit', () => {
+    it('returns the byte value when bounded', () => {
+      expect(parseMemoryV1Limit('536870912')).to.equal(536870912);
+    });
+
+    it('returns os.totalmem() when the kernel sentinel is used (unbounded)', () => {
+      // Treat any value larger than 16 * host RAM as unbounded
+      const sentinel = String(os.totalmem() * 32);
+      expect(parseMemoryV1Limit(sentinel)).to.equal(os.totalmem());
+    });
+
+    it('returns null for invalid content', () => {
+      expect(parseMemoryV1Limit('garbage')).to.be.null;
+      expect(parseMemoryV1Limit('')).to.be.null;
+    });
+  });
+});
+
+describe('CgroupV1Source', () => {
+  it('converts cpuacct.usage from nanoseconds to fractional cpu', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu/cpuacct.usage': '1000000', // 1 ms in ns = 1000 us
+      '/sys/fs/cgroup/cpu/cpu.cfs_quota_us': '100000', // 1 core
+      '/sys/fs/cgroup/cpu/cpu.cfs_period_us': '100000',
+      '/sys/fs/cgroup/memory/memory.usage_in_bytes': '0',
+      '/sys/fs/cgroup/memory/memory.limit_in_bytes': '1073741824',
+    };
+    const readFile = async (path: string) => responses[path];
+
+    const now = Sinon.stub();
+    now.onCall(0).returns(1_000_000);
+    now.onCall(1).returns(1_001_000);
+
+    const source = new CgroupV1Source({ readFile, now });
+    await source.read();
+
+    // 1,000,000,000 ns = 1,000,000 us delta over 1000 ms wall on 1 core = 100%
+    responses['/sys/fs/cgroup/cpu/cpuacct.usage'] = '1001000000';
+    const result = await source.read();
+    expect(result.cpu).to.be.closeTo(1.0, 0.001);
+  });
+
+  it('computes memory fraction', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu/cpuacct.usage': '0',
+      '/sys/fs/cgroup/cpu/cpu.cfs_quota_us': '100000',
+      '/sys/fs/cgroup/cpu/cpu.cfs_period_us': '100000',
+      '/sys/fs/cgroup/memory/memory.usage_in_bytes': '268435456',
+      '/sys/fs/cgroup/memory/memory.limit_in_bytes': '536870912',
+    };
+    const source = new CgroupV1Source({
+      readFile: async (path: string) => responses[path],
+    });
+    const result = await source.read();
+    expect(result.memory).to.equal(0.5);
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -1,6 +1,13 @@
 /* eslint-disable no-unused-expressions */
-import { HostSource, readWithTimeout } from '@browserless.io/browserless';
+import {
+  HostSource,
+  parseCpuMax,
+  parseCpuStatUsageUsec,
+  parseMemoryMax,
+  readWithTimeout,
+} from '@browserless.io/browserless';
 import { expect } from 'chai';
+import os from 'os';
 import Sinon from 'sinon';
 import si from 'systeminformation';
 
@@ -56,5 +63,60 @@ describe('readWithTimeout', () => {
     }
     expect(err).to.exist;
     expect((err as Error & { name: string }).name).to.equal('TimeoutError');
+  });
+});
+
+describe('cgroup v2 parsers', () => {
+  describe('parseCpuMax', () => {
+    it('returns quota / period as cores when bounded', () => {
+      expect(parseCpuMax('100000 100000')).to.equal(1);
+      expect(parseCpuMax('50000 100000')).to.equal(0.5);
+      expect(parseCpuMax('400000 100000')).to.equal(4);
+    });
+
+    it('returns the host CPU count when unbounded ("max")', () => {
+      expect(parseCpuMax('max 100000')).to.equal(os.cpus().length);
+    });
+
+    it('returns null for malformed content', () => {
+      expect(parseCpuMax('')).to.be.null;
+      expect(parseCpuMax('garbage')).to.be.null;
+      expect(parseCpuMax('100000')).to.be.null;
+    });
+  });
+
+  describe('parseCpuStatUsageUsec', () => {
+    it('extracts usage_usec', () => {
+      const content =
+        'usage_usec 12345\nuser_usec 6000\nsystem_usec 6345\n';
+      expect(parseCpuStatUsageUsec(content)).to.equal(12345);
+    });
+
+    it('ignores unknown fields added by future kernels', () => {
+      const content =
+        'usage_usec 999\nfuture_field 42\nuser_usec 500\n';
+      expect(parseCpuStatUsageUsec(content)).to.equal(999);
+    });
+
+    it('returns null when usage_usec is missing or non-numeric', () => {
+      expect(parseCpuStatUsageUsec('user_usec 1\nsystem_usec 2\n')).to.be.null;
+      expect(parseCpuStatUsageUsec('usage_usec abc\n')).to.be.null;
+      expect(parseCpuStatUsageUsec('')).to.be.null;
+    });
+  });
+
+  describe('parseMemoryMax', () => {
+    it('returns the byte value when bounded', () => {
+      expect(parseMemoryMax('536870912')).to.equal(536870912);
+    });
+
+    it('returns os.totalmem() when unbounded ("max")', () => {
+      expect(parseMemoryMax('max')).to.equal(os.totalmem());
+    });
+
+    it('returns null for malformed content', () => {
+      expect(parseMemoryMax('')).to.be.null;
+      expect(parseMemoryMax('garbage')).to.be.null;
+    });
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -435,4 +435,23 @@ describe('detectMachineStatsSource', () => {
     );
     expect(source.name).to.equal('cgroup-v2');
   });
+
+  it('picks CgroupV1Source when preference is "cgroup" and only v1 is present', () => {
+    const source = detectMachineStatsSource(
+      'cgroup',
+      fileExistsFor(['/sys/fs/cgroup/cpu/cpuacct.usage']),
+    );
+    expect(source.name).to.equal('cgroup-v1');
+  });
+
+  it('prefers v2 when both probes exist in auto mode', () => {
+    const source = detectMachineStatsSource(
+      'auto',
+      fileExistsFor([
+        '/sys/fs/cgroup/cgroup.controllers',
+        '/sys/fs/cgroup/cpu/cpuacct.usage',
+      ]),
+    );
+    expect(source.name).to.equal('cgroup-v2');
+  });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -278,6 +278,11 @@ describe('cgroup v1 parsers', () => {
       expect(parseCpuV1Quota('abc', '100000')).to.be.null;
       expect(parseCpuV1Quota('100000', '0')).to.be.null;
     });
+
+    it('returns null when quota content is empty or whitespace', () => {
+      expect(parseCpuV1Quota('', '100000')).to.be.null;
+      expect(parseCpuV1Quota('   ', '100000')).to.be.null;
+    });
   });
 
   describe('parseMemoryV1Limit', () => {
@@ -299,6 +304,8 @@ describe('cgroup v1 parsers', () => {
 });
 
 describe('CgroupV1Source', () => {
+  afterEach(() => Sinon.restore());
+
   it('converts cpuacct.usage from nanoseconds to fractional cpu', async () => {
     const responses: Record<string, string> = {
       '/sys/fs/cgroup/cpu/cpuacct.usage': '1000000', // 1 ms in ns = 1000 us
@@ -335,5 +342,49 @@ describe('CgroupV1Source', () => {
     });
     const result = await source.read();
     expect(result.memory).to.equal(0.5);
+  });
+
+  it('returns nulls when a read fails, logs once per category', async () => {
+    const warnStub = Sinon.stub(Logger.prototype, 'warn');
+
+    const readFile = async () => {
+      throw new Error('EACCES');
+    };
+
+    const source = new CgroupV1Source({ readFile });
+    const result1 = await source.read();
+    const result2 = await source.read();
+
+    expect(result1).to.deep.equal({ cpu: null, memory: null });
+    expect(result2).to.deep.equal({ cpu: null, memory: null });
+
+    // 2 categories of read failure (cpu-read, memory-read) — each logged exactly once.
+    expect(warnStub.callCount).to.equal(2);
+    const messages = warnStub.getCalls().map((c) => c.args[0] as string);
+    expect(messages.some((m) => m.includes('cpu-read'))).to.be.true;
+    expect(messages.some((m) => m.includes('memory-read'))).to.be.true;
+  });
+
+  it('decouples memory failure from cpu success', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu/cpuacct.usage': '1000000',
+      '/sys/fs/cgroup/cpu/cpu.cfs_quota_us': '100000',
+      '/sys/fs/cgroup/cpu/cpu.cfs_period_us': '100000',
+      '/sys/fs/cgroup/memory/memory.usage_in_bytes': '0',
+      '/sys/fs/cgroup/memory/memory.limit_in_bytes': 'garbage',
+    };
+    const readFile = async (path: string) => responses[path];
+
+    const now = Sinon.stub();
+    now.onCall(0).returns(1_000_000);
+    now.onCall(1).returns(1_001_000);
+
+    const source = new CgroupV1Source({ readFile, now });
+    await source.read(); // first sample stored
+
+    responses['/sys/fs/cgroup/cpu/cpuacct.usage'] = '1001000000';
+    const result = await source.read();
+    expect(result.cpu).to.be.closeTo(1.0, 0.001);
+    expect(result.memory).to.be.null;
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 import {
+  CgroupV2Source,
   HostSource,
   parseCpuMax,
   parseCpuStatUsageUsec,
@@ -118,5 +119,110 @@ describe('cgroup v2 parsers', () => {
       expect(parseMemoryMax('')).to.be.null;
       expect(parseMemoryMax('garbage')).to.be.null;
     });
+  });
+});
+
+describe('CgroupV2Source', () => {
+  const makeReadFile = (responses: Record<string, string | Error>) => {
+    return async (path: string) => {
+      const v = responses[path];
+      if (v === undefined) throw new Error(`unexpected path ${path}`);
+      if (v instanceof Error) throw v;
+      return v;
+    };
+  };
+
+  it('returns null for cpu on the first call (no prior sample)', async () => {
+    const now = Sinon.stub();
+    now.returns(1_000_000);
+
+    const source = new CgroupV2Source({
+      readFile: makeReadFile({
+        '/sys/fs/cgroup/cpu.stat': 'usage_usec 1000\n',
+        '/sys/fs/cgroup/cpu.max': '100000 100000',
+        '/sys/fs/cgroup/memory.current': '536870912',
+        '/sys/fs/cgroup/memory.max': '1073741824',
+      }),
+      now,
+    });
+
+    const result = await source.read();
+    expect(result.cpu).to.be.null;
+    expect(result.memory).to.equal(0.5);
+  });
+
+  it('computes cpu fraction from delta between two reads', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu.stat': 'usage_usec 1000\n',
+      '/sys/fs/cgroup/cpu.max': '100000 100000', // 1 core
+      '/sys/fs/cgroup/memory.current': '0',
+      '/sys/fs/cgroup/memory.max': '1073741824',
+    };
+    const readFile = async (path: string) => responses[path];
+
+    const now = Sinon.stub();
+    now.onCall(0).returns(1_000_000); // first sample at t=0
+    now.onCall(1).returns(1_001_000); // second read 1000ms later
+
+    const source = new CgroupV2Source({ readFile, now });
+    await source.read(); // store first sample
+
+    // 1,000,000 usec of CPU time consumed in 1000 ms wall, on 1 core = 100%
+    responses['/sys/fs/cgroup/cpu.stat'] = 'usage_usec 1001000\n';
+
+    const result = await source.read();
+    expect(result.cpu).to.be.closeTo(1.0, 0.001);
+  });
+
+  it('uses os.cpus().length when cpu.max is "max"', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu.stat': 'usage_usec 0\n',
+      '/sys/fs/cgroup/cpu.max': 'max 100000',
+      '/sys/fs/cgroup/memory.current': '0',
+      '/sys/fs/cgroup/memory.max': 'max',
+    };
+    const readFile = async (path: string) => responses[path];
+
+    const now = Sinon.stub();
+    now.onCall(0).returns(1_000_000);
+    now.onCall(1).returns(1_001_000);
+
+    const source = new CgroupV2Source({ readFile, now });
+    await source.read();
+
+    const cores = os.cpus().length;
+    // 1,000,000 usec used over 1000 ms wall on N cores = 1/N
+    responses['/sys/fs/cgroup/cpu.stat'] = 'usage_usec 1000000\n';
+
+    const result = await source.read();
+    expect(result.cpu).to.be.closeTo(1 / cores, 0.001);
+  });
+
+  it('returns nulls when a read fails, logs once per category', async () => {
+    const readFile = async () => {
+      throw new Error('EACCES');
+    };
+
+    const source = new CgroupV2Source({ readFile });
+    const result1 = await source.read();
+    const result2 = await source.read();
+
+    expect(result1).to.deep.equal({ cpu: null, memory: null });
+    expect(result2).to.deep.equal({ cpu: null, memory: null });
+  });
+
+  it('returns nulls when cpu.stat is unparseable', async () => {
+    const source = new CgroupV2Source({
+      readFile: makeReadFile({
+        '/sys/fs/cgroup/cpu.stat': 'garbage\n',
+        '/sys/fs/cgroup/cpu.max': '100000 100000',
+        '/sys/fs/cgroup/memory.current': '0',
+        '/sys/fs/cgroup/memory.max': '1073741824',
+      }),
+    });
+
+    const result = await source.read();
+    expect(result.cpu).to.be.null;
+    expect(result.memory).to.equal(0);
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -2,6 +2,7 @@
 import {
   CgroupV2Source,
   HostSource,
+  Logger,
   parseCpuMax,
   parseCpuStatUsageUsec,
   parseMemoryMax,
@@ -123,6 +124,8 @@ describe('cgroup v2 parsers', () => {
 });
 
 describe('CgroupV2Source', () => {
+  afterEach(() => Sinon.restore());
+
   const makeReadFile = (responses: Record<string, string | Error>) => {
     return async (path: string) => {
       const v = responses[path];
@@ -199,6 +202,8 @@ describe('CgroupV2Source', () => {
   });
 
   it('returns nulls when a read fails, logs once per category', async () => {
+    const warnStub = Sinon.stub(Logger.prototype, 'warn');
+
     const readFile = async () => {
       throw new Error('EACCES');
     };
@@ -209,6 +214,12 @@ describe('CgroupV2Source', () => {
 
     expect(result1).to.deep.equal({ cpu: null, memory: null });
     expect(result2).to.deep.equal({ cpu: null, memory: null });
+
+    // 2 categories of read failure (cpu-read, memory-read) — each logged exactly once.
+    expect(warnStub.callCount).to.equal(2);
+    const messages = warnStub.getCalls().map((c) => c.args[0] as string);
+    expect(messages.some((m) => m.includes('cpu-read'))).to.be.true;
+    expect(messages.some((m) => m.includes('memory-read'))).to.be.true;
   });
 
   it('returns nulls when cpu.stat is unparseable', async () => {
@@ -224,5 +235,27 @@ describe('CgroupV2Source', () => {
     const result = await source.read();
     expect(result.cpu).to.be.null;
     expect(result.memory).to.equal(0);
+  });
+
+  it('decouples memory failure from cpu success', async () => {
+    const responses: Record<string, string> = {
+      '/sys/fs/cgroup/cpu.stat': 'usage_usec 1000\n',
+      '/sys/fs/cgroup/cpu.max': '100000 100000', // 1 core
+      '/sys/fs/cgroup/memory.current': '0',
+      '/sys/fs/cgroup/memory.max': 'garbage',
+    };
+    const readFile = async (path: string) => responses[path];
+
+    const now = Sinon.stub();
+    now.onCall(0).returns(1_000_000);
+    now.onCall(1).returns(1_001_000);
+
+    const source = new CgroupV2Source({ readFile, now });
+    await source.read(); // first sample stored
+
+    responses['/sys/fs/cgroup/cpu.stat'] = 'usage_usec 1001000\n';
+    const result = await source.read();
+    expect(result.cpu).to.be.closeTo(1.0, 0.001);
+    expect(result.memory).to.be.null;
   });
 });

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -393,21 +393,29 @@ describe('CgroupV1Source', () => {
 });
 
 describe('detectMachineStatsSource', () => {
+  const V2_FILES = [
+    '/sys/fs/cgroup/cgroup.controllers',
+    '/sys/fs/cgroup/cpu.stat',
+    '/sys/fs/cgroup/cpu.max',
+    '/sys/fs/cgroup/memory.current',
+    '/sys/fs/cgroup/memory.max',
+  ];
+  const V1_FILES = [
+    '/sys/fs/cgroup/cpu/cpuacct.usage',
+    '/sys/fs/cgroup/cpu/cpu.cfs_quota_us',
+    '/sys/fs/cgroup/cpu/cpu.cfs_period_us',
+    '/sys/fs/cgroup/memory/memory.usage_in_bytes',
+    '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+  ];
   const fileExistsFor = (paths: string[]) => (p: string) => paths.includes(p);
 
-  it('picks CgroupV2Source when /sys/fs/cgroup/cgroup.controllers exists', () => {
-    const source = detectMachineStatsSource(
-      'auto',
-      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
-    );
+  it('picks CgroupV2Source when the full v2 file set exists', () => {
+    const source = detectMachineStatsSource('auto', fileExistsFor(V2_FILES));
     expect(source.name).to.equal('cgroup-v2');
   });
 
   it('picks CgroupV1Source when v1 exists and v2 does not', () => {
-    const source = detectMachineStatsSource(
-      'auto',
-      fileExistsFor(['/sys/fs/cgroup/cpu/cpuacct.usage']),
-    );
+    const source = detectMachineStatsSource('auto', fileExistsFor(V1_FILES));
     expect(source.name).to.equal('cgroup-v1');
   });
 
@@ -417,10 +425,7 @@ describe('detectMachineStatsSource', () => {
   });
 
   it('forces HostSource when preference is "host"', () => {
-    const source = detectMachineStatsSource(
-      'host',
-      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
-    );
+    const source = detectMachineStatsSource('host', fileExistsFor(V2_FILES));
     expect(source.name).to.equal('host (systeminformation)');
   });
 
@@ -431,30 +436,37 @@ describe('detectMachineStatsSource', () => {
   });
 
   it('forces CgroupV2 when preference is "cgroup" and v2 is present', () => {
-    const source = detectMachineStatsSource(
-      'cgroup',
-      fileExistsFor(['/sys/fs/cgroup/cgroup.controllers']),
-    );
+    const source = detectMachineStatsSource('cgroup', fileExistsFor(V2_FILES));
     expect(source.name).to.equal('cgroup-v2');
   });
 
   it('picks CgroupV1Source when preference is "cgroup" and only v1 is present', () => {
-    const source = detectMachineStatsSource(
-      'cgroup',
-      fileExistsFor(['/sys/fs/cgroup/cpu/cpuacct.usage']),
-    );
+    const source = detectMachineStatsSource('cgroup', fileExistsFor(V1_FILES));
     expect(source.name).to.equal('cgroup-v1');
   });
 
-  it('prefers v2 when both probes exist in auto mode', () => {
+  it('prefers v2 when both file sets exist in auto mode', () => {
     const source = detectMachineStatsSource(
       'auto',
-      fileExistsFor([
-        '/sys/fs/cgroup/cgroup.controllers',
-        '/sys/fs/cgroup/cpu/cpuacct.usage',
-      ]),
+      fileExistsFor([...V2_FILES, ...V1_FILES]),
     );
     expect(source.name).to.equal('cgroup-v2');
+  });
+
+  it('falls back to HostSource in auto mode when v2 is partially present', () => {
+    // cgroup.controllers exists but cpu.stat does not — non-standard mount
+    const partial = V2_FILES.filter((p) => p !== '/sys/fs/cgroup/cpu.stat');
+    const source = detectMachineStatsSource('auto', fileExistsFor(partial));
+    expect(source.name).to.equal('host (systeminformation)');
+  });
+
+  it('throws in cgroup mode when v1 is partially present', () => {
+    const partial = V1_FILES.filter(
+      (p) => p !== '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+    );
+    expect(() =>
+      detectMachineStatsSource('cgroup', fileExistsFor(partial)),
+    ).to.throw(/cgroup/i);
   });
 });
 

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -351,9 +351,13 @@ export class Monitoring extends EventEmitter {
   constructor(
     protected config: Config,
     statsSource?: MachineStatsSource,
+    logFn?: (msg: string) => void,
   ) {
     super();
-    this.statsSource = statsSource ?? new HostSource();
+    this.statsSource =
+      statsSource ?? detectMachineStatsSource(config.getMachineStatsSource());
+    const log = logFn ?? ((msg: string) => this.log.info(msg));
+    log(`Machine stats source: ${this.statsSource.name}`);
   }
 
   public async getMachineStats(): Promise<IResourceLoad> {

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -180,9 +180,11 @@ export function parseCpuV1Quota(
 ): number | null {
   const period = Number(periodContent.trim());
   if (!Number.isFinite(period) || period <= 0) return null;
-  const quota = Number(quotaContent.trim());
+  const trimmedQuota = quotaContent.trim();
+  if (!trimmedQuota) return null;
+  const quota = Number(trimmedQuota);
   if (!Number.isFinite(quota)) return null;
-  if (quota <= 0) return os.cpus().length; // -1 means unbounded
+  if (quota <= 0) return os.cpus().length; // <= 0 (including -1) means unbounded
   return quota / period;
 }
 
@@ -203,12 +205,12 @@ export class CgroupV1Source implements MachineStatsSource {
   protected lastSample: Sample | null = null;
   protected loggedFailure: Set<string> = new Set();
 
-  protected readFile: ReadFileFn;
   protected now: () => number;
+  protected readFile: ReadFileFn;
 
   constructor(opts: CgroupSourceOpts = {}) {
-    this.readFile = opts.readFile ?? defaultReadFile;
     this.now = opts.now ?? Date.now;
+    this.readFile = opts.readFile ?? defaultReadFile;
   }
 
   public async read(): Promise<IResourceLoad> {

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -46,26 +46,18 @@ export class HostSource implements MachineStatsSource {
 
 export class Monitoring extends EventEmitter {
   protected log = new Logger('hardware');
-  constructor(protected config: Config) {
+  protected statsSource: MachineStatsSource;
+
+  constructor(
+    protected config: Config,
+    statsSource?: MachineStatsSource,
+  ) {
     super();
+    this.statsSource = statsSource ?? new HostSource();
   }
 
   public async getMachineStats(): Promise<IResourceLoad> {
-    const [cpuLoad, memLoad] = await Promise.all([
-      si.currentLoad(),
-      si.mem(),
-    ]).catch((err) => {
-      this.log.error(`Error checking machine stats`, err);
-      return [null, null];
-    });
-
-    const cpu = cpuLoad ? cpuLoad.currentLoadUser / 100 : null;
-    const memory = memLoad ? memLoad.active / memLoad.total : null;
-
-    return {
-      cpu,
-      memory,
-    };
+    return this.statsSource.read();
   }
 
   public async overloaded(): Promise<{
@@ -86,24 +78,12 @@ export class Monitoring extends EventEmitter {
     const memoryOverloaded = !!(
       memoryInt && memoryInt >= this.config.getMemoryLimit()
     );
-    return {
-      cpuInt,
-      cpuOverloaded,
-      memoryInt,
-      memoryOverloaded,
-    };
+    return { cpuInt, cpuOverloaded, memoryInt, memoryOverloaded };
   }
 
-  /**
-   * Implement any browserless-core-specific shutdown logic here.
-   * Calls the empty-SDK stop method for downstream implementations.
-   */
   public async shutdown() {
     return await this.stop();
   }
 
-  /**
-   * Left blank for downstream SDK modules to optionally implement.
-   */
   public stop() {}
 }

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -317,8 +317,20 @@ const defaultFileExists: FileExists = (path) => {
   }
 };
 
-const CGROUP_V2_PROBE = '/sys/fs/cgroup/cgroup.controllers';
-const CGROUP_V1_PROBE = '/sys/fs/cgroup/cpu/cpuacct.usage';
+const CGROUP_V2_REQUIRED = [
+  '/sys/fs/cgroup/cgroup.controllers',
+  '/sys/fs/cgroup/cpu.stat',
+  '/sys/fs/cgroup/cpu.max',
+  '/sys/fs/cgroup/memory.current',
+  '/sys/fs/cgroup/memory.max',
+];
+const CGROUP_V1_REQUIRED = [
+  '/sys/fs/cgroup/cpu/cpuacct.usage',
+  '/sys/fs/cgroup/cpu/cpu.cfs_quota_us',
+  '/sys/fs/cgroup/cpu/cpu.cfs_period_us',
+  '/sys/fs/cgroup/memory/memory.usage_in_bytes',
+  '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+];
 
 export function detectMachineStatsSource(
   preference: 'auto' | 'host' | 'cgroup',
@@ -326,15 +338,15 @@ export function detectMachineStatsSource(
 ): MachineStatsSource {
   if (preference === 'host') return new HostSource();
 
-  const hasV2 = fileExists(CGROUP_V2_PROBE);
-  const hasV1 = !hasV2 && fileExists(CGROUP_V1_PROBE);
+  const hasAll = (paths: string[]) => paths.every((p) => fileExists(p));
+  const hasV2 = hasAll(CGROUP_V2_REQUIRED);
+  const hasV1 = !hasV2 && hasAll(CGROUP_V1_REQUIRED);
 
   if (preference === 'cgroup') {
     if (hasV2) return new CgroupV2Source();
     if (hasV1) return new CgroupV1Source();
     throw new Error(
-      'MACHINE_STATS_SOURCE=cgroup but no cgroup files found at ' +
-        `${CGROUP_V2_PROBE} or ${CGROUP_V1_PROBE}.`,
+      'MACHINE_STATS_SOURCE=cgroup but required cgroup stat files are missing.',
     );
   }
 

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -1,6 +1,48 @@
 import { Config, IResourceLoad, Logger } from '@browserless.io/browserless';
 import { EventEmitter } from 'events';
+import { readFile as fsReadFile } from 'fs/promises';
 import si from 'systeminformation';
+
+const READ_TIMEOUT_MS = 200;
+
+type ReadFileFn = (path: string, signal: AbortSignal) => Promise<string>;
+
+const defaultReadFile: ReadFileFn = (path, signal) =>
+  fsReadFile(path, { encoding: 'utf8', signal });
+
+export async function readWithTimeout(
+  path: string,
+  readFile: ReadFileFn = defaultReadFile,
+  timeoutMs: number = READ_TIMEOUT_MS,
+): Promise<string> {
+  const signal = AbortSignal.timeout(timeoutMs);
+  return readFile(path, signal);
+}
+
+export interface MachineStatsSource {
+  read(): Promise<IResourceLoad>;
+  readonly name: string;
+}
+
+export class HostSource implements MachineStatsSource {
+  public readonly name = 'host (systeminformation)';
+  protected log = new Logger('hardware');
+
+  public async read(): Promise<IResourceLoad> {
+    const [cpuLoad, memLoad] = await Promise.all([
+      si.currentLoad(),
+      si.mem(),
+    ]).catch((err) => {
+      this.log.error(`Error checking machine stats`, err);
+      return [null, null];
+    });
+
+    const cpu = cpuLoad ? cpuLoad.currentLoadUser / 100 : null;
+    const memory = memLoad ? memLoad.active / memLoad.total : null;
+
+    return { cpu, memory };
+  }
+}
 
 export class Monitoring extends EventEmitter {
   protected log = new Logger('hardware');

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -1,5 +1,6 @@
 import { Config, IResourceLoad, Logger } from '@browserless.io/browserless';
 import { EventEmitter } from 'events';
+import fs from 'fs';
 import { readFile as fsReadFile } from 'fs/promises';
 import os from 'os';
 import si from 'systeminformation';
@@ -293,6 +294,44 @@ export class CgroupV1Source implements MachineStatsSource {
       err,
     );
   }
+}
+
+type FileExists = (path: string) => boolean;
+
+const defaultFileExists: FileExists = (path) => {
+  try {
+    fs.accessSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const CGROUP_V2_PROBE = '/sys/fs/cgroup/cgroup.controllers';
+const CGROUP_V1_PROBE = '/sys/fs/cgroup/cpu/cpuacct.usage';
+
+export function detectMachineStatsSource(
+  preference: 'auto' | 'host' | 'cgroup',
+  fileExists: FileExists = defaultFileExists,
+): MachineStatsSource {
+  if (preference === 'host') return new HostSource();
+
+  const hasV2 = fileExists(CGROUP_V2_PROBE);
+  const hasV1 = !hasV2 && fileExists(CGROUP_V1_PROBE);
+
+  if (preference === 'cgroup') {
+    if (hasV2) return new CgroupV2Source();
+    if (hasV1) return new CgroupV1Source();
+    throw new Error(
+      'MACHINE_STATS_SOURCE=cgroup but no cgroup files found at ' +
+        `${CGROUP_V2_PROBE} or ${CGROUP_V1_PROBE}.`,
+    );
+  }
+
+  // 'auto'
+  if (hasV2) return new CgroupV2Source();
+  if (hasV1) return new CgroupV1Source();
+  return new HostSource();
 }
 
 export class Monitoring extends EventEmitter {

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -81,9 +81,16 @@ export class Monitoring extends EventEmitter {
     return { cpuInt, cpuOverloaded, memoryInt, memoryOverloaded };
   }
 
+  /**
+   * Implement any browserless-core-specific shutdown logic here.
+   * Calls the empty-SDK stop method for downstream implementations.
+   */
   public async shutdown() {
     return await this.stop();
   }
 
+  /**
+   * Left blank for downstream SDK modules to optionally implement.
+   */
   public stop() {}
 }

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -1,6 +1,7 @@
 import { Config, IResourceLoad, Logger } from '@browserless.io/browserless';
 import { EventEmitter } from 'events';
 import { readFile as fsReadFile } from 'fs/promises';
+import os from 'os';
 import si from 'systeminformation';
 
 const READ_TIMEOUT_MS = 200;
@@ -17,6 +18,40 @@ export async function readWithTimeout(
 ): Promise<string> {
   const signal = AbortSignal.timeout(timeoutMs);
   return readFile(path, signal);
+}
+
+export function parseCpuMax(content: string): number | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/\s+/);
+  if (parts.length !== 2) return null;
+  const [quotaRaw, periodRaw] = parts;
+  const period = Number(periodRaw);
+  if (!Number.isFinite(period) || period <= 0) return null;
+  if (quotaRaw === 'max') return os.cpus().length;
+  const quota = Number(quotaRaw);
+  if (!Number.isFinite(quota) || quota <= 0) return null;
+  return quota / period;
+}
+
+export function parseCpuStatUsageUsec(content: string): number | null {
+  for (const line of content.split('\n')) {
+    const [key, value] = line.trim().split(/\s+/);
+    if (key === 'usage_usec') {
+      const n = Number(value);
+      return Number.isFinite(n) ? n : null;
+    }
+  }
+  return null;
+}
+
+export function parseMemoryMax(content: string): number | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  if (trimmed === 'max') return os.totalmem();
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
 }
 
 export interface MachineStatsSource {

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -296,13 +296,23 @@ export class CgroupV1Source implements MachineStatsSource {
   }
 }
 
-type FileExists = (path: string) => boolean;
+export type FileExists = (path: string) => boolean;
+
+let detectionLog: Logger | undefined;
 
 const defaultFileExists: FileExists = (path) => {
   try {
     fs.accessSync(path);
     return true;
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT' && code !== 'EACCES' && code !== 'ENOTDIR') {
+      detectionLog ??= new Logger('hardware');
+      detectionLog.warn(
+        `Unexpected error probing ${path}; treating as missing:`,
+        err,
+      );
+    }
     return false;
   }
 };

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -174,6 +174,125 @@ export class CgroupV2Source implements MachineStatsSource {
   }
 }
 
+export function parseCpuV1Quota(
+  quotaContent: string,
+  periodContent: string,
+): number | null {
+  const period = Number(periodContent.trim());
+  if (!Number.isFinite(period) || period <= 0) return null;
+  const quota = Number(quotaContent.trim());
+  if (!Number.isFinite(quota)) return null;
+  if (quota <= 0) return os.cpus().length; // -1 means unbounded
+  return quota / period;
+}
+
+export function parseMemoryV1Limit(content: string): number | null {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  // Kernel sentinel for "unlimited" is a huge number (e.g. 9223372036854771712).
+  // Anything > 16 * host RAM is treated as unbounded.
+  if (n > os.totalmem() * 16) return os.totalmem();
+  return n;
+}
+
+export class CgroupV1Source implements MachineStatsSource {
+  public readonly name = 'cgroup-v1';
+  protected log = new Logger('hardware');
+  protected lastSample: Sample | null = null;
+  protected loggedFailure: Set<string> = new Set();
+
+  protected readFile: ReadFileFn;
+  protected now: () => number;
+
+  constructor(opts: CgroupSourceOpts = {}) {
+    this.readFile = opts.readFile ?? defaultReadFile;
+    this.now = opts.now ?? Date.now;
+  }
+
+  public async read(): Promise<IResourceLoad> {
+    const [cpu, memory] = await Promise.all([
+      this.readCpu(),
+      this.readMemory(),
+    ]);
+    return { cpu, memory };
+  }
+
+  protected async readCpu(): Promise<number | null> {
+    let usageNsContent: string;
+    let quotaContent: string;
+    let periodContent: string;
+    try {
+      [usageNsContent, quotaContent, periodContent] = await Promise.all([
+        readWithTimeout('/sys/fs/cgroup/cpu/cpuacct.usage', this.readFile),
+        readWithTimeout('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', this.readFile),
+        readWithTimeout('/sys/fs/cgroup/cpu/cpu.cfs_period_us', this.readFile),
+      ]);
+    } catch (err) {
+      this.logOnce('cpu-read', err);
+      return null;
+    }
+
+    const usageNs = Number(usageNsContent.trim());
+    const cores = parseCpuV1Quota(quotaContent, periodContent);
+    if (!Number.isFinite(usageNs) || cores === null || cores <= 0) {
+      this.logOnce('cpu-parse', new Error('cgroup v1 cpu parse failed'));
+      return null;
+    }
+
+    const usageUsec = usageNs / 1000;
+    const timestamp = this.now();
+    const previous = this.lastSample;
+    this.lastSample = { usageUsec, timestamp };
+    if (!previous) return null;
+
+    const dWallMs = timestamp - previous.timestamp;
+    if (dWallMs <= 0) return null;
+    const dUsageUsec = usageUsec - previous.usageUsec;
+    if (dUsageUsec < 0) return null;
+
+    return dUsageUsec / (dWallMs * cores * 1000);
+  }
+
+  protected async readMemory(): Promise<number | null> {
+    let usageContent: string;
+    let limitContent: string;
+    try {
+      [usageContent, limitContent] = await Promise.all([
+        readWithTimeout(
+          '/sys/fs/cgroup/memory/memory.usage_in_bytes',
+          this.readFile,
+        ),
+        readWithTimeout(
+          '/sys/fs/cgroup/memory/memory.limit_in_bytes',
+          this.readFile,
+        ),
+      ]);
+    } catch (err) {
+      this.logOnce('memory-read', err);
+      return null;
+    }
+
+    const usage = Number(usageContent.trim());
+    const limit = parseMemoryV1Limit(limitContent);
+    if (!Number.isFinite(usage) || limit === null || limit <= 0) {
+      this.logOnce('memory-parse', new Error('cgroup v1 memory parse failed'));
+      return null;
+    }
+    return usage / limit;
+  }
+
+  protected logOnce(category: string, err: unknown) {
+    if (this.loggedFailure.has(category)) return;
+    this.loggedFailure.add(category);
+    this.log.warn(
+      `cgroup v1 ${category} failure (further occurrences silenced):`,
+      err,
+    );
+  }
+}
+
 export class Monitoring extends EventEmitter {
   protected log = new Logger('hardware');
   protected statsSource: MachineStatsSource;

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -79,6 +79,101 @@ export class HostSource implements MachineStatsSource {
   }
 }
 
+type Sample = { usageUsec: number; timestamp: number };
+
+interface CgroupSourceOpts {
+  now?: () => number;
+  readFile?: ReadFileFn;
+}
+
+export class CgroupV2Source implements MachineStatsSource {
+  public readonly name = 'cgroup-v2';
+  protected log = new Logger('hardware');
+  protected lastSample: Sample | null = null;
+  protected loggedFailure: Set<string> = new Set();
+
+  protected now: () => number;
+  protected readFile: ReadFileFn;
+
+  constructor(opts: CgroupSourceOpts = {}) {
+    this.now = opts.now ?? Date.now;
+    this.readFile = opts.readFile ?? defaultReadFile;
+  }
+
+  public async read(): Promise<IResourceLoad> {
+    const [cpu, memory] = await Promise.all([
+      this.readCpu(),
+      this.readMemory(),
+    ]);
+    return { cpu, memory };
+  }
+
+  protected async readCpu(): Promise<number | null> {
+    let usageContent: string;
+    let maxContent: string;
+    try {
+      [usageContent, maxContent] = await Promise.all([
+        readWithTimeout('/sys/fs/cgroup/cpu.stat', this.readFile),
+        readWithTimeout('/sys/fs/cgroup/cpu.max', this.readFile),
+      ]);
+    } catch (err) {
+      this.logOnce('cpu-read', err);
+      return null;
+    }
+
+    const usageUsec = parseCpuStatUsageUsec(usageContent);
+    const cores = parseCpuMax(maxContent);
+    if (usageUsec === null || cores === null || cores <= 0) {
+      this.logOnce('cpu-parse', new Error('cgroup v2 cpu parse failed'));
+      return null;
+    }
+
+    const timestamp = this.now();
+    const previous = this.lastSample;
+    this.lastSample = { timestamp, usageUsec };
+
+    if (!previous) return null;
+
+    const dWallMs = timestamp - previous.timestamp;
+    if (dWallMs <= 0) return null;
+    const dUsageUsec = usageUsec - previous.usageUsec;
+    if (dUsageUsec < 0) return null;
+
+    return dUsageUsec / (dWallMs * cores * 1000);
+  }
+
+  protected async readMemory(): Promise<number | null> {
+    let currentContent: string;
+    let maxContent: string;
+    try {
+      [currentContent, maxContent] = await Promise.all([
+        readWithTimeout('/sys/fs/cgroup/memory.current', this.readFile),
+        readWithTimeout('/sys/fs/cgroup/memory.max', this.readFile),
+      ]);
+    } catch (err) {
+      this.logOnce('memory-read', err);
+      return null;
+    }
+
+    const current = Number(currentContent.trim());
+    const max = parseMemoryMax(maxContent);
+    if (!Number.isFinite(current) || max === null || max <= 0) {
+      this.logOnce('memory-parse', new Error('cgroup v2 memory parse failed'));
+      return null;
+    }
+    return current / max;
+  }
+
+  protected logOnce(category: string, err: unknown) {
+    if (this.loggedFailure.has(category)) return;
+    this.loggedFailure.add(category);
+    this.log.warn(
+      `cgroup v2 ${category} failure (further occurrences silenced):`,
+      err,
+    );
+  }
+}
+
 export class Monitoring extends EventEmitter {
   protected log = new Logger('hardware');
   protected statsSource: MachineStatsSource;


### PR DESCRIPTION
## Summary

- Make `MAX_CPU_PERCENT` / `MAX_MEMORY_PERCENT` measure cgroup-scoped CPU and memory inside Docker so the limiter health-check trips (and 429 / 503 responses follow) when a container hits its cgroup quota while the host still looks idle.
- Add a `MachineStatsSource` abstraction with three implementations: `CgroupV2Source` (reads `/sys/fs/cgroup/cpu.{stat,max}` and `memory.{current,max}`), `CgroupV1Source` (reads `/sys/fs/cgroup/cpu/cpuacct.usage` + `cfs_quota_us` + `cfs_period_us` and `/sys/fs/cgroup/memory/memory.{usage,limit}_in_bytes`), and `HostSource` (wraps the existing `systeminformation` calls — preserves today's behavior outside Docker).
- New `MACHINE_STATS_SOURCE` env var (`auto` (default) | `host` | `cgroup`). `cgroup` mode throws at startup if no cgroup files are found — useful as a strict-mode safety net.
- Detection runs once at `Monitoring` construction and the chosen source is logged at startup (`Machine stats source: cgroup-v2` etc.).
- Read safety: each cgroup read is wrapped in `AbortSignal.timeout(200)`. Failures are decoupled per-axis (CPU vs memory) and per-category (`cpu-read`, `cpu-parse`, `memory-read`, `memory-parse`) and de-duplicated so an unhealthy reader logs once per category and falls open (returns `null`) — never mass-rejects traffic.

## Background

`Monitoring.overloaded()` previously called `systeminformation`, which reads host `/proc/stat` and `/proc/meminfo`. Inside a Docker container without cgroup namespace remapping, those are host metrics — so a container hitting its cgroup quota looked idle to the limiter, `cpuOverloaded`/`memoryOverloaded` never tripped, and 429s never fired. New traffic kept piling onto saturated containers.

## Test plan

- [x] Unit tests: 41 in `src/monitoring.spec.ts` (HostSource, readWithTimeout, both cgroup parser families, both source classes including log-once + symmetric failure decoupling, detection cascade across all preference × probe combinations).
- [x] Limiter regression test in `src/limiter.spec.ts`: with a fake source reporting CPU 95% and `MAX_CPU_PERCENT=10`, the limiter rejects via `overCapacityFn`, the handler is never invoked, the rejection message matches the health-check branch, and `metrics.rejected` increments.
- [x] Full suite: 508 passing, 3 pending, 0 failing.
- [x] Lint clean.
- [x] Manual integration matrix on Ubuntu 22.04 / 24.04 / 26.04 containers (host: Ubuntu 24.04, kernel 6.8, cgroup v2):
  - `--cpus=1 --memory=1g`, `--cpus=0.5 --memory=512m`, `--cpus=4 --memory=4g`, no limits — startup log shows `cgroup-v2`; reported percentages reflect the cgroup quota, not the host.
  - `MACHINE_STATS_SOURCE=host` override forces `host (systeminformation)` even inside a cgroup container.
  - `MACHINE_STATS_SOURCE=cgroup` strict mode picks the cgroup source; throws on macOS (no cgroup files) with the documented message.
  - Invalid value → throws with the validation error from `Config.getMachineStatsSource()`.
  - **Trip test**: `--cpus=1 + MAX_CPU_PERCENT=10` + CPU burn → `cpuOverloaded: true`. `--memory=512m + MAX_MEMORY_PERCENT=5` → `memoryOverloaded: true`.
- [x] Cgroup v1: synthesized v1 file tree bind-mounted at `/sys/fs/cgroup` inside a container (kernel-independent v1 simulation). Detection picks `cgroup-v1`; memory math exact (0.5 for 268M / 536M); CPU math correct (Δns → us → fraction); unbounded quota (`-1`) falls back to `os.cpus().length`; malformed quota content triggers the `cpu-parse` log-once path.

## Backward compatibility

- Default `MAX_CPU_PERCENT=99` / `MAX_MEMORY_PERCENT=99` means deployments below saturation are unaffected.
- `IResourceLoad` shape, `Monitoring.getMachineStats()`, `Monitoring.overloaded()`, and the `/pressure` JSON shape are unchanged.
- `new Monitoring(config)` continues to work — the new `statsSource` and `logFn` constructor parameters are optional.
- macOS, Windows, and non-cgroup Linux: identical behavior to today (`HostSource` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config option to select machine stats source (auto/host/cgroup) with explicit preference and detection; monitoring uses pluggable sources and logs the chosen provider.
  * Added cgroup v1/v2 support and timeout-bounded reads for CPU/memory collection.
  * Config now exposes a validated machine-stats-source setting that enforces allowed values.

* **Tests**
  * Comprehensive tests for collection, parsing, detection, and timeouts across host, cgroup v1/v2.
  * Test for overload/health-check rejection in the limiter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->