### PR TITLE
fix: PLT-992 wait for node to exit in start.sh so JS shutdown handlers complete

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,14 +5,6 @@ set -e
 # so we need to kill it just in case
 [ -f /tmp/.X99-lock ] && rm -f /tmp/.X99-lock
 
-_kill_procs() {
-  kill -TERM $node
-  kill -TERM $xvfb
-}
-
-# Relay quit commands to processes
-trap _kill_procs SIGTERM SIGINT
-
 if [ -z "$DISPLAY" ]
 then
   Xvfb :99 -screen 0 1024x768x16 -nolisten tcp -nolisten unix >/dev/null 2>&1 &
@@ -20,12 +12,30 @@ then
   export DISPLAY=:99
 fi
 
-dumb-init -- node build/index.js $@ &
+dumb-init -- node build/index.js "$@" &
 node=$!
 
-wait $node
+# Forward SIGTERM/SIGINT to node so its JS handlers can run.
+_forward_term() { kill -TERM "$node" 2>/dev/null || true; }
+trap _forward_term SIGTERM SIGINT
 
-if [ ! -z "$xvfb" ]
+# Loop on wait until node actually exits. The first `wait` returns >128 the
+# moment the signal arrives, leaving node still alive and mid-cleanup; with
+# `set -e` and a single `wait`, bash would exit here and the kernel would
+# SIGKILL node before BrowserManager.shutdown() finishes deleting
+# /tmp/browserless-data-dirs/*. Looping until `kill -0` reports the PID is
+# gone preserves the SDK's graceful-shutdown contract.
+set +e
+while kill -0 "$node" 2>/dev/null; do
+  wait "$node"
+  rc=$?
+done
+set -e
+
+if [ -n "$xvfb" ]
 then
-  wait $xvfb
+  kill -TERM "$xvfb" 2>/dev/null || true
+  wait "$xvfb" 2>/dev/null || true
 fi
+
+exit "${rc:-0}"


### PR DESCRIPTION
## Summary

Pairs with #5343. Without this fix, the BrowserManager shutdown cleanup added in #5343 has no effect under `docker stop` / `docker restart` — the container exits in ~0.4s with code 143 and only `SIGTERM received` makes it to the log.

The previous trap pattern was:

```bash
_kill_procs() { kill -TERM $node; kill -TERM $xvfb; }
trap _kill_procs SIGTERM SIGINT
…
wait $node
```

When SIGTERM arrives, the trap fires and `kill -TERM $node` is sent to dumb-init. Then bash returns from the (now signal-interrupted) `wait` with status >128, and `set -e` exits the shell. Bash exiting terminates the container's PID namespace and the kernel SIGKILLs node before `BrowserManager.shutdown()` can finish deleting `/tmp/browserless-data-dirs/*`. Each deploy/restart of a busy worker leaks one orphan data-dir per active session.

Fix: loop on `wait` until `kill -0` reports the pid is gone, then surface node's real exit code so the container's exit reflects whether shutdown completed cleanly.

## Verification

Tested by overlaying the patched `start.sh` into `ghcr.io/browserless/chromium:latest` and reproducing the reproducer from #5343:

- 3 long-lived sessions held open, then `docker stop -t 30` / `docker restart`:
  - **Before:** exit 143 in ~0.4s, only `SIGTERM received` logged, 3 dirs left in `/tmp/browserless-data-dirs/`.
  - **After:** exit 0, full trace (`Closing down browser instances` → `Deleting data directory` ×3 → `HTTP Server shutdown complete` → `Shutdown complete`), data-dir empty.

## Test plan

- [x] `docker stop -t 30` cleanup verified
- [x] `docker restart` cleanup verified
- [x] Clean exit on natural process termination (no signal): node exits 0, loop exits via `kill -0`, script exits 0
- [ ] CI image build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup script reliability by enhancing signal handling and process management to ensure graceful shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->