### PR TITLE
fix(browsers): close orphan /tmp data-dir leaks across SDK lifecycle

### DIFF
--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -1,0 +1,377 @@
+/* eslint-disable no-unused-expressions */
+import {
+  BrowserManager,
+  Config,
+  FileSystem,
+  Hooks,
+} from '@browserless.io/browserless';
+import * as fs from 'fs/promises';
+import { expect } from 'chai';
+import { tmpdir } from 'os';
+import path from 'path';
+import Sinon from 'sinon';
+
+/**
+ * Subclass that exposes `protected` cleanup internals so individual
+ * invariants can be exercised without standing up a real Chrome
+ * process. The behaviours under test are pure FS lifecycle — no
+ * browser binary needed.
+ */
+class TestableBrowserManager extends BrowserManager {
+  public testRemoveUserDataDir(dir: string | null) {
+    return this.removeUserDataDir(dir);
+  }
+  public testSweepOrphanDataDirs() {
+    return this.sweepOrphanDataDirs();
+  }
+  public testPeriodicSweep() {
+    return this.periodicSweep();
+  }
+  public getPendingCleanup() {
+    return this.pendingCleanup;
+  }
+  public getPeriodicSweepHandle() {
+    return this.periodicSweepHandle;
+  }
+  public getInitCleanupPromise() {
+    return this.initCleanupPromise;
+  }
+  public isShuttingDown() {
+    return this.shuttingDown;
+  }
+  public registerSession(browser: object, session: object) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.browsers.set(browser as any, session as any);
+  }
+  public hasBrowser(browser: object) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return this.browsers.has(browser as any);
+  }
+  public browsersSize() {
+    return this.browsers.size;
+  }
+}
+
+const pathExists = async (p: string) =>
+  fs
+    .stat(p)
+    .then(() => true)
+    .catch(() => false);
+
+const makeManager = async () => {
+  const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+  const config = new Config();
+  await config.setDataDir(dataDir);
+  const fileSystem = Sinon.createStubInstance(FileSystem);
+  const hooks = Sinon.createStubInstance(Hooks);
+  const manager = new TestableBrowserManager(config, hooks, fileSystem);
+  // Wait for the startup sweep to finish so per-test setup doesn't race
+  // against it.
+  await manager.getInitCleanupPromise();
+  return { config, dataDir, fileSystem, hooks, manager };
+};
+
+const cleanupTestDir = async (dir: string) => {
+  await fs.rm(dir, { force: true, recursive: true }).catch(() => undefined);
+};
+
+interface MockBrowser {
+  close: Sinon.SinonStub;
+  isRunning: () => boolean;
+  keepUntil: () => number;
+  on: () => void;
+  trackingId: undefined;
+  wsEndpoint: () => null;
+}
+
+const makeMockBrowser = (
+  closeBehavior: 'reject' | 'resolve' = 'resolve',
+): MockBrowser => ({
+  close:
+    closeBehavior === 'resolve'
+      ? Sinon.stub().resolves()
+      : Sinon.stub().rejects(new Error('mock close error')),
+  isRunning: () => false,
+  keepUntil: () => 0,
+  on: () => undefined,
+  trackingId: undefined,
+  wsEndpoint: () => null,
+});
+
+const makeSession = (overrides: Record<string, unknown> = {}) => ({
+  id: 'test-session',
+  initialConnectURL: '/test',
+  isTempDataDir: true,
+  launchOptions: {},
+  numbConnected: 0,
+  resolver: () => undefined,
+  routePath: '/test',
+  startedOn: Date.now(),
+  trackingId: undefined,
+  ttl: 0,
+  userDataDir: null,
+  ...overrides,
+});
+
+describe(`BrowserManager — orphan data-dir cleanup`, () => {
+  describe(`removeUserDataDir`, () => {
+    it('removes an existing data-dir', async () => {
+      const { dataDir, manager } = await makeManager();
+      const target = path.join(dataDir, 'browserless-data-dir-r1');
+      await fs.mkdir(target);
+
+      await manager.testRemoveUserDataDir(target);
+
+      expect(await pathExists(target)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('clears pendingCleanup entry when the path no longer exists', async () => {
+      const { dataDir, manager } = await makeManager();
+      const ghost = path.join(dataDir, 'ghost-' + Date.now());
+      // Simulate a previous failed attempt that enqueued the path.
+      manager.getPendingCleanup().add(ghost);
+
+      await manager.testRemoveUserDataDir(ghost);
+
+      expect(manager.getPendingCleanup().has(ghost)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('clears pendingCleanup entry on a successful retry', async () => {
+      const { dataDir, manager } = await makeManager();
+      const target = path.join(dataDir, 'browserless-data-dir-r2');
+      await fs.mkdir(target);
+      manager.getPendingCleanup().add(target);
+
+      await manager.testRemoveUserDataDir(target);
+
+      expect(manager.getPendingCleanup().has(target)).to.be.false;
+      expect(await pathExists(target)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+  });
+
+  describe(`sweepOrphanDataDirs (startup sweep)`, () => {
+    it('removes prior-run browserless-data-dir-* leftovers on construction', async () => {
+      const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      await fs.mkdir(path.join(dataDir, 'browserless-data-dir-old1'));
+      await fs.mkdir(path.join(dataDir, 'browserless-data-dir-old2'));
+
+      const config = new Config();
+      await config.setDataDir(dataDir);
+      const manager = new TestableBrowserManager(
+        config,
+        Sinon.createStubInstance(Hooks),
+        Sinon.createStubInstance(FileSystem),
+      );
+      await manager.getInitCleanupPromise();
+
+      const remaining = await fs.readdir(dataDir);
+      expect(
+        remaining.filter((e) => e.startsWith('browserless-data-dir-')),
+      ).to.have.length(0);
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('leaves non-browserless entries in dataDir alone', async () => {
+      const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      const friend = path.join(dataDir, 'unrelated-stuff');
+      const orphan = path.join(dataDir, 'browserless-data-dir-zzz');
+      await fs.mkdir(friend);
+      await fs.mkdir(orphan);
+      // Plant a file that should also be untouched.
+      await fs.writeFile(path.join(dataDir, 'a-marker.txt'), 'hi');
+
+      const config = new Config();
+      await config.setDataDir(dataDir);
+      const manager = new TestableBrowserManager(
+        config,
+        Sinon.createStubInstance(Hooks),
+        Sinon.createStubInstance(FileSystem),
+      );
+      await manager.getInitCleanupPromise();
+
+      expect(await pathExists(friend)).to.be.true;
+      expect(await pathExists(path.join(dataDir, 'a-marker.txt'))).to.be.true;
+      expect(await pathExists(orphan)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+  });
+
+  describe(`close()`, () => {
+    it('evicts the session from the registry even when browser.close() rejects', async () => {
+      const { dataDir, manager } = await makeManager();
+      const browser = makeMockBrowser('reject');
+      const session = makeSession({
+        isTempDataDir: false,
+        userDataDir: '/some/external/path-not-managed-by-us',
+      });
+      manager.registerSession(browser, session);
+      expect(manager.hasBrowser(browser)).to.be.true;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await manager.close(browser as any, session as any, true);
+
+      expect(manager.hasBrowser(browser)).to.be.false;
+      expect(browser.close.calledOnce).to.be.true;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('removes a temp data-dir even when browser.close() rejects', async () => {
+      const { dataDir, manager } = await makeManager();
+      const browser = makeMockBrowser('reject');
+      const target = path.join(dataDir, 'browserless-data-dir-c1');
+      await fs.mkdir(target);
+      const session = makeSession({ isTempDataDir: true, userDataDir: target });
+      manager.registerSession(browser, session);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await manager.close(browser as any, session as any, true);
+
+      expect(await pathExists(target)).to.be.false;
+      expect(manager.hasBrowser(browser)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('does NOT remove the data-dir when isTempDataDir is false', async () => {
+      const { dataDir, manager } = await makeManager();
+      const browser = makeMockBrowser('resolve');
+      const external = path.join(dataDir, 'externally-owned');
+      await fs.mkdir(external);
+      const session = makeSession({
+        isTempDataDir: false,
+        userDataDir: external,
+      });
+      manager.registerSession(browser, session);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await manager.close(browser as any, session as any, true);
+
+      expect(await pathExists(external)).to.be.true;
+      expect(manager.hasBrowser(browser)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+  });
+
+  describe(`shutdown()`, () => {
+    it('continues cleanup when one b.close() rejects (Promise.allSettled)', async () => {
+      const { dataDir, manager } = await makeManager();
+      const okBrowser = makeMockBrowser('resolve');
+      const badBrowser = makeMockBrowser('reject');
+      const okDir = path.join(dataDir, 'browserless-data-dir-ok');
+      const badDir = path.join(dataDir, 'browserless-data-dir-bad');
+      await fs.mkdir(okDir);
+      await fs.mkdir(badDir);
+      manager.registerSession(
+        okBrowser,
+        makeSession({ id: 'ok', isTempDataDir: true, userDataDir: okDir }),
+      );
+      manager.registerSession(
+        badBrowser,
+        makeSession({ id: 'bad', isTempDataDir: true, userDataDir: badDir }),
+      );
+
+      await manager.shutdown();
+
+      expect(okBrowser.close.calledOnce).to.be.true;
+      expect(badBrowser.close.calledOnce).to.be.true;
+      expect(await pathExists(okDir)).to.be.false;
+      expect(await pathExists(badDir)).to.be.false;
+      await cleanupTestDir(dataDir);
+    });
+
+    it('sets shuttingDown to true and clears periodicSweepHandle', async () => {
+      const { dataDir, manager } = await makeManager();
+      expect(manager.isShuttingDown()).to.be.false;
+      expect(manager.getPeriodicSweepHandle()).to.not.be.null;
+
+      await manager.shutdown();
+
+      expect(manager.isShuttingDown()).to.be.true;
+      expect(manager.getPeriodicSweepHandle()).to.be.null;
+      await cleanupTestDir(dataDir);
+    });
+
+    it('does not arm periodicSweepHandle when shutdown is called during init', async () => {
+      const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      // A backlog of orphans makes the startup sweep slow enough for the
+      // race to be observable: shutdown() runs while initCleanup() is
+      // mid-walk.
+      for (let i = 0; i < 50; i++) {
+        await fs.mkdir(path.join(dataDir, `browserless-data-dir-init-${i}`));
+      }
+
+      const config = new Config();
+      await config.setDataDir(dataDir);
+      const manager = new TestableBrowserManager(
+        config,
+        Sinon.createStubInstance(Hooks),
+        Sinon.createStubInstance(FileSystem),
+      );
+      // Shut down without first awaiting initCleanupPromise. shutdown's
+      // own await on the promise is what we're testing.
+      await manager.shutdown();
+
+      expect(manager.getPeriodicSweepHandle()).to.be.null;
+      await cleanupTestDir(dataDir);
+    });
+  });
+
+  describe(`periodicSweep`, () => {
+    it('drains pendingCleanup and removes paths that have reappeared as deletable', async () => {
+      const { dataDir, manager } = await makeManager();
+      const target = path.join(dataDir, 'browserless-data-dir-ps');
+      await fs.mkdir(target);
+      manager.getPendingCleanup().add(target);
+
+      await manager.testPeriodicSweep();
+
+      expect(await pathExists(target)).to.be.false;
+      expect(manager.getPendingCleanup().has(target)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('drops pendingCleanup entries whose paths have vanished externally', async () => {
+      const { dataDir, manager } = await makeManager();
+      const ghost = path.join(dataDir, 'browserless-data-dir-ghost');
+      // Never create the dir; it's "vanished" from the start.
+      manager.getPendingCleanup().add(ghost);
+
+      await manager.testPeriodicSweep();
+
+      expect(manager.getPendingCleanup().has(ghost)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('skips host-wide chromium-internal sweep by default (CLEANUP_HOST_CHROMIUM_TEMP_DIRS unset)', async () => {
+      // The env-var read is at module-load time, and the test process
+      // does not set it — so this test exercises the default-safe path.
+      const { dataDir, manager } = await makeManager();
+      const cdir = await fs.mkdtemp(
+        path.join(tmpdir(), 'org.chromium.Chromium.test-'),
+      );
+      // Make it look long-stale so it would be a deletion candidate.
+      const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+      await fs.utimes(cdir, oldTime, oldTime);
+
+      await manager.testPeriodicSweep();
+
+      // With Pass 2 gated off, the host-wide chromium dir must survive.
+      expect(await pathExists(cdir)).to.be.true;
+      await fs.rm(cdir, { force: true, recursive: true });
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+  });
+});

--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -39,6 +39,9 @@ class TestableBrowserManager extends BrowserManager {
   public isShuttingDown() {
     return this.shuttingDown;
   }
+  public getInstanceId() {
+    return this.instanceId;
+  }
   public registerSession(browser: object, session: object) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.browsers.set(browser as any, session as any);
@@ -156,49 +159,90 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
   });
 
   describe(`sweepOrphanDataDirs (startup sweep)`, () => {
-    it('removes prior-run browserless-data-dir-* leftovers on construction', async () => {
-      const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
-      await fs.mkdir(path.join(dataDir, 'browserless-data-dir-old1'));
-      await fs.mkdir(path.join(dataDir, 'browserless-data-dir-old2'));
-
-      const config = new Config();
-      await config.setDataDir(dataDir);
-      const manager = new TestableBrowserManager(
-        config,
-        Sinon.createStubInstance(Hooks),
-        Sinon.createStubInstance(FileSystem),
+    it('removes orphan data-dirs scoped to this instance', async () => {
+      const { dataDir, manager } = await makeManager();
+      const instanceId = manager.getInstanceId();
+      // Simulate prior-run leftovers owned by THIS instance (matching
+      // prefix). After construction the startup sweep already ran on
+      // an empty dir; plant the orphans now and run the sweep again
+      // directly.
+      const orphan1 = path.join(
+        dataDir,
+        `browserless-data-dir-${instanceId}-old1`,
       );
-      await manager.getInitCleanupPromise();
+      const orphan2 = path.join(
+        dataDir,
+        `browserless-data-dir-${instanceId}-old2`,
+      );
+      await fs.mkdir(orphan1);
+      await fs.mkdir(orphan2);
 
-      const remaining = await fs.readdir(dataDir);
-      expect(
-        remaining.filter((e) => e.startsWith('browserless-data-dir-')),
-      ).to.have.length(0);
+      await manager.testSweepOrphanDataDirs();
+
+      expect(await pathExists(orphan1)).to.be.false;
+      expect(await pathExists(orphan2)).to.be.false;
       await manager.shutdown();
       await cleanupTestDir(dataDir);
     });
 
-    it('leaves non-browserless entries in dataDir alone', async () => {
+    it('leaves data-dirs owned by other BrowserManager instances untouched', async () => {
+      // Two managers sharing the same `config.getDataDir()`. Manager A's
+      // startup sweep must not touch dirs owned by manager B (different
+      // instanceId prefix), even though both use the same name family.
       const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
-      const friend = path.join(dataDir, 'unrelated-stuff');
-      const orphan = path.join(dataDir, 'browserless-data-dir-zzz');
-      await fs.mkdir(friend);
-      await fs.mkdir(orphan);
-      // Plant a file that should also be untouched.
-      await fs.writeFile(path.join(dataDir, 'a-marker.txt'), 'hi');
 
-      const config = new Config();
-      await config.setDataDir(dataDir);
-      const manager = new TestableBrowserManager(
-        config,
+      const configA = new Config();
+      await configA.setDataDir(dataDir);
+      const managerA = new TestableBrowserManager(
+        configA,
         Sinon.createStubInstance(Hooks),
         Sinon.createStubInstance(FileSystem),
       );
-      await manager.getInitCleanupPromise();
+      await managerA.getInitCleanupPromise();
+
+      const configB = new Config();
+      await configB.setDataDir(dataDir);
+      const managerB = new TestableBrowserManager(
+        configB,
+        Sinon.createStubInstance(Hooks),
+        Sinon.createStubInstance(FileSystem),
+      );
+      await managerB.getInitCleanupPromise();
+
+      // Plant a "live" data-dir owned by manager B.
+      const bDir = path.join(
+        dataDir,
+        `browserless-data-dir-${managerB.getInstanceId()}-live`,
+      );
+      await fs.mkdir(bDir);
+
+      // Manager A re-runs its startup sweep (e.g. simulating a restart).
+      await managerA.testSweepOrphanDataDirs();
+
+      expect(await pathExists(bDir)).to.be.true;
+      await managerA.shutdown();
+      await managerB.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('leaves non-browserless entries in dataDir alone', async () => {
+      const { dataDir, manager } = await makeManager();
+      const instanceId = manager.getInstanceId();
+      const friend = path.join(dataDir, 'unrelated-stuff');
+      const ownOrphan = path.join(
+        dataDir,
+        `browserless-data-dir-${instanceId}-zzz`,
+      );
+      await fs.mkdir(friend);
+      await fs.mkdir(ownOrphan);
+      // Plant a file that should also be untouched.
+      await fs.writeFile(path.join(dataDir, 'a-marker.txt'), 'hi');
+
+      await manager.testSweepOrphanDataDirs();
 
       expect(await pathExists(friend)).to.be.true;
       expect(await pathExists(path.join(dataDir, 'a-marker.txt'))).to.be.true;
-      expect(await pathExists(orphan)).to.be.false;
+      expect(await pathExists(ownOrphan)).to.be.false;
       await manager.shutdown();
       await cleanupTestDir(dataDir);
     });

--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -377,6 +377,54 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       expect(manager.hasBrowser(browser)).to.be.false;
     });
 
+    it('evicts the session from the registry SYNCHRONOUSLY, before browser.close() yields', async () => {
+      // killSessions() and complete() invoke `this.close(...)` without
+      // `await`. The caller (e.g. an HTTP handler responding 204 to
+      // /kill/all) returns as soon as close() yields. If the eviction
+      // from `this.browsers` ran AFTER the first `await browser.close()`,
+      // the next request — say `GET /sessions` or `/chromium?trackingId=X`
+      // for a just-killed X — would still see the dead session for the
+      // duration of browser shutdown (potentially hundreds of ms). The
+      // eviction therefore has to happen in the synchronous prefix of
+      // close(), before any await.
+      const { manager } = await makeManager();
+
+      // browser.close() blocks on a gate that we never resolve until the
+      // assertion is done — so close() is provably still in flight when
+      // we check the map, and any deferred eviction would miss.
+      let resolveClose!: () => void;
+      const closeGate = new Promise<void>((r) => {
+        resolveClose = r;
+      });
+      const browser = {
+        close: Sinon.stub().callsFake(() => closeGate),
+        isRunning: () => false,
+        keepUntil: () => 0,
+        on: () => undefined,
+        trackingId: undefined,
+        wsEndpoint: () => null,
+      };
+      const session = makeSession({
+        isTempDataDir: false,
+        userDataDir: '/some/external/path-not-managed-by-us',
+      });
+      manager.registerSession(browser, session);
+      expect(manager.hasBrowser(browser)).to.be.true;
+
+      // Fire-and-forget call — the close promise is still pending.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const closePromise = manager.close(browser as any, session as any, true);
+
+      // Synchronous check: the map should already be updated, even though
+      // browser.close() is still blocked on `closeGate`.
+      expect(manager.hasBrowser(browser)).to.be.false;
+      expect(browser.close.calledOnce).to.be.true;
+
+      // Release the gate so close() finishes and afterEach doesn't hang.
+      resolveClose();
+      await closePromise;
+    });
+
     it('does NOT remove the data-dir when isTempDataDir is false', async () => {
       const { dataDir, manager } = await makeManager();
       const browser = makeMockBrowser('resolve');

--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -4,6 +4,8 @@ import {
   Config,
   FileSystem,
   Hooks,
+  Logger,
+  ServerError,
 } from '@browserless.io/browserless';
 import * as fs from 'fs/promises';
 import { expect } from 'chai';
@@ -52,6 +54,9 @@ class TestableBrowserManager extends BrowserManager {
   }
   public browsersSize() {
     return this.browsers.size;
+  }
+  public setShuttingDown(value: boolean) {
+    this.shuttingDown = value;
   }
 }
 
@@ -540,6 +545,137 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
           process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS = prev;
         }
       }
+    });
+  });
+
+  describe(`getBrowserForRequest — launch-vs-shutdown race`, () => {
+    // The post-launch shutdown re-check (index.ts in
+    // `getBrowserForRequest`, after `await browser.launch(...)`) closes
+    // the narrow window where a request passes the early
+    // `shuttingDown` gate, allocates a data-dir, launches a browser,
+    // and only THEN sees `shuttingDown` flip to true. Without the
+    // re-check + teardown, that browser would be missing from the
+    // shutdown's `this.browsers` snapshot and leak its Chrome process
+    // and data-dir.
+    //
+    // The race is hard to reproduce with a real browser launch
+    // (timing depends on Chrome startup), so this drives the path
+    // synthetically: a mock Browser whose `launch()` blocks on an
+    // externally-resolvable gate. The test holds launch in flight,
+    // flips `shuttingDown`, releases launch, and asserts the cleanup
+    // path ran (close called, data-dir removed, ServerError thrown
+    // matching the early gate).
+    it('cleans up the in-flight browser + data-dir when shutdown is set after launch starts', async () => {
+      const { config, manager, dataDir } = await makeManager();
+
+      let resolveLaunchStarted: () => void;
+      const launchStarted = new Promise<void>((r) => {
+        resolveLaunchStarted = r;
+      });
+      let resolveLaunch: () => void;
+      const launchGate = new Promise<void>((r) => {
+        resolveLaunch = r;
+      });
+
+      let createdDataDir: string | null = null;
+      let closeCalled = 0;
+
+      class MockBrowser {
+        constructor(opts: { userDataDir: string | null }) {
+          createdDataDir = opts.userDataDir;
+        }
+        async launch() {
+          resolveLaunchStarted();
+          await launchGate;
+        }
+        async close() {
+          closeCalled++;
+        }
+        on() {}
+        keepUntil() {
+          return 0;
+        }
+        isRunning() {
+          return false;
+        }
+        wsEndpoint() {
+          // Never read on the shutdown-race path (the throw fires
+          // before getFinalPathSegment is called).
+          return null;
+        }
+      }
+
+      const router = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        browser: MockBrowser as any,
+        defaultLaunchOptions: {},
+        path: '/test',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const req = {
+        parsed: {
+          searchParams: new URLSearchParams(),
+          pathname: '/test',
+          search: '',
+        },
+        headers: { 'user-agent': '' },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const requestLogger = new Logger('test');
+
+      // Kick off the request; it will allocate a data-dir, construct
+      // MockBrowser, and await launch().
+      const requestPromise = manager.getBrowserForRequest(
+        req,
+        router,
+        requestLogger,
+      );
+
+      // Wait until launch is actually in flight.
+      await launchStarted;
+
+      expect(createdDataDir).to.be.a('string');
+      expect(await pathExists(createdDataDir!)).to.be.true;
+
+      // Flip shuttingDown WHILE launch is still pending. The post-
+      // launch check will observe `true` after launch resolves below.
+      manager.setShuttingDown(true);
+
+      // Release launch so the request resumes into the post-launch
+      // shutdown re-check.
+      resolveLaunch!();
+
+      let caught: Error | null = null;
+      try {
+        await requestPromise;
+      } catch (err) {
+        caught = err as Error;
+      }
+
+      expect(caught, 'request must reject').to.not.be.null;
+      expect(caught).to.be.instanceOf(ServerError);
+      expect(caught!.message).to.match(/shutting down/i);
+
+      // The teardown path must have closed the in-flight browser AND
+      // removed the data-dir we allocated.
+      expect(closeCalled).to.equal(1);
+      expect(await pathExists(createdDataDir!)).to.be.false;
+
+      // The session must NOT have been registered (the race-loss path
+      // throws before the `this.browsers.set(...)` line). Without
+      // this guarantee, the leaked-via-snapshot bug the post-launch
+      // check is meant to prevent would still be present even with
+      // the dir cleanup.
+      expect(manager.browsersSize()).to.equal(0);
+
+      // Also confirm createdDataDir was inside our managed dataDir
+      // (not some unrelated path) — guards against a regression where
+      // the userDataDir variable in the production code is no longer
+      // the one passed to MockBrowser.
+      expect(createdDataDir!.startsWith(await config.getDataDir())).to.be.true;
+      expect(createdDataDir!.startsWith(dataDir)).to.be.true;
     });
   });
 });

--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -61,6 +61,40 @@ const pathExists = async (p: string) =>
     .then(() => true)
     .catch(() => false);
 
+const cleanupTestDir = async (dir: string) => {
+  await fs.rm(dir, { force: true, recursive: true }).catch(() => undefined);
+};
+
+/**
+ * Per-test cleanup tracker. Every manager constructed inside a spec is
+ * registered here so `afterEach` shuts it down (clearing the periodic-
+ * sweep interval) and removes its data-dir, even when an assertion
+ * throws mid-test. Without this, a failed assertion would leak the
+ * interval (keeping mocha from exiting cleanly) and the temp dir
+ * (cluttering /tmp across runs).
+ */
+const tracked: Array<{ manager: TestableBrowserManager; dataDir: string }> =
+  [];
+const trackedPaths: string[] = [];
+const track = (manager: TestableBrowserManager, dataDir: string) => {
+  tracked.push({ manager, dataDir });
+};
+const trackPath = (p: string) => {
+  trackedPaths.push(p);
+};
+const drainTracked = async () => {
+  while (tracked.length) {
+    const { manager, dataDir } = tracked.pop()!;
+    // shutdown() is idempotent (gated by `shuttingDown`), so re-running
+    // on a manager whose test already shut it down is harmless.
+    await manager.shutdown().catch(() => undefined);
+    await cleanupTestDir(dataDir);
+  }
+  while (trackedPaths.length) {
+    await cleanupTestDir(trackedPaths.pop()!);
+  }
+};
+
 const makeManager = async () => {
   const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
   const config = new Config();
@@ -68,14 +102,11 @@ const makeManager = async () => {
   const fileSystem = Sinon.createStubInstance(FileSystem);
   const hooks = Sinon.createStubInstance(Hooks);
   const manager = new TestableBrowserManager(config, hooks, fileSystem);
+  track(manager, dataDir);
   // Wait for the startup sweep to finish so per-test setup doesn't race
   // against it.
   await manager.getInitCleanupPromise();
   return { config, dataDir, fileSystem, hooks, manager };
-};
-
-const cleanupTestDir = async (dir: string) => {
-  await fs.rm(dir, { force: true, recursive: true }).catch(() => undefined);
 };
 
 interface MockBrowser {
@@ -117,6 +148,13 @@ const makeSession = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe(`BrowserManager — orphan data-dir cleanup`, () => {
+  // Always-runs cleanup. Tests register managers via `track()` (or
+  // implicitly via `makeManager()`); this hook shuts them down and
+  // removes their temp dirs even if an assertion threw.
+  afterEach(async () => {
+    await drainTracked();
+  });
+
   describe(`removeUserDataDir`, () => {
     it('removes an existing data-dir', async () => {
       const { dataDir, manager } = await makeManager();
@@ -126,8 +164,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await manager.testRemoveUserDataDir(target);
 
       expect(await pathExists(target)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('clears pendingCleanup entry when the path no longer exists', async () => {
@@ -139,8 +175,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await manager.testRemoveUserDataDir(ghost);
 
       expect(manager.getPendingCleanup().has(ghost)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('clears pendingCleanup entry on a successful retry', async () => {
@@ -153,8 +187,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(manager.getPendingCleanup().has(target)).to.be.false;
       expect(await pathExists(target)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
   });
 
@@ -188,8 +220,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(await pathExists(orphan1)).to.be.false;
       expect(await pathExists(orphan2)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('removes stale orphan dirs whose name embeds a different instanceId (cross-restart cleanup)', async () => {
@@ -209,8 +239,37 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await manager.testSweepOrphanDataDirs();
 
       expect(await pathExists(orphan)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
+    });
+
+    it('runs via the constructor-triggered initCleanup path', async () => {
+      // Verifies the wiring from `constructor` → `initCleanup` →
+      // `sweepOrphanDataDirs`, not just the direct method invocation
+      // exercised by the other tests in this describe. Plant orphans
+      // BEFORE constructing the manager; the constructor kicks off
+      // initCleanup asynchronously, and we wait on the promise it
+      // exposes to know the sweep has finished.
+      const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      trackPath(dataDir);
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const orphan = path.join(dataDir, 'browserless-data-dir-prior-run');
+      await fs.mkdir(orphan);
+      await fs.utimes(orphan, oneHourAgo, oneHourAgo);
+
+      const config = new Config();
+      await config.setDataDir(dataDir);
+      const manager = new TestableBrowserManager(
+        config,
+        Sinon.createStubInstance(Hooks),
+        Sinon.createStubInstance(FileSystem),
+      );
+      track(manager, dataDir);
+
+      // Do NOT pre-await via makeManager. The constructor already
+      // kicked off initCleanup; awaiting the promise it exposes is the
+      // only thing we should need.
+      await manager.getInitCleanupPromise();
+
+      expect(await pathExists(orphan)).to.be.false;
     });
 
     it('leaves fresh data-dirs untouched (treated as live, regardless of instanceId)', async () => {
@@ -220,6 +279,7 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       // sharing one `config.getDataDir()` exercises the multi-process
       // case directly.
       const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      trackPath(dataDir);
 
       const configA = new Config();
       await configA.setDataDir(dataDir);
@@ -228,6 +288,7 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
         Sinon.createStubInstance(Hooks),
         Sinon.createStubInstance(FileSystem),
       );
+      track(managerA, dataDir);
       await managerA.getInitCleanupPromise();
 
       const configB = new Config();
@@ -237,6 +298,7 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
         Sinon.createStubInstance(Hooks),
         Sinon.createStubInstance(FileSystem),
       );
+      track(managerB, dataDir);
       await managerB.getInitCleanupPromise();
 
       // A "live" data-dir owned by manager B. mkdir leaves mtime at
@@ -252,9 +314,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await managerA.testSweepOrphanDataDirs();
 
       expect(await pathExists(bDir)).to.be.true;
-      await managerA.shutdown();
-      await managerB.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('leaves non-browserless entries in dataDir alone', async () => {
@@ -277,14 +336,12 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       expect(await pathExists(friend)).to.be.true;
       expect(await pathExists(path.join(dataDir, 'a-marker.txt'))).to.be.true;
       expect(await pathExists(ownOrphan)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
   });
 
   describe(`close()`, () => {
     it('evicts the session from the registry even when browser.close() rejects', async () => {
-      const { dataDir, manager } = await makeManager();
+      const { manager } = await makeManager();
       const browser = makeMockBrowser('reject');
       const session = makeSession({
         isTempDataDir: false,
@@ -298,8 +355,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(manager.hasBrowser(browser)).to.be.false;
       expect(browser.close.calledOnce).to.be.true;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('removes a temp data-dir even when browser.close() rejects', async () => {
@@ -315,8 +370,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(await pathExists(target)).to.be.false;
       expect(manager.hasBrowser(browser)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('does NOT remove the data-dir when isTempDataDir is false', async () => {
@@ -335,8 +388,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(await pathExists(external)).to.be.true;
       expect(manager.hasBrowser(browser)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
   });
 
@@ -364,11 +415,10 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       expect(badBrowser.close.calledOnce).to.be.true;
       expect(await pathExists(okDir)).to.be.false;
       expect(await pathExists(badDir)).to.be.false;
-      await cleanupTestDir(dataDir);
     });
 
     it('sets shuttingDown to true and clears periodicSweepHandle', async () => {
-      const { dataDir, manager } = await makeManager();
+      const { manager } = await makeManager();
       expect(manager.isShuttingDown()).to.be.false;
       expect(manager.getPeriodicSweepHandle()).to.not.be.null;
 
@@ -376,11 +426,11 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(manager.isShuttingDown()).to.be.true;
       expect(manager.getPeriodicSweepHandle()).to.be.null;
-      await cleanupTestDir(dataDir);
     });
 
     it('does not arm periodicSweepHandle when shutdown is called during init', async () => {
       const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
+      trackPath(dataDir);
       // A backlog of stale orphans makes the startup sweep slow enough
       // for the race to be observable: shutdown() runs while
       // initCleanup() is mid-walk. Backdate the mtime so the staleness
@@ -400,12 +450,12 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
         Sinon.createStubInstance(Hooks),
         Sinon.createStubInstance(FileSystem),
       );
+      track(manager, dataDir);
       // Shut down without first awaiting initCleanupPromise. shutdown's
       // own await on the promise is what we're testing.
       await manager.shutdown();
 
       expect(manager.getPeriodicSweepHandle()).to.be.null;
-      await cleanupTestDir(dataDir);
     });
   });
 
@@ -420,8 +470,6 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
       expect(await pathExists(target)).to.be.false;
       expect(manager.getPendingCleanup().has(target)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
     it('drops pendingCleanup entries whose paths have vanished externally', async () => {
@@ -433,28 +481,65 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await manager.testPeriodicSweep();
 
       expect(manager.getPendingCleanup().has(ghost)).to.be.false;
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
     });
 
-    it('skips host-wide chromium-internal sweep by default (CLEANUP_HOST_CHROMIUM_TEMP_DIRS unset)', async () => {
-      // The env-var read is at module-load time, and the test process
-      // does not set it — so this test exercises the default-safe path.
-      const { dataDir, manager } = await makeManager();
-      const cdir = await fs.mkdtemp(
-        path.join(tmpdir(), 'org.chromium.Chromium.test-'),
-      );
-      // Make it look long-stale so it would be a deletion candidate.
-      const oldTime = new Date(Date.now() - 60 * 60 * 1000);
-      await fs.utimes(cdir, oldTime, oldTime);
+    // The host-wide chromium-internal sweep is gated by
+    // `CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true`. The pair of tests below
+    // exercise both branches in the same process; the gate is read on
+    // each tick (not at module load), so flipping the env var around
+    // each test is sufficient — no module re-imports required. Each
+    // test owns its own `org.chromium.Chromium.*` fixture in the OS
+    // tmpdir (registered with `trackPath` so it gets cleaned up even
+    // when the assertion that asserts it was *not* deleted fails).
+    it('skips host-wide chromium-internal sweep when CLEANUP_HOST_CHROMIUM_TEMP_DIRS is unset', async () => {
+      const prev = process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS;
+      delete process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS;
+      try {
+        const { manager } = await makeManager();
+        const cdir = await fs.mkdtemp(
+          path.join(tmpdir(), 'org.chromium.Chromium.test-'),
+        );
+        trackPath(cdir);
+        // Make it look long-stale so it would be a deletion candidate.
+        const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+        await fs.utimes(cdir, oldTime, oldTime);
 
-      await manager.testPeriodicSweep();
+        await manager.testPeriodicSweep();
 
-      // With Pass 2 gated off, the host-wide chromium dir must survive.
-      expect(await pathExists(cdir)).to.be.true;
-      await fs.rm(cdir, { force: true, recursive: true });
-      await manager.shutdown();
-      await cleanupTestDir(dataDir);
+        // With Pass 2 gated off, the host-wide chromium dir must survive.
+        expect(await pathExists(cdir)).to.be.true;
+      } finally {
+        if (prev === undefined) {
+          delete process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS;
+        } else {
+          process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS = prev;
+        }
+      }
+    });
+
+    it('sweeps host-wide chromium-internal dirs when CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true', async () => {
+      const prev = process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS;
+      process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS = 'true';
+      try {
+        const { manager } = await makeManager();
+        const cdir = await fs.mkdtemp(
+          path.join(tmpdir(), 'org.chromium.Chromium.test-'),
+        );
+        trackPath(cdir);
+        // 1 hour idle is well past the 30-minute ORPHAN_IDLE_MS floor.
+        const oldTime = new Date(Date.now() - 60 * 60 * 1000);
+        await fs.utimes(cdir, oldTime, oldTime);
+
+        await manager.testPeriodicSweep();
+
+        expect(await pathExists(cdir)).to.be.false;
+      } finally {
+        if (prev === undefined) {
+          delete process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS;
+        } else {
+          process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS = prev;
+        }
+      }
     });
   });
 });

--- a/src/browsers/index.spec.ts
+++ b/src/browsers/index.spec.ts
@@ -159,13 +159,18 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
   });
 
   describe(`sweepOrphanDataDirs (startup sweep)`, () => {
-    it('removes orphan data-dirs scoped to this instance', async () => {
+    // Helper: backdate a directory's mtime so the staleness check treats
+    // it as orphaned. 1 hour is well past the 30-minute ORPHAN_IDLE_MS
+    // threshold and matches the "prior-run leftover" scenario this
+    // sweep is designed to catch.
+    const ageDir = (p: string) => {
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      return fs.utimes(p, oneHourAgo, oneHourAgo);
+    };
+
+    it('removes stale orphan data-dirs from prior runs', async () => {
       const { dataDir, manager } = await makeManager();
       const instanceId = manager.getInstanceId();
-      // Simulate prior-run leftovers owned by THIS instance (matching
-      // prefix). After construction the startup sweep already ran on
-      // an empty dir; plant the orphans now and run the sweep again
-      // directly.
       const orphan1 = path.join(
         dataDir,
         `browserless-data-dir-${instanceId}-old1`,
@@ -176,6 +181,8 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       );
       await fs.mkdir(orphan1);
       await fs.mkdir(orphan2);
+      await ageDir(orphan1);
+      await ageDir(orphan2);
 
       await manager.testSweepOrphanDataDirs();
 
@@ -185,10 +192,33 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       await cleanupTestDir(dataDir);
     });
 
-    it('leaves data-dirs owned by other BrowserManager instances untouched', async () => {
-      // Two managers sharing the same `config.getDataDir()`. Manager A's
-      // startup sweep must not touch dirs owned by manager B (different
-      // instanceId prefix), even though both use the same name family.
+    it('removes stale orphan dirs whose name embeds a different instanceId (cross-restart cleanup)', async () => {
+      // The dominant leak scenario: a previous run crashed without
+      // graceful shutdown, leaving its data-dirs behind; this run has a
+      // freshly-generated instanceId, so the sweep must NOT scope by
+      // instance prefix or it would never reclaim those dirs.
+      const { dataDir, manager } = await makeManager();
+      const alienInstanceId = 'previous-run-instance-id';
+      const orphan = path.join(
+        dataDir,
+        `browserless-data-dir-${alienInstanceId}-old`,
+      );
+      await fs.mkdir(orphan);
+      await ageDir(orphan);
+
+      await manager.testSweepOrphanDataDirs();
+
+      expect(await pathExists(orphan)).to.be.false;
+      await manager.shutdown();
+      await cleanupTestDir(dataDir);
+    });
+
+    it('leaves fresh data-dirs untouched (treated as live, regardless of instanceId)', async () => {
+      // A directory whose mtime is fresh is presumed to belong to a live
+      // session — either ours (in flight) or another concurrently-running
+      // BrowserManager process sharing this data-dir. Two managers
+      // sharing one `config.getDataDir()` exercises the multi-process
+      // case directly.
       const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
 
       const configA = new Config();
@@ -209,14 +239,16 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       );
       await managerB.getInitCleanupPromise();
 
-      // Plant a "live" data-dir owned by manager B.
+      // A "live" data-dir owned by manager B. mkdir leaves mtime at
+      // `now`, so it falls inside the staleness window.
       const bDir = path.join(
         dataDir,
         `browserless-data-dir-${managerB.getInstanceId()}-live`,
       );
       await fs.mkdir(bDir);
 
-      // Manager A re-runs its startup sweep (e.g. simulating a restart).
+      // Manager A re-runs its sweep (e.g. simulating a restart). It
+      // must not delete manager B's fresh dir.
       await managerA.testSweepOrphanDataDirs();
 
       expect(await pathExists(bDir)).to.be.true;
@@ -235,8 +267,10 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
       );
       await fs.mkdir(friend);
       await fs.mkdir(ownOrphan);
+      await ageDir(ownOrphan);
       // Plant a file that should also be untouched.
       await fs.writeFile(path.join(dataDir, 'a-marker.txt'), 'hi');
+      await ageDir(friend);
 
       await manager.testSweepOrphanDataDirs();
 
@@ -347,11 +381,16 @@ describe(`BrowserManager — orphan data-dir cleanup`, () => {
 
     it('does not arm periodicSweepHandle when shutdown is called during init', async () => {
       const dataDir = await fs.mkdtemp(path.join(tmpdir(), 'bless-bm-test-'));
-      // A backlog of orphans makes the startup sweep slow enough for the
-      // race to be observable: shutdown() runs while initCleanup() is
-      // mid-walk.
+      // A backlog of stale orphans makes the startup sweep slow enough
+      // for the race to be observable: shutdown() runs while
+      // initCleanup() is mid-walk. Backdate the mtime so the staleness
+      // check actually queues each dir for deletion (otherwise the
+      // sweep skips them and finishes instantly).
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
       for (let i = 0; i < 50; i++) {
-        await fs.mkdir(path.join(dataDir, `browserless-data-dir-init-${i}`));
+        const p = path.join(dataDir, `browserless-data-dir-init-${i}`);
+        await fs.mkdir(p);
+        await fs.utimes(p, oneHourAgo, oneHourAgo);
       }
 
       const config = new Config();

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs/promises';
 import {
   BLESS_PAGE_IDENTIFIER,
   BadRequest,
@@ -39,6 +40,29 @@ import { Page } from 'puppeteer-core';
 import { deleteAsync } from 'del';
 import micromatch from 'micromatch';
 import path from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * How long an `org.chromium.Chromium.*` temp directory must be untouched
+ * before the periodic sweep considers it abandoned. Chrome only writes to
+ * these dirs while a related subprocess is alive, so a 30-minute idle
+ * threshold is well past any realistic active session.
+ */
+const CHROMIUM_ORPHAN_IDLE_MS = 30 * 60 * 1000;
+
+/**
+ * Interval between periodic-sweep runs. Each run drains the
+ * `pendingCleanup` retry queue and walks the host /tmp for chromium-internal
+ * orphans. 5 minutes balances responsiveness against `readdir`/`stat` cost.
+ */
+const PERIODIC_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Per-attempt backoff for `removeUserDataDir` retries. Chrome typically
+ * releases file handles within a few hundred milliseconds of `browser.close()`,
+ * so 200ms / 400ms / 800ms covers the realistic EBUSY window.
+ */
+const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
 
 export class BrowserManager {
   protected reconnectionPatterns = ['/devtools/browser', '/function/connect'];
@@ -54,11 +78,27 @@ export class BrowserManager {
     WebKitPlaywright.name,
   ];
 
+  /**
+   * Data-dirs whose deletion failed transiently and must be retried by the
+   * periodic sweep. Populated by `removeUserDataDir` after exhausting its
+   * inline retries; drained by `periodicSweep`.
+   */
+  protected pendingCleanup: Set<string> = new Set();
+
+  /**
+   * Handle for the periodic sweep loop, kept so `shutdown` can stop it.
+   */
+  protected periodicSweepHandle: NodeJS.Timeout | null = null;
+
   constructor(
     protected config: Config,
     protected hooks: Hooks,
     protected fileSystem: FileSystem,
-  ) {}
+  ) {
+    // Fire-and-forget startup sweep + periodic loop. Failures inside are
+    // logged but never thrown — cleanup is best-effort by design.
+    void this.initCleanup();
+  }
 
   protected browserIsChrome(b: BrowserInstance) {
     return this.chromeBrowsers.some(
@@ -67,13 +107,149 @@ export class BrowserManager {
   }
 
   protected async removeUserDataDir(userDataDir: string | null) {
-    if (userDataDir && (await exists(userDataDir))) {
-      this.log.debug(`Deleting data directory "${userDataDir}"`);
-      await deleteAsync(userDataDir, { force: true }).catch((err) => {
-        this.log.error(
-          `Error cleaning up user-data-dir "${err}" at ${userDataDir}`,
+    if (!userDataDir) return;
+    if (!(await exists(userDataDir))) return;
+
+    this.log.debug(`Deleting data directory "${userDataDir}"`);
+
+    for (let attempt = 0; attempt < REMOVE_RETRY_BACKOFF_MS.length; attempt++) {
+      try {
+        await deleteAsync(userDataDir, { force: true });
+        this.pendingCleanup.delete(userDataDir);
+        return;
+      } catch (err) {
+        const isLastAttempt =
+          attempt === REMOVE_RETRY_BACKOFF_MS.length - 1;
+        if (isLastAttempt) {
+          this.log.warn(
+            `Failed to remove user-data-dir "${userDataDir}" after ${REMOVE_RETRY_BACKOFF_MS.length} attempts (${err}); queued for periodic sweep`,
+          );
+          this.pendingCleanup.add(userDataDir);
+          return;
+        }
+        await new Promise((resolve) =>
+          global.setTimeout(resolve, REMOVE_RETRY_BACKOFF_MS[attempt]),
         );
+      }
+    }
+  }
+
+  /**
+   * Run once at construction: sweep prior-run orphans from the configured
+   * data-dir, then arm the periodic sweep loop. Catches and logs any
+   * failures so a transient FS error never prevents the manager from
+   * starting.
+   */
+  protected async initCleanup(): Promise<void> {
+    try {
+      await this.sweepOrphanDataDirs();
+    } catch (err) {
+      this.log.warn(`Startup orphan sweep failed: ${err}`);
+    }
+    this.periodicSweepHandle = global.setInterval(() => {
+      this.periodicSweep().catch((err) => {
+        this.log.warn(`Periodic sweep failed: ${err}`);
       });
+    }, PERIODIC_SWEEP_INTERVAL_MS);
+  }
+
+  /**
+   * Walks the configured `dataDir` and removes any `browserless-data-dir-*`
+   * leftovers. Called once at startup, before any new sessions land — every
+   * such dir is guaranteed to be from a prior run (this manager has no
+   * sessions yet) so no PID check is needed.
+   */
+  protected async sweepOrphanDataDirs(): Promise<void> {
+    const baseDir = await this.config.getDataDir();
+    if (!(await exists(baseDir))) return;
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(baseDir);
+    } catch (err) {
+      this.log.warn(`Could not read data-dir "${baseDir}": ${err}`);
+      return;
+    }
+
+    const orphans = entries.filter((e) =>
+      e.startsWith('browserless-data-dir-'),
+    );
+    if (orphans.length === 0) return;
+
+    this.log.info(
+      `Startup sweep: removing ${orphans.length} orphan data-dir(s) from prior run`,
+    );
+    for (const orphan of orphans) {
+      await this.removeUserDataDir(path.join(baseDir, orphan));
+    }
+  }
+
+  /**
+   * Runs every PERIODIC_SWEEP_INTERVAL_MS. Two passes:
+   *
+   * 1. Drain `pendingCleanup` — paths that failed inline retries earlier.
+   *    A previously busy file handle is almost always released by the time
+   *    the periodic sweep fires, so this catches the long-tail EBUSY cases.
+   *
+   * 2. Walk `/tmp` for chromium-internal subprocess orphans
+   *    (`org.chromium.Chromium.*`). Chrome creates these via mkdtemp for
+   *    its renderer/GPU/network/url_fetcher subprocesses and reaps them on
+   *    graceful shutdown — but a parent-process kill (OOM, segfault,
+   *    SIGKILL) leaves them behind. We use mtime-only as the liveness
+   *    signal: any subprocess actively using the dir would have touched it
+   *    within the last few minutes, so 30 min of mtime idleness is a safe
+   *    floor.
+   */
+  protected async periodicSweep(): Promise<void> {
+    // Pass 1: retry queue
+    for (const dir of Array.from(this.pendingCleanup)) {
+      await this.removeUserDataDir(dir);
+    }
+
+    // Pass 2: chromium-internal orphans. These live in the OS temp dir
+    // because Chrome creates them via mkdtemp, which is hard-wired to
+    // os.tmpdir() — independent of our configurable DATA_DIR. Using
+    // dirname(getDataDir()) only matches /tmp in the default config and
+    // silently misses the orphans whenever DATA_DIR points elsewhere.
+    const tmpRoot = tmpdir();
+    let entries: string[];
+    try {
+      entries = await fs.readdir(tmpRoot);
+    } catch (err) {
+      this.log.debug(`Could not read tmp root "${tmpRoot}": ${err}`);
+      return;
+    }
+
+    const now = Date.now();
+    let removed = 0;
+    for (const entry of entries) {
+      if (!entry.startsWith('org.chromium.Chromium.')) continue;
+      const full = path.join(tmpRoot, entry);
+
+      let mtime: Date;
+      try {
+        const stat = await fs.stat(full);
+        if (!stat.isDirectory()) continue;
+        mtime = stat.mtime;
+      } catch {
+        // Disappeared between readdir and stat — fine, move on.
+        continue;
+      }
+
+      if (now - mtime.getTime() < CHROMIUM_ORPHAN_IDLE_MS) continue;
+
+      try {
+        await deleteAsync(full, { force: true });
+        removed++;
+      } catch (err) {
+        this.log.debug(`Could not remove chromium orphan "${full}": ${err}`);
+      }
+    }
+
+    if (removed > 0) {
+      this.log.info(
+        `Periodic sweep removed ${removed} stale chromium-internal orphan(s) from "${tmpRoot}"`,
+      );
     }
   }
 
@@ -309,7 +485,6 @@ export class BrowserManager {
     const connected = session.numbConnected;
     const hasKeepUntil = keepUntil > now;
     const keepOpen = (connected > 0 || hasKeepUntil) && !force;
-    const cleanupACtions: Array<() => Promise<void>> = [];
     const priorTimer = this.timers.get(session.id);
 
     if (priorTimer) {
@@ -340,17 +515,30 @@ export class BrowserManager {
 
     if (!keepOpen) {
       this.log.debug(`Closing browser session`);
-      cleanupACtions.push(() => browser.close());
-
-      if (session.isTempDataDir) {
-        this.log.debug(
-          `Deleting "${session.userDataDir}" user-data-dir and session from memory`,
+      // Serialise: await Chrome shutdown FIRST so it releases its file
+      // handles, then delete the data-dir. Running these in parallel
+      // (the previous behaviour) raced `deleteAsync` against Chrome
+      // releasing its FDs and produced silent EBUSY/ENOTEMPTY failures
+      // that left orphan profile dirs in `/tmp`.
+      //
+      // Cleanup runs in `finally` so a `browser.close()` rejection
+      // (process already gone, IPC error, etc.) cannot skip the
+      // data-dir delete and leak the orphan we were trying to prevent.
+      try {
+        await browser.close();
+      } catch (err) {
+        this.log.warn(
+          `browser.close() rejected during session close ("${session.id}"): ${err}; proceeding with data-dir cleanup`,
         );
-        this.browsers.delete(browser);
-        cleanupACtions.push(() => this.removeUserDataDir(session.userDataDir));
+      } finally {
+        if (session.isTempDataDir) {
+          this.log.debug(
+            `Deleting "${session.userDataDir}" user-data-dir and session from memory`,
+          );
+          this.browsers.delete(browser);
+          await this.removeUserDataDir(session.userDataDir);
+        }
       }
-
-      await Promise.all(cleanupACtions.map((a) => a()));
     }
   }
 
@@ -665,12 +853,51 @@ export class BrowserManager {
   public async shutdown(): Promise<void> {
     this.log.info(`Closing down browser instances`);
     const sessions = Array.from(this.browsers);
-    await Promise.all(sessions.map(([b]) => b.close()));
-    const timers = Array.from(this.timers);
-    await Promise.all(timers.map(([, timer]) => clearInterval(timer)));
+
+    // Capture every temp data-dir BEFORE we close the browsers — `close`
+    // would clear the references and we'd lose the paths. Without this,
+    // every SIGTERM (deploy, container restart, config change) leaks
+    // one orphan data-dir per active session into /tmp.
+    const tempDataDirs = sessions
+      .filter(([, session]) => session.isTempDataDir)
+      .map(([, session]) => session.userDataDir)
+      .filter((d): d is string => !!d);
+
+    // Best-effort: a single `b.close()` rejection must not prevent the
+    // remaining browsers from closing, the data-dirs from being removed,
+    // the timers from being cleared, or `stop()` from running. Use
+    // `allSettled` so we always reach the rest of the shutdown sequence.
+    const closeResults = await Promise.allSettled(
+      sessions.map(([b]) => b.close()),
+    );
+    for (const result of closeResults) {
+      if (result.status === 'rejected') {
+        this.log.warn(
+          `browser.close() rejected during shutdown: ${result.reason}; continuing with cleanup`,
+        );
+      }
+    }
+
+    // Chrome processes are now terminated (or known-failed); safe to
+    // delete their data-dirs. `removeUserDataDir` swallows its own
+    // errors internally so this should not reject, but `allSettled` is
+    // cheap insurance.
+    await Promise.allSettled(
+      tempDataDirs.map((dir) => this.removeUserDataDir(dir)),
+    );
+
+    // Timer / state cleanup is unconditional — regardless of how the
+    // close+delete steps went, the manager must end up in a clean
+    // state, with no leaked timers and the periodic sweep stopped.
     this.timers.forEach((t) => clearTimeout(t));
     this.browsers = new Map();
     this.timers = new Map();
+
+    if (this.periodicSweepHandle) {
+      global.clearInterval(this.periodicSweepHandle);
+      this.periodicSweepHandle = null;
+    }
+
     await this.stop();
     this.log.info(`Shutdown complete`);
   }

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -64,6 +64,18 @@ const PERIODIC_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
  */
 const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
 
+/**
+ * The chromium-internal subprocess orphan sweep (`org.chromium.Chromium.*`
+ * dirs in the OS temp directory) walks paths that are NOT
+ * browserless-managed and could in principle be created by other
+ * Chrome-using workloads sharing the same `os.tmpdir()`. Default off so
+ * the SDK is safe to drop into shared environments. Container
+ * deployments where /tmp is owned exclusively by browserless can opt in
+ * with `CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true`.
+ */
+const HOST_CHROMIUM_CLEANUP_ENABLED =
+  process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS === 'true';
+
 export class BrowserManager {
   protected reconnectionPatterns = ['/devtools/browser', '/function/connect'];
   protected browsers: Map<BrowserInstance, BrowserlessSession> = new Map();
@@ -90,14 +102,35 @@ export class BrowserManager {
    */
   protected periodicSweepHandle: NodeJS.Timeout | null = null;
 
+  /**
+   * Resolves once the startup orphan sweep has completed AND the periodic
+   * sweep loop has been (conditionally) armed. Awaited by:
+   *   - `shutdown()`, so it cannot race with `initCleanup` re-arming the
+   *     sweep handle after we've cleared it.
+   *   - `getBrowserForRequest()`, so a new session cannot create a fresh
+   *     `browserless-data-dir-*` while the startup sweep is mid-walk —
+   *     otherwise the sweep's prefix filter would match (and delete) the
+   *     in-flight dir.
+   */
+  protected initCleanupPromise: Promise<void> | null = null;
+
+  /**
+   * Set true at the very start of `shutdown`. Read by `initCleanup` to
+   * skip arming the periodic sweep when shutdown happened during startup,
+   * and by `getBrowserForRequest` to bail rather than spin up a new
+   * session against a manager that's tearing down.
+   */
+  protected shuttingDown = false;
+
   constructor(
     protected config: Config,
     protected hooks: Hooks,
     protected fileSystem: FileSystem,
   ) {
-    // Fire-and-forget startup sweep + periodic loop. Failures inside are
-    // logged but never thrown — cleanup is best-effort by design.
-    void this.initCleanup();
+    // Track the init promise so shutdown() and request handling can
+    // synchronise against it. Failures inside are logged but never
+    // thrown — cleanup is best-effort by design.
+    this.initCleanupPromise = this.initCleanup();
   }
 
   protected browserIsChrome(b: BrowserInstance) {
@@ -108,7 +141,13 @@ export class BrowserManager {
 
   protected async removeUserDataDir(userDataDir: string | null) {
     if (!userDataDir) return;
-    if (!(await exists(userDataDir))) return;
+    if (!(await exists(userDataDir))) {
+      // Path has vanished (manual cleanup, tmpfs unmount, deleted by
+      // someone else). Drop any stale entry so the periodic sweep
+      // doesn't keep retrying it forever.
+      this.pendingCleanup.delete(userDataDir);
+      return;
+    }
 
     this.log.debug(`Deleting data directory "${userDataDir}"`);
 
@@ -145,6 +184,16 @@ export class BrowserManager {
       await this.sweepOrphanDataDirs();
     } catch (err) {
       this.log.warn(`Startup orphan sweep failed: ${err}`);
+    }
+    // If shutdown was called while the startup sweep was running, do not
+    // arm the periodic sweep — shutdown has already cleared whatever
+    // handle was here previously and a new interval would outlive the
+    // manager.
+    if (this.shuttingDown) {
+      this.log.debug(
+        'Skipping periodic-sweep arm: shutdown was requested during startup sweep',
+      );
+      return;
     }
     this.periodicSweepHandle = global.setInterval(() => {
       this.periodicSweep().catch((err) => {
@@ -211,6 +260,17 @@ export class BrowserManager {
     // os.tmpdir() — independent of our configurable DATA_DIR. Using
     // dirname(getDataDir()) only matches /tmp in the default config and
     // silently misses the orphans whenever DATA_DIR points elsewhere.
+    //
+    // The OS tmp dir can be shared with other workloads, so this pass
+    // is gated behind CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true. Default off
+    // — opt in only when the SDK is the sole owner of /tmp (typical
+    // single-purpose container deployments).
+    if (!HOST_CHROMIUM_CLEANUP_ENABLED) {
+      this.log.debug(
+        'Skipping host-wide chromium-internal orphan sweep; set CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true to enable',
+      );
+      return;
+    }
     const tmpRoot = tmpdir();
     let entries: string[];
     try {
@@ -609,6 +669,20 @@ export class BrowserManager {
     router: BrowserHTTPRoute | BrowserWebsocketRoute,
     logger: Logger,
   ): Promise<BrowserInstance> {
+    // Gate every new session on the startup orphan sweep finishing.
+    // Without this, `generateDataDir(...)` below could race the sweep:
+    // both paths use the `browserless-data-dir-*` prefix in the same
+    // dataDir, and the sweep would happily delete an in-flight new
+    // session's directory because it cannot tell prior-run leftovers
+    // from concurrently-created ones.
+    if (this.initCleanupPromise) {
+      await this.initCleanupPromise;
+    }
+    if (this.shuttingDown) {
+      throw new ServerError(
+        'BrowserManager is shutting down; cannot accept new sessions',
+      );
+    }
     const { browser: Browser } = router;
     const blockAds = parseBooleanParam(
       req.parsed.searchParams,
@@ -852,6 +926,17 @@ export class BrowserManager {
 
   public async shutdown(): Promise<void> {
     this.log.info(`Closing down browser instances`);
+    // Set the flag FIRST so `initCleanup` (if still running) sees it and
+    // skips the periodic-sweep arm — otherwise the interval could be
+    // re-armed after we clear it below and outlive the manager.
+    this.shuttingDown = true;
+    if (this.initCleanupPromise) {
+      // Wait for the startup sweep to finish so it cannot complete and
+      // re-arm `periodicSweepHandle` after our `clearInterval` runs.
+      await this.initCleanupPromise.catch(() => {
+        // Already logged inside initCleanup; nothing else to do here.
+      });
+    }
     const sessions = Array.from(this.browsers);
 
     // Capture every temp data-dir BEFORE we close the browsers — `close`

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -588,14 +588,23 @@ export class BrowserManager {
         await browser.close();
       } catch (err) {
         this.log.warn(
-          `browser.close() rejected during session close ("${session.id}"): ${err}; proceeding with data-dir cleanup`,
+          `browser.close() rejected during session close ("${session.id}"): ${err}; proceeding with cleanup`,
         );
       } finally {
+        // Evict the session from the registry unconditionally — sessions
+        // created with an explicit --user-data-dir (isTempDataDir=false)
+        // must still be removed from `this.browsers`, otherwise they
+        // leak into `getAllSessions()` and trackingId lookups as stale
+        // closed-browser entries.
+        this.browsers.delete(browser);
+
+        // Data-dir removal stays guarded: only the dirs WE created
+        // (isTempDataDir=true) are ours to delete. A caller-supplied
+        // --user-data-dir is the caller's lifecycle to manage.
         if (session.isTempDataDir) {
           this.log.debug(
             `Deleting "${session.userDataDir}" user-data-dir and session from memory`,
           );
-          this.browsers.delete(browser);
           await this.removeUserDataDir(session.userDataDir);
         }
       }

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -30,6 +30,7 @@ import {
   exists,
   generateDataDir,
   getFinalPathSegment,
+  id,
   makeExternalURL,
   noop,
   parseBooleanParam,
@@ -58,11 +59,24 @@ const CHROMIUM_ORPHAN_IDLE_MS = 30 * 60 * 1000;
 const PERIODIC_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
- * Per-attempt backoff for `removeUserDataDir` retries. Chrome typically
- * releases file handles within a few hundred milliseconds of `browser.close()`,
- * so 200ms / 400ms / 800ms covers the realistic EBUSY window.
+ * Wait times between `removeUserDataDir` attempts. Chrome typically
+ * releases file handles within a few hundred milliseconds of
+ * `browser.close()`, so 200ms / 400ms / 800ms covers the realistic
+ * EBUSY window. The loop runs `length + 1` attempts in total: the
+ * first try is unconditional, and each subsequent retry waits for
+ * the corresponding entry in this array before retrying.
  */
 const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
+
+/**
+ * Filename prefix shared by every per-session user-data-dir we create.
+ * The full directory name is `${SESSION_DATA_DIR_PREFIX}${instanceId}-${sessionId}`,
+ * so the `${instanceId}-` segment scopes ownership to a single
+ * BrowserManager instance. Sweeps in the shared base data-dir filter on
+ * the instance-qualified prefix and never touch directories owned by
+ * other manager instances co-located in the same `config.getDataDir()`.
+ */
+const SESSION_DATA_DIR_PREFIX = 'browserless-data-dir-';
 
 /**
  * The chromium-internal subprocess orphan sweep (`org.chromium.Chromium.*`
@@ -122,6 +136,15 @@ export class BrowserManager {
    */
   protected shuttingDown = false;
 
+  /**
+   * Random per-construction identifier woven into every user-data-dir
+   * this manager creates. Two BrowserManager instances sharing a single
+   * `config.getDataDir()` (e.g. multiple processes pointed at the same
+   * /tmp) end up with non-overlapping data-dir name prefixes, so neither
+   * instance's sweep ever sees the other's live profiles.
+   */
+  protected readonly instanceId: string = id();
+
   constructor(
     protected config: Config,
     protected hooks: Hooks,
@@ -151,21 +174,30 @@ export class BrowserManager {
 
     this.log.debug(`Deleting data directory "${userDataDir}"`);
 
-    for (let attempt = 0; attempt < REMOVE_RETRY_BACKOFF_MS.length; attempt++) {
+    // `length + 1` attempts in total: the initial try, then one retry
+    // per backoff entry. The previous `< length` upper bound stopped
+    // after `length` attempts and silently dropped the trailing backoff
+    // entry on the floor, so the array's last value (e.g. 800ms) was
+    // never used as a wait and the matching final retry never ran.
+    const totalAttempts = REMOVE_RETRY_BACKOFF_MS.length + 1;
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
       try {
         await deleteAsync(userDataDir, { force: true });
         this.pendingCleanup.delete(userDataDir);
         return;
       } catch (err) {
-        const isLastAttempt =
-          attempt === REMOVE_RETRY_BACKOFF_MS.length - 1;
+        const isLastAttempt = attempt === totalAttempts - 1;
         if (isLastAttempt) {
           this.log.warn(
-            `Failed to remove user-data-dir "${userDataDir}" after ${REMOVE_RETRY_BACKOFF_MS.length} attempts (${err}); queued for periodic sweep`,
+            `Failed to remove user-data-dir "${userDataDir}" after ${totalAttempts} attempts (${err}); queued for periodic sweep`,
           );
           this.pendingCleanup.add(userDataDir);
           return;
         }
+        // `attempt < REMOVE_RETRY_BACKOFF_MS.length` is guaranteed here
+        // because the only attempt index that could exceed the array is
+        // the final one, which already returned in the `isLastAttempt`
+        // branch above.
         await new Promise((resolve) =>
           global.setTimeout(resolve, REMOVE_RETRY_BACKOFF_MS[attempt]),
         );
@@ -203,10 +235,16 @@ export class BrowserManager {
   }
 
   /**
-   * Walks the configured `dataDir` and removes any `browserless-data-dir-*`
-   * leftovers. Called once at startup, before any new sessions land — every
-   * such dir is guaranteed to be from a prior run (this manager has no
-   * sessions yet) so no PID check is needed.
+   * Walks the configured `dataDir` and removes any orphaned data-dirs
+   * that we own but never cleaned up. Called once at startup, before
+   * any new sessions land.
+   *
+   * The filter is scoped to `${SESSION_DATA_DIR_PREFIX}${instanceId}-`
+   * so a manager whose `config.getDataDir()` is shared with other
+   * BrowserManager instances (multi-process deploys, shared /tmp) only
+   * touches its own leftovers. Other instances' live profiles use a
+   * different `instanceId` segment in the path and are skipped by this
+   * filter.
    */
   protected async sweepOrphanDataDirs(): Promise<void> {
     const baseDir = await this.config.getDataDir();
@@ -220,13 +258,12 @@ export class BrowserManager {
       return;
     }
 
-    const orphans = entries.filter((e) =>
-      e.startsWith('browserless-data-dir-'),
-    );
+    const ownedPrefix = `${SESSION_DATA_DIR_PREFIX}${this.instanceId}-`;
+    const orphans = entries.filter((e) => e.startsWith(ownedPrefix));
     if (orphans.length === 0) return;
 
     this.log.info(
-      `Startup sweep: removing ${orphans.length} orphan data-dir(s) from prior run`,
+      `Startup sweep: removing ${orphans.length} orphan data-dir(s) owned by instance ${this.instanceId}`,
     );
     for (const orphan of orphans) {
       await this.removeUserDataDir(path.join(baseDir, orphan));
@@ -845,11 +882,16 @@ export class BrowserManager {
     }
 
     // Always specify a user-data-dir since plugins can "inject" their own
-    // unless it's playwright which takes care of its own data-dirs
+    // unless it's playwright which takes care of its own data-dirs.
+    // The auto-generated dir name embeds `${instanceId}-` so a
+    // co-located BrowserManager's startup sweep (which filters by
+    // instance prefix) cannot match — and therefore cannot delete —
+    // this instance's profile. Manual `--user-data-dir` paths bypass
+    // this entirely, since the caller owns the path's lifecycle.
     const userDataDir =
       manualUserDataDir ||
       (!this.playwrightBrowserNames.includes(Browser.name)
-        ? await generateDataDir(undefined, this.config)
+        ? await generateDataDir(`${this.instanceId}-${id()}`, this.config)
         : null);
 
     const proxyServerArg = launchOptions.args?.find((arg) =>
@@ -900,6 +942,33 @@ export class BrowserManager {
       stealth: launchOptions?.stealth,
     });
     await this.hooks.browser({ browser, req });
+
+    // Post-launch shutdown check. The earlier check at the top of this
+    // method races with `shutdown()`: a request can pass that gate,
+    // generate a data-dir, launch a browser, and only THEN have
+    // shutdown set the flag and snapshot `this.browsers` — at which
+    // point this in-flight browser would be missing from the snapshot
+    // and never closed, leaking both the Chrome process and the
+    // data-dir. Re-check before registration; if shutdown is now in
+    // progress, tear down what we just created using the same paths
+    // that `close()` and `removeUserDataDir` use, then surface the
+    // same ServerError as the early gate.
+    if (this.shuttingDown) {
+      try {
+        await browser.close();
+      } catch (err) {
+        this.log.warn(
+          `browser.close() rejected during shutdown-race teardown: ${err}`,
+        );
+      }
+      const isTempDataDir = !manualUserDataDir;
+      if (isTempDataDir && userDataDir) {
+        await this.removeUserDataDir(userDataDir);
+      }
+      throw new ServerError(
+        'BrowserManager is shutting down; cannot accept new sessions',
+      );
+    }
 
     const sessionId = getFinalPathSegment(browser.wsEndpoint()!)!;
     const session: BrowserlessSession = {

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -44,12 +44,19 @@ import path from 'path';
 import { tmpdir } from 'os';
 
 /**
- * How long an `org.chromium.Chromium.*` temp directory must be untouched
- * before the periodic sweep considers it abandoned. Chrome only writes to
- * these dirs while a related subprocess is alive, so a 30-minute idle
- * threshold is well past any realistic active session.
+ * How long a tracked temp directory must be untouched before our sweeps
+ * consider it abandoned. Used by both:
+ *   - the startup sweep over `${SESSION_DATA_DIR_PREFIX}*` entries in the
+ *     configured data-dir, where a live Chrome session continuously
+ *     writes profile state (cookies, cache, prefs) so a stale mtime is a
+ *     reliable "no live owner" signal even when the data-dir is shared
+ *     across BrowserManager instances; and
+ *   - the periodic sweep over `org.chromium.Chromium.*` dirs in the OS
+ *     temp dir, which Chrome only writes to while the related subprocess
+ *     is alive.
+ * 30 minutes is well past any realistic active session in either case.
  */
-const CHROMIUM_ORPHAN_IDLE_MS = 30 * 60 * 1000;
+const ORPHAN_IDLE_MS = 30 * 60 * 1000;
 
 /**
  * Interval between periodic-sweep runs. Each run drains the
@@ -70,11 +77,11 @@ const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
 
 /**
  * Filename prefix shared by every per-session user-data-dir we create.
- * The full directory name is `${SESSION_DATA_DIR_PREFIX}${instanceId}-${sessionId}`,
- * so the `${instanceId}-` segment scopes ownership to a single
- * BrowserManager instance. Sweeps in the shared base data-dir filter on
- * the instance-qualified prefix and never touch directories owned by
- * other manager instances co-located in the same `config.getDataDir()`.
+ * The full directory name is `${SESSION_DATA_DIR_PREFIX}${instanceId}-${sessionId}`;
+ * the `${instanceId}-` segment is a debugging/traceability hint, not a
+ * safety boundary. Cross-instance safety in the startup sweep is enforced
+ * by the mtime staleness check, not by name filtering — see
+ * `sweepOrphanDataDirs`.
  */
 const SESSION_DATA_DIR_PREFIX = 'browserless-data-dir-';
 
@@ -121,10 +128,12 @@ export class BrowserManager {
    * sweep loop has been (conditionally) armed. Awaited by:
    *   - `shutdown()`, so it cannot race with `initCleanup` re-arming the
    *     sweep handle after we've cleared it.
-   *   - `getBrowserForRequest()`, so a new session cannot create a fresh
-   *     `browserless-data-dir-*` while the startup sweep is mid-walk —
-   *     otherwise the sweep's prefix filter would match (and delete) the
-   *     in-flight dir.
+   *   - `getBrowserForRequest()`, so the startup sweep finishes before
+   *     new sessions land. The mtime staleness check makes a same-tick
+   *     race a non-issue (a freshly-created dir has fresh mtime and is
+   *     skipped), but the await keeps the request path simpler — it
+   *     never has to reason about a sweep concurrently `stat`-ing a dir
+   *     it's also creating.
    */
   protected initCleanupPromise: Promise<void> | null = null;
 
@@ -137,11 +146,11 @@ export class BrowserManager {
   protected shuttingDown = false;
 
   /**
-   * Random per-construction identifier woven into every user-data-dir
-   * this manager creates. Two BrowserManager instances sharing a single
-   * `config.getDataDir()` (e.g. multiple processes pointed at the same
-   * /tmp) end up with non-overlapping data-dir name prefixes, so neither
-   * instance's sweep ever sees the other's live profiles.
+   * Random per-construction identifier embedded in every user-data-dir
+   * this manager creates. Useful for tracing which dir came from which
+   * process when reading a shared `config.getDataDir()`. Cross-instance
+   * sweep safety is enforced by mtime staleness, not by this id — see
+   * `sweepOrphanDataDirs`.
    */
   protected readonly instanceId: string = id();
 
@@ -235,16 +244,24 @@ export class BrowserManager {
   }
 
   /**
-   * Walks the configured `dataDir` and removes any orphaned data-dirs
-   * that we own but never cleaned up. Called once at startup, before
-   * any new sessions land.
+   * Walks the configured `dataDir` and removes orphaned per-session
+   * data-dirs left over from prior runs. Called once at construction,
+   * before any new sessions land.
    *
-   * The filter is scoped to `${SESSION_DATA_DIR_PREFIX}${instanceId}-`
-   * so a manager whose `config.getDataDir()` is shared with other
-   * BrowserManager instances (multi-process deploys, shared /tmp) only
-   * touches its own leftovers. Other instances' live profiles use a
-   * different `instanceId` segment in the path and are skipped by this
-   * filter.
+   * The dominant leak source is a container restarting (deploy, OOM,
+   * SIGKILL) without finishing graceful shutdown — the previous run's
+   * `${SESSION_DATA_DIR_PREFIX}*` directories survive into the new run
+   * because each fresh `BrowserManager` gets a new random `instanceId`,
+   * so an instance-qualified name filter would never match prior-run
+   * orphans (PR review thread on browserless#5343). Filtering on the
+   * general `SESSION_DATA_DIR_PREFIX` lets us catch them.
+   *
+   * Cross-instance safety (multiple BrowserManager processes sharing the
+   * same `config.getDataDir()`) is enforced by the mtime staleness check
+   * rather than by name scoping: a live Chrome session continuously
+   * writes profile state (cookies, cache, prefs) so a directory idle for
+   * ORPHAN_IDLE_MS is reliably orphaned. A directory owned by another
+   * concurrently-running instance has fresh mtime and is skipped.
    */
   protected async sweepOrphanDataDirs(): Promise<void> {
     const baseDir = await this.config.getDataDir();
@@ -258,15 +275,47 @@ export class BrowserManager {
       return;
     }
 
-    const ownedPrefix = `${SESSION_DATA_DIR_PREFIX}${this.instanceId}-`;
-    const orphans = entries.filter((e) => e.startsWith(ownedPrefix));
-    if (orphans.length === 0) return;
+    const candidates = entries.filter((e) =>
+      e.startsWith(SESSION_DATA_DIR_PREFIX),
+    );
+    if (candidates.length === 0) return;
+
+    const now = Date.now();
+    const orphans: string[] = [];
+    let liveSkipped = 0;
+    for (const entry of candidates) {
+      const full = path.join(baseDir, entry);
+      let mtimeMs: number;
+      try {
+        const stat = await fs.stat(full);
+        if (!stat.isDirectory()) continue;
+        mtimeMs = stat.mtimeMs;
+      } catch {
+        // Vanished between readdir and stat — fine, move on.
+        continue;
+      }
+      if (now - mtimeMs < ORPHAN_IDLE_MS) {
+        liveSkipped++;
+        continue;
+      }
+      orphans.push(full);
+    }
+
+    if (orphans.length === 0) {
+      if (liveSkipped > 0) {
+        this.log.debug(
+          `Startup sweep: ${liveSkipped} data-dir(s) skipped as live (mtime newer than ${ORPHAN_IDLE_MS}ms)`,
+        );
+      }
+      return;
+    }
 
     this.log.info(
-      `Startup sweep: removing ${orphans.length} orphan data-dir(s) owned by instance ${this.instanceId}`,
+      `Startup sweep: removing ${orphans.length} orphan data-dir(s)` +
+        (liveSkipped > 0 ? ` (${liveSkipped} live dir(s) skipped)` : ''),
     );
     for (const orphan of orphans) {
-      await this.removeUserDataDir(path.join(baseDir, orphan));
+      await this.removeUserDataDir(orphan);
     }
   }
 
@@ -333,7 +382,7 @@ export class BrowserManager {
         continue;
       }
 
-      if (now - mtime.getTime() < CHROMIUM_ORPHAN_IDLE_MS) continue;
+      if (now - mtime.getTime() < ORPHAN_IDLE_MS) continue;
 
       try {
         await deleteAsync(full, { force: true });
@@ -883,11 +932,10 @@ export class BrowserManager {
 
     // Always specify a user-data-dir since plugins can "inject" their own
     // unless it's playwright which takes care of its own data-dirs.
-    // The auto-generated dir name embeds `${instanceId}-` so a
-    // co-located BrowserManager's startup sweep (which filters by
-    // instance prefix) cannot match — and therefore cannot delete —
-    // this instance's profile. Manual `--user-data-dir` paths bypass
-    // this entirely, since the caller owns the path's lifecycle.
+    // The auto-generated name embeds `${instanceId}-` purely for
+    // traceability when multiple BrowserManager processes share a
+    // `config.getDataDir()`. Manual `--user-data-dir` paths bypass this
+    // entirely, since the caller owns the path's lifecycle.
     const userDataDir =
       manualUserDataDir ||
       (!this.playwrightBrowserNames.includes(Browser.name)

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -23,6 +23,7 @@ import {
   Logger,
   NotFound,
   Request,
+  SESSION_DATA_DIR_PREFIX,
   ServerError,
   WebKitPlaywright,
   availableBrowsers,
@@ -75,15 +76,9 @@ const PERIODIC_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
  */
 const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
 
-/**
- * Filename prefix shared by every per-session user-data-dir we create.
- * The full directory name is `${SESSION_DATA_DIR_PREFIX}${instanceId}-${sessionId}`;
- * the `${instanceId}-` segment is a debugging/traceability hint, not a
- * safety boundary. Cross-instance safety in the startup sweep is enforced
- * by the mtime staleness check, not by name filtering — see
- * `sweepOrphanDataDirs`.
- */
-const SESSION_DATA_DIR_PREFIX = 'browserless-data-dir-';
+// `SESSION_DATA_DIR_PREFIX` lives in src/utils.ts next to `generateDataDir`
+// so the create-side and the sweep-side share a single source of truth;
+// it's imported via the package's main barrel above.
 
 /**
  * The chromium-internal subprocess orphan sweep (`org.chromium.Chromium.*`

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -130,6 +130,16 @@ export class BrowserManager {
   protected periodicSweepHandle: NodeJS.Timeout | null = null;
 
   /**
+   * Re-entrancy guard for `periodicSweep`. The interval would otherwise
+   * fire a second tick on top of a still-running first tick if a sweep
+   * ever exceeds `PERIODIC_SWEEP_INTERVAL_MS` (large `pendingCleanup`
+   * drain or slow FS). See `periodicSweep` for how this composes with
+   * cross-process safety (idempotent `deleteAsync` + mtime liveness
+   * check), which this flag does NOT provide.
+   */
+  protected sweepInFlight = false;
+
+  /**
    * Resolves once the startup orphan sweep has completed AND the periodic
    * sweep loop has been (conditionally) armed. Awaited by:
    *   - `shutdown()`, so it cannot race with `initCleanup` re-arming the
@@ -214,7 +224,7 @@ export class BrowserManager {
         // the final one, which already returned in the `isLastAttempt`
         // branch above.
         await new Promise((resolve) =>
-          global.setTimeout(resolve, REMOVE_RETRY_BACKOFF_MS[attempt]),
+          setTimeout(resolve, REMOVE_RETRY_BACKOFF_MS[attempt]),
         );
       }
     }
@@ -242,7 +252,7 @@ export class BrowserManager {
       );
       return;
     }
-    this.periodicSweepHandle = global.setInterval(() => {
+    this.periodicSweepHandle = setInterval(() => {
       this.periodicSweep().catch((err) => {
         this.log.warn(`Periodic sweep failed: ${err}`);
       });
@@ -293,7 +303,12 @@ export class BrowserManager {
       const full = path.join(baseDir, entry);
       let mtimeMs: number;
       try {
-        const stat = await fs.stat(full);
+        // lstat (not stat) so a `browserless-data-dir-*` symlink in the
+        // dataDir is treated as a non-directory and skipped — keeps
+        // `deleteAsync({ force: true })` (which weakens `del`'s default
+        // cwd protection) from following an attacker-planted link to a
+        // path outside our managed scope.
+        const stat = await fs.lstat(full);
         if (!stat.isDirectory()) continue;
         mtimeMs = stat.mtimeMs;
       } catch {
@@ -340,68 +355,106 @@ export class BrowserManager {
    *    signal: any subprocess actively using the dir would have touched it
    *    within the last few minutes, so 30 min of mtime idleness is a safe
    *    floor.
+   *
+   * Concurrency model — three layers, addressing different scopes:
+   *
+   *   - **Intra-process re-entrancy** (single instance, slow tick): the
+   *     `sweepInFlight` guard. A tick that runs longer than
+   *     PERIODIC_SWEEP_INTERVAL_MS (large pendingCleanup or slow FS)
+   *     would otherwise have its successor fire on top of it. The guard
+   *     drops the overlapping tick; the next interval picks up where
+   *     the in-flight one left off.
+   *
+   *   - **Same-process, multi-instance** (rare; e.g. tests, future SDK
+   *     compositions): `pendingCleanup` is per-instance, so Pass 1 is
+   *     trivially isolated. Pass 2 walks the shared `os.tmpdir()` and
+   *     could see the same `org.chromium.Chromium.*` entries; safety
+   *     comes from `deleteAsync({ force: true })` treating ENOENT as
+   *     success — second-place deleter exits cleanly.
+   *
+   *   - **Cross-process, shared filesystem** (multi-tenant host with
+   *     bind-mounted /tmp; not the typical dedicated/cloud-unit deploy
+   *     where each container owns its /tmp): no in-memory coordination
+   *     is possible. Same `force: true` idempotency handles concurrent
+   *     deletes; the mtime liveness check protects directories owned
+   *     by another live process (their mtime is fresh because the
+   *     other process keeps writing profile state). If a deployment
+   *     ever needs stronger cross-process guarantees, an advisory
+   *     `flock` on a lock file in dataDir is the natural addition;
+   *     none of the current consumers (1 container = 1 process) need it.
    */
   protected async periodicSweep(): Promise<void> {
-    // Pass 1: retry queue
-    for (const dir of Array.from(this.pendingCleanup)) {
-      await this.removeUserDataDir(dir);
-    }
-
-    // Pass 2: chromium-internal orphans. These live in the OS temp dir
-    // because Chrome creates them via mkdtemp, which is hard-wired to
-    // os.tmpdir() — independent of our configurable DATA_DIR. Using
-    // dirname(getDataDir()) only matches /tmp in the default config and
-    // silently misses the orphans whenever DATA_DIR points elsewhere.
-    //
-    // The OS tmp dir can be shared with other workloads, so this pass
-    // is gated behind CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true. Default off
-    // — opt in only when the SDK is the sole owner of /tmp (typical
-    // single-purpose container deployments).
-    if (!isHostChromiumCleanupEnabled()) {
-      this.log.debug(
-        'Skipping host-wide chromium-internal orphan sweep; set CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true to enable',
-      );
-      return;
-    }
-    const tmpRoot = tmpdir();
-    let entries: string[];
+    if (this.sweepInFlight) return;
+    this.sweepInFlight = true;
     try {
-      entries = await fs.readdir(tmpRoot);
-    } catch (err) {
-      this.log.debug(`Could not read tmp root "${tmpRoot}": ${err}`);
-      return;
-    }
-
-    const now = Date.now();
-    let removed = 0;
-    for (const entry of entries) {
-      if (!entry.startsWith('org.chromium.Chromium.')) continue;
-      const full = path.join(tmpRoot, entry);
-
-      let mtime: Date;
-      try {
-        const stat = await fs.stat(full);
-        if (!stat.isDirectory()) continue;
-        mtime = stat.mtime;
-      } catch {
-        // Disappeared between readdir and stat — fine, move on.
-        continue;
+      // Pass 1: retry queue
+      for (const dir of Array.from(this.pendingCleanup)) {
+        await this.removeUserDataDir(dir);
       }
 
-      if (now - mtime.getTime() < ORPHAN_IDLE_MS) continue;
-
+      // Pass 2: chromium-internal orphans. These live in the OS temp
+      // dir because Chrome creates them via mkdtemp, which is hard-
+      // wired to os.tmpdir() — independent of our configurable
+      // DATA_DIR. Using dirname(getDataDir()) only matches /tmp in
+      // the default config and silently misses the orphans whenever
+      // DATA_DIR points elsewhere.
+      //
+      // The OS tmp dir can be shared with other workloads, so this
+      // pass is gated behind CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true.
+      // Default off — opt in only when the SDK is the sole owner of
+      // /tmp (typical single-purpose container deployments).
+      if (!isHostChromiumCleanupEnabled()) {
+        this.log.debug(
+          'Skipping host-wide chromium-internal orphan sweep; set CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true to enable',
+        );
+        return;
+      }
+      const tmpRoot = tmpdir();
+      let entries: string[];
       try {
-        await deleteAsync(full, { force: true });
-        removed++;
+        entries = await fs.readdir(tmpRoot);
       } catch (err) {
-        this.log.debug(`Could not remove chromium orphan "${full}": ${err}`);
+        this.log.debug(`Could not read tmp root "${tmpRoot}": ${err}`);
+        return;
       }
-    }
 
-    if (removed > 0) {
-      this.log.info(
-        `Periodic sweep removed ${removed} stale chromium-internal orphan(s) from "${tmpRoot}"`,
-      );
+      const now = Date.now();
+      let removed = 0;
+      for (const entry of entries) {
+        if (!entry.startsWith('org.chromium.Chromium.')) continue;
+        const full = path.join(tmpRoot, entry);
+
+        let mtimeMs: number;
+        try {
+          // lstat (not stat) so a symlink planted in /tmp is treated as
+          // a non-directory and skipped — the staleness check below
+          // would otherwise follow it to its target before we know
+          // whether the target is a directory we should be touching.
+          const stat = await fs.lstat(full);
+          if (!stat.isDirectory()) continue;
+          mtimeMs = stat.mtimeMs;
+        } catch {
+          // Disappeared between readdir and stat — fine, move on.
+          continue;
+        }
+
+        if (now - mtimeMs < ORPHAN_IDLE_MS) continue;
+
+        try {
+          await deleteAsync(full, { force: true });
+          removed++;
+        } catch (err) {
+          this.log.debug(`Could not remove chromium orphan "${full}": ${err}`);
+        }
+      }
+
+      if (removed > 0) {
+        this.log.info(
+          `Periodic sweep removed ${removed} stale chromium-internal orphan(s) from "${tmpRoot}"`,
+        );
+      }
+    } finally {
+      this.sweepInFlight = false;
     }
   }
 
@@ -641,7 +694,7 @@ export class BrowserManager {
 
     if (priorTimer) {
       this.log.debug(`Deleting prior keep-until timer for "${session.id}"`);
-      global.clearTimeout(priorTimer);
+      clearTimeout(priorTimer);
     }
 
     this.log.debug(
@@ -655,7 +708,7 @@ export class BrowserManager {
       );
       this.timers.set(
         session.id,
-        global.setTimeout(() => {
+        setTimeout(() => {
           const session = this.browsers.get(browser);
           if (session) {
             this.log.trace(`Timer hit for "${session.id}"`);
@@ -1111,7 +1164,7 @@ export class BrowserManager {
     this.timers = new Map();
 
     if (this.periodicSweepHandle) {
-      global.clearInterval(this.periodicSweepHandle);
+      clearInterval(this.periodicSweepHandle);
       this.periodicSweepHandle = null;
     }
 

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -720,15 +720,31 @@ export class BrowserManager {
 
     if (!keepOpen) {
       this.log.debug(`Closing browser session`);
+
+      // Evict from the registry SYNCHRONOUSLY, before any `await`. Both
+      // `killSessions` and `complete` are fire-and-forget callers
+      // (they invoke `this.close(...)` without awaiting), so anything
+      // that happens after the first yield is invisible to them — the
+      // caller has already returned, the HTTP response has already
+      // been sent, and a subsequent `GET /sessions` or trackingId-
+      // uniqueness check on the next request would see the just-killed
+      // session as still active for the duration of `browser.close()`
+      // (potentially hundreds of ms). Pre-PR this delete was
+      // synchronous; this restores that contract while keeping the
+      // unconditional eviction (sessions with isTempDataDir=false used
+      // to leak past close() entirely) and the FD-release-race fix
+      // below.
+      this.browsers.delete(browser);
+
       // Serialise: await Chrome shutdown FIRST so it releases its file
       // handles, then delete the data-dir. Running these in parallel
       // (the previous behaviour) raced `deleteAsync` against Chrome
       // releasing its FDs and produced silent EBUSY/ENOTEMPTY failures
       // that left orphan profile dirs in `/tmp`.
       //
-      // Cleanup runs in `finally` so a `browser.close()` rejection
-      // (process already gone, IPC error, etc.) cannot skip the
-      // data-dir delete and leak the orphan we were trying to prevent.
+      // Data-dir cleanup runs in `finally` so a `browser.close()`
+      // rejection (process already gone, IPC error, etc.) cannot skip
+      // the delete and leak the orphan we were trying to prevent.
       try {
         await browser.close();
       } catch (err) {
@@ -736,13 +752,6 @@ export class BrowserManager {
           `browser.close() rejected during session close ("${session.id}"): ${err}; proceeding with cleanup`,
         );
       } finally {
-        // Evict the session from the registry unconditionally — sessions
-        // created with an explicit --user-data-dir (isTempDataDir=false)
-        // must still be removed from `this.browsers`, otherwise they
-        // leak into `getAllSessions()` and trackingId lookups as stale
-        // closed-browser entries.
-        this.browsers.delete(browser);
-
         // Data-dir removal stays guarded: only the dirs WE created
         // (isTempDataDir=true) are ours to delete. A caller-supplied
         // --user-data-dir is the caller's lifecycle to manage.

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -93,8 +93,14 @@ const SESSION_DATA_DIR_PREFIX = 'browserless-data-dir-';
  * the SDK is safe to drop into shared environments. Container
  * deployments where /tmp is owned exclusively by browserless can opt in
  * with `CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true`.
+ *
+ * Evaluated lazily on each periodic-sweep tick (rather than captured at
+ * module load) so process-level test setup can flip the env var between
+ * cases without re-importing the module — and so a runtime
+ * configuration change in long-running services would also take effect
+ * on the next tick.
  */
-const HOST_CHROMIUM_CLEANUP_ENABLED =
+const isHostChromiumCleanupEnabled = () =>
   process.env.CLEANUP_HOST_CHROMIUM_TEMP_DIRS === 'true';
 
 export class BrowserManager {
@@ -351,7 +357,7 @@ export class BrowserManager {
     // is gated behind CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true. Default off
     // — opt in only when the SDK is the sole owner of /tmp (typical
     // single-purpose container deployments).
-    if (!HOST_CHROMIUM_CLEANUP_ENABLED) {
+    if (!isHostChromiumCleanupEnabled()) {
       this.log.debug(
         'Skipping host-wide chromium-internal orphan sweep; set CLEANUP_HOST_CHROMIUM_TEMP_DIRS=true to enable',
       );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -319,6 +319,20 @@ export const removeNullStringify = (
 export const jsonOrString = (maybeJson: string): unknown | string =>
   safeParse(maybeJson) ?? maybeJson;
 
+/**
+ * Filename prefix shared by every per-session user-data-dir we create.
+ * The full directory name is `${SESSION_DATA_DIR_PREFIX}${instanceId}-${sessionId}`;
+ * the `${instanceId}-` segment is a debugging/traceability hint, not a
+ * safety boundary. Cross-instance safety in the startup sweep is enforced
+ * by an mtime staleness check, not by name filtering — see
+ * `BrowserManager.sweepOrphanDataDirs`.
+ *
+ * Lives here (next to `generateDataDir`, which writes the path) and is
+ * imported by `BrowserManager` so the create-side and sweep-side cannot
+ * drift out of sync.
+ */
+export const SESSION_DATA_DIR_PREFIX = 'browserless-data-dir-';
+
 export const generateDataDir = async (
   sessionId: string = id(),
   config: Config,
@@ -326,7 +340,7 @@ export const generateDataDir = async (
   const baseDirectory = await config.getDataDir();
   const dataDirPath = path.join(
     baseDirectory,
-    `browserless-data-dir-${sessionId}`,
+    `${SESSION_DATA_DIR_PREFIX}${sessionId}`,
   );
 
   if (await exists(dataDirPath)) {


### PR DESCRIPTION
## Summary

Closes orphan `/tmp` data-dir leaks in `BrowserManager` that accumulate over long-lived deployments and eventually fill the host disk. Confirmed in production-style workload measurements:

- **~180 MB/hr** of `/tmp` growth at synthetic high concurrency.
- The dominant grower is `/tmp/browserless-data-dirs/<id>/Default/Cache/Cache_Data/sqldb*-wal` (Chrome HTTP cache in surviving profile dirs).
- Secondary growth from `/tmp/org.chromium.Chromium.*` chromium-internal subprocess orphans accumulating at ~10 dirs/min.
- After ~6 weeks of uninterrupted runtime a single container's `/tmp` was observed at ~28 GB, occupying nearly the full root volume.

The leak is purely an SDK-side lifecycle issue, independent of any logging or storage-driver configuration.

## Root cause — five distinct gaps in BrowserManager

1. **`shutdown()` skipped data-dir cleanup entirely.** It called `b.close()` for every active session, then dropped the references — every `SIGTERM` (deploy / container restart / config change) leaked one orphan data-dir per active session.
2. **`close()` ran `browser.close()` and `removeUserDataDir` in parallel** via `Promise.all`. `deleteAsync` raced Chrome's FD release; intermittent `EBUSY`/`ENOTEMPTY` errors were caught and logged but never recovered.
3. **`removeUserDataDir` had no retry.** A single transient FS error → permanent leak.
4. **No startup sweep.** Each container recreate accumulated orphans without ever cleaning up dirs from prior runs.
5. **Chromium-internal subprocess orphans (`org.chromium.Chromium.*`) had no cleanup.** Chrome creates these via `mkdtemp` for renderer/GPU/network/url_fetcher subprocesses and only reaps them on graceful exit. Any kill (OOM, segfault, `SIGKILL`) leaves them behind.

## Changes (one file: `src/browsers/index.ts`)

1. **`shutdown()`** — capture `isTempDataDir` paths before `b.close()`, then await `removeUserDataDir` for each after browsers are closed.
2. **`close()`** — serialise: `await browser.close()` then `await removeUserDataDir`. Eliminates the FD-release race.
3. **`removeUserDataDir`** — retry 3× with 200/400/800 ms backoff. Survivors are enqueued into `pendingCleanup` for the periodic sweep to retry later.
4. **New `sweepOrphanDataDirs()`** — runs at construction, walks `dataDir`, removes any `browserless-data-dir-*` from a prior run.
5. **New `periodicSweep()`** — every 5 min, drains `pendingCleanup` and removes `/tmp/org.chromium.Chromium.*` dirs whose mtime is older than 30 min. mtime-only liveness signal — any subprocess actively using the dir would have touched it within minutes.

All five layers are additive defense-in-depth. (1)-(2) target the happy path; (3) covers transient FS errors; (4) recovers from prior-run leaks; (5) catches Chrome-internal subprocess orphans we don't otherwise manage.

## Tuning constants

```ts
const CHROMIUM_ORPHAN_IDLE_MS = 30 * 60 * 1000;   // mtime threshold for org.chromium.Chromium.*
const PERIODIC_SWEEP_INTERVAL_MS = 5 * 60 * 1000; // sweep loop cadence
const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];  // EBUSY backoff schedule
```

Each is documented inline.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/browsers/index.ts` clean
- [x] `npm run build` clean (ts + adblock + schemas + devtools + openapi)
- [x] Non-browser unit tests (`limiter`, `file-system`, `utils`, `metrics`, `shim`, `monitoring`, `function-context-validation`) — 101 passing, 1 unrelated failure (`Couldn't load route /chrome/content?(/) due to missing browser binary for "ChromeCDP"` — environment dependency, would fail on main too).
- [ ] Browser-binary-dependent tests in `routes/*/tests/` — require `npm run install:browsers`; to be run in CI / by reviewer with browsers installed.
- [ ] Soak test post-merge: sustained workload against a long-lived container, expect `/tmp` size to plateau (not monotonically grow), `org.chromium.Chromium.*` count bounded, `browserless-data-dirs/` count tracking active sessions ±5.

## Out of scope

- Unit tests for the new sweep/retry logic — recommend adding once the local browser test harness is wired up. The existing `kill-sessions` and `websocket` specs exercise the modified `close()` path indirectly.
- Where `/tmp` is mounted (overlay, bind-mount, separate volume) is an infrastructure concern downstream of this SDK fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup sweep on launch plus optional periodic sweep to reclaim orphaned browser temp data and (when enabled) idle Chromium temp dirs; host-temp cleanup can be toggled.

* **Bug Fixes**
  * Robust cleanup with retries, queued retries and periodic draining; tolerates stale or missing paths.
  * Safer session/shutdown flow: blocks new sessions during startup cleanup, aborts in-flight launches on shutdown, ensures browsers close and temp dirs removed reliably.

* **Tests**
  * Comprehensive test suite covering cleanup, periodic sweep, shutdown, and launch-vs-shutdown race scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->