### PR TITLE
chore: build/v2.48.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# [Latest](https://github.com/browserless/browserless/compare/v2.48.1...main)
+# [Latest](https://github.com/browserless/browserless/compare/v2.48.2...main)
+
+# [v2.48.2](https://github.com/browserless/browserless/compare/v2.48.1...v2.48.2)
+- Expose `profile` system query parameter so SDK routes can hydrate authenticated profiles.
+- Supports the following libraries and browsers:
+  - puppeteer-core: `24.42.0`
+  - playwright-core: `1.59.1`, `1.58.2`, `1.57.0`, `1.56.1`, and `1.55.1`.
+  - Chromium: `147.0.7727.0`
+  - Chrome: `147.0.7727.116` (amd64 only)
+  - Firefox: `148.0.2`
+  - Webkit: `26.0`
+  - Edge: `147.0.3912.86` (amd64 only)
 
 # [v2.48.1](https://github.com/browserless/browserless/compare/v2.48.0...v2.48.1)
 - Dependency updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.48.1",
+  "version": "2.48.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserless.io/browserless",
-      "version": "2.48.1",
+      "version": "2.48.2",
       "license": "SSPL",
       "dependencies": {
         "@hapi/bourne": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.48.1",
+  "version": "2.48.2",
   "license": "SSPL",
   "description": "The browserless platform",
   "author": "browserless.io",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v2.48.2

* **New Features**
  * Added `profile` system query parameter to enable authenticated profile hydration in SDK routes.

* **Chores**
  * Updated supported library and browser matrix with latest puppeteer-core and playwright-core versions and corresponding browser build versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->