### PR TITLE
chore: allow sdk routes to use profiles

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -195,4 +195,11 @@ export interface SystemQueryParameters {
    * Custom session identifier
    */
   trackingId?: string;
+
+  /**
+   * Name of an authenticated profile to hydrate into the browser at launch.
+   * The profile's cookies, localStorage and IndexedDB are injected via CDP
+   * before your code runs. No-op in builds without a profile subsystem.
+   */
+  profile?: string;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional `profile` query parameter to enable authenticated profile state initialization on launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->