### PR TITLE
fix(monitoring): smooth CPU overload detection to eliminate spurious 429s

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -180,6 +180,13 @@ export class Config extends EventEmitter {
   )
     .trim()
     .toLowerCase();
+  protected cpuSampleIntervalMs = +(
+    process.env.CPU_SAMPLE_INTERVAL_MS ?? '1000'
+  );
+  protected cpuEmaAlpha = +(process.env.CPU_EMA_ALPHA ?? '0.3');
+  protected cpuOverloadHysteresis = +(
+    process.env.CPU_OVERLOAD_HYSTERESIS ?? '10'
+  );
   protected maxPayloadSize = +(process.env.MAX_PAYLOAD_SIZE ?? '10485760'); // Default 10MB
   protected healthCheck = !!parseEnvVars(false, 'HEALTH');
   protected failedHealthURL = process.env.FAILED_HEALTH_URL ?? null;
@@ -267,6 +274,24 @@ export class Config extends EventEmitter {
       );
     }
     return value;
+  }
+  public getCpuSampleIntervalMs(): number {
+    return this.cpuSampleIntervalMs;
+  }
+  public getCpuEmaAlpha(): number {
+    return this.cpuEmaAlpha;
+  }
+  public getCpuOverloadHysteresis(): number {
+    return this.cpuOverloadHysteresis;
+  }
+  public setCpuSampleIntervalMs(value: number): number {
+    return (this.cpuSampleIntervalMs = value);
+  }
+  public setCpuEmaAlpha(value: number): number {
+    return (this.cpuEmaAlpha = value);
+  }
+  public setCpuOverloadHysteresis(value: number): number {
+    return (this.cpuOverloadHysteresis = value);
   }
   public getMaxPayloadSize(): number {
     return this.maxPayloadSize;

--- a/src/limiter.spec.ts
+++ b/src/limiter.spec.ts
@@ -16,8 +16,17 @@ const noop = () => undefined;
 const webHooks = Sinon.createStubInstance(WebHooks);
 const hooks = Sinon.createStubInstance(Hooks);
 
+const monitorings: Monitoring[] = [];
+const trackMonitoring = (m: Monitoring): Monitoring => {
+  monitorings.push(m);
+  return m;
+};
+
 describe(`Limiter`, () => {
   afterEach(() => {
+    monitorings.forEach((m) => m.stop());
+    monitorings.length = 0;
+
     webHooks.callFailedHealthURL.resetHistory();
     webHooks.callQueueAlertURL.resetHistory();
     webHooks.callRejectAlertURL.resetHistory();
@@ -35,7 +44,7 @@ describe(`Limiter`, () => {
       const config = new Config();
       config.setQueueAlertURL('https://one.one.one.one');
 
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       const metrics = new Metrics();
 
       config.setConcurrent(1);
@@ -72,7 +81,7 @@ describe(`Limiter`, () => {
       const args = ['one', 'two', 'three'];
       const config = new Config();
       const metrics = new Metrics();
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       config.setConcurrent(1);
       config.setQueued(0);
       config.setTimeout(-1);
@@ -100,7 +109,7 @@ describe(`Limiter`, () => {
 
   it('waits to run jobs until the first are done', async () => {
     const config = new Config();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     const metrics = new Metrics();
     config.setConcurrent(1);
     config.setQueued(1);
@@ -123,7 +132,7 @@ describe(`Limiter`, () => {
 
   it('continues to process jobs even if an earlier job errors', (d) => {
     const config = new Config();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     const metrics = new Metrics();
 
     config.setConcurrent(1);
@@ -149,7 +158,7 @@ describe(`Limiter`, () => {
 
   it('bubbles up errors', async () => {
     const config = new Config();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     const metrics = new Metrics();
     const error = new Error('WOW');
 
@@ -181,7 +190,7 @@ describe(`Limiter`, () => {
   it('calls an error handler with arguments if there are too many function calls', () => {
     const args = ['one', 'two', 'three'];
     const config = new Config();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     const metrics = new Metrics();
     config.setConcurrent(1);
     config.setQueued(0);
@@ -208,7 +217,7 @@ describe(`Limiter`, () => {
       const args = ['one', 'two', 'three'];
       const config = new Config();
       const metrics = new Metrics();
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       config.setConcurrent(1);
       config.setQueued(0);
       config.setTimeout(10);
@@ -242,7 +251,7 @@ describe(`Limiter`, () => {
   it('allows overriding the timeouts', async () => {
     const config = new Config();
     const metrics = new Metrics();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     config.setConcurrent(2);
     config.setQueued(0);
     config.setTimeout(1);
@@ -265,7 +274,7 @@ describe(`Limiter`, () => {
   it(`doesn't call a timeout handler if the job finishes in time`, async () => {
     const config = new Config();
     const metrics = new Metrics();
-    const monitoring = new Monitoring(config);
+    const monitoring = trackMonitoring(new Monitoring(config));
     config.setConcurrent(1);
     config.setQueued(0);
     config.setTimeout(20);
@@ -283,7 +292,7 @@ describe(`Limiter`, () => {
   it(`won't add items to the queue when reached`, () =>
     new Promise((r) => {
       const config = new Config();
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       const metrics = new Metrics();
       config.setConcurrent(1);
       config.setQueued(0);
@@ -314,7 +323,7 @@ describe(`Limiter`, () => {
       config.setCPULimit(1);
       config.setMemoryLimit(1);
 
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       const metrics = new Metrics();
       config.setConcurrent(10);
       config.setQueued(10);
@@ -341,7 +350,7 @@ describe(`Limiter`, () => {
       config.setMemoryLimit(100);
 
       const metrics = new Metrics();
-      const monitoring = new Monitoring(config);
+      const monitoring = trackMonitoring(new Monitoring(config));
       config.setConcurrent(10);
       config.setQueued(10);
       config.setTimeout(-1);

--- a/src/monitoring.spec.ts
+++ b/src/monitoring.spec.ts
@@ -4,7 +4,9 @@ import {
   CgroupV2Source,
   Config,
   HostSource,
+  IResourceLoad,
   Logger,
+  MachineStatsSource,
   Monitoring,
   detectMachineStatsSource,
   parseCpuMax,
@@ -488,6 +490,7 @@ describe('Monitoring source wiring', () => {
     expect(logSpy.calledOnce).to.be.true;
     expect(logSpy.firstCall.args[0]).to.match(/source.*fake/i);
     expect(monitoring).to.exist;
+    monitoring.stop();
   });
 
   it('delegates getMachineStats() to the configured source', async () => {
@@ -499,6 +502,7 @@ describe('Monitoring source wiring', () => {
     const monitoring = new Monitoring(config, fakeSource);
     const stats = await monitoring.getMachineStats();
     expect(stats).to.deep.equal({ cpu: 0.7, memory: 0.3 });
+    monitoring.stop();
   });
 
   it('honors MACHINE_STATS_SOURCE=host even on a cgroup host', () => {
@@ -507,5 +511,165 @@ describe('Monitoring source wiring', () => {
     const monitoring = new Monitoring(config);
     // We cannot read protected statsSource; verify behavior via getMachineStats path on dev hosts (HostSource exists). Simply expect construction to succeed.
     expect(monitoring).to.exist;
+    monitoring.stop();
+  });
+});
+
+class ControlledSource implements MachineStatsSource {
+  public readonly name = 'controlled';
+  protected values: Array<{ cpu: number | null; memory: number | null }> = [];
+  protected callCount = 0;
+
+  public setSequence(
+    values: Array<{ cpu: number | null; memory: number | null }>,
+  ) {
+    this.values = values;
+    this.callCount = 0;
+  }
+
+  public async read(): Promise<IResourceLoad> {
+    const i = this.callCount;
+    this.callCount++;
+    if (this.values.length === 0) {
+      return { cpu: 0, memory: 0 };
+    }
+    return this.values[Math.min(i, this.values.length - 1)];
+  }
+}
+
+class TestMonitoring extends Monitoring {
+  public async runSample(): Promise<void> {
+    return this.sample();
+  }
+  public seedCpu(value: number | null): void {
+    this.smoothedCpu = value;
+  }
+  public peekCpuOverloadedState(): boolean {
+    return this.cpuOverloadedState;
+  }
+}
+
+const makeConfig = (overrides: Partial<Record<string, number>> = {}) => {
+  const config = new Config();
+  // Push the timer well beyond the test's lifetime so only manual runSample()
+  // calls drive the EMA — keeps assertions deterministic.
+  config.setCpuSampleIntervalMs(60_000);
+  config.setCpuEmaAlpha(overrides.alpha ?? 0.3);
+  config.setCpuOverloadHysteresis(overrides.hysteresis ?? 10);
+  return config;
+};
+
+describe('Monitoring smoothing and hysteresis', () => {
+  afterEach(() => Sinon.restore());
+
+  it('smooths CPU samples via EMA so a single spike does not trip the threshold', async () => {
+    const config = makeConfig();
+    config.enableHealthChecks(true);
+    config.setCPULimit(80);
+
+    const source = new ControlledSource();
+    source.setSequence([
+      { cpu: 0.6, memory: 0 },
+      { cpu: 0.18, memory: 0 },
+      { cpu: 0.9, memory: 0 },
+      { cpu: 0.22, memory: 0 },
+    ]);
+
+    const monitoring = new TestMonitoring(config, source, () => {});
+    // Constructor consumed the first sample (0.6 → seeded 60%).
+    await monitoring.runSample(); // 0.18 → smoothed ~47.4
+    await monitoring.runSample(); // 0.90 → smoothed ~60.2
+    await monitoring.runSample(); // 0.22 → smoothed ~48.7
+
+    const { cpuInt, cpuOverloaded } = await monitoring.overloaded();
+    expect(cpuInt).to.be.lessThan(80);
+    expect(cpuOverloaded).to.be.false;
+    monitoring.stop();
+  });
+
+  it('enters overloaded only after sustained high load', async () => {
+    const config = makeConfig();
+    config.enableHealthChecks(true);
+    config.setCPULimit(80);
+
+    const source = new ControlledSource();
+    source.setSequence([{ cpu: 0.85, memory: 0 }]);
+
+    const monitoring = new TestMonitoring(config, source, () => {});
+    // Constructor consumes the first 0.85 → smoothed = 85.
+    const { cpuInt, cpuOverloaded } = await monitoring.overloaded();
+    expect(cpuInt).to.equal(85);
+    expect(cpuOverloaded).to.be.true;
+    monitoring.stop();
+  });
+
+  it('applies hysteresis: stays overloaded between exit and enter thresholds', async () => {
+    const config = makeConfig({ hysteresis: 10 });
+    config.enableHealthChecks(true);
+    config.setCPULimit(80);
+
+    const source = new ControlledSource();
+    source.setSequence([{ cpu: 0, memory: 0 }]);
+
+    const monitoring = new TestMonitoring(config, source, () => {});
+    await monitoring.runSample();
+
+    monitoring.seedCpu(85);
+    let result = await monitoring.overloaded();
+    expect(result.cpuOverloaded, 'enters overloaded at >= 80').to.be.true;
+
+    monitoring.seedCpu(75);
+    result = await monitoring.overloaded();
+    expect(result.cpuOverloaded, 'holds at 75 (above exit 70)').to.be.true;
+
+    monitoring.seedCpu(69);
+    result = await monitoring.overloaded();
+    expect(result.cpuOverloaded, 'exits below 70').to.be.false;
+    monitoring.stop();
+  });
+
+  it('blocks overloaded() until the first sample resolves', async () => {
+    const config = makeConfig();
+    config.enableHealthChecks(true);
+    config.setCPULimit(80);
+
+    let resolveRead!: (v: IResourceLoad) => void;
+    const source: MachineStatsSource = {
+      name: 'pending',
+      read: () =>
+        new Promise<IResourceLoad>((r) => {
+          resolveRead = r;
+        }),
+    };
+
+    const monitoring = new TestMonitoring(config, source, () => {});
+    const overloadedPromise = monitoring.overloaded();
+
+    let resolved = false;
+    overloadedPromise.then(() => {
+      resolved = true;
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(resolved, 'should not resolve before first sample').to.be.false;
+
+    resolveRead({ cpu: 0.5, memory: 0.4 });
+    const result = await overloadedPromise;
+    expect(result.cpuInt).to.equal(50);
+    expect(result.cpuOverloaded).to.be.false;
+    monitoring.stop();
+  });
+
+  it('stop() clears the sampler interval', async () => {
+    const config = makeConfig();
+    const source = new ControlledSource();
+    source.setSequence([{ cpu: 0.1, memory: 0 }]);
+
+    const monitoring = new TestMonitoring(config, source, () => {});
+    await monitoring.runSample();
+
+    const clearSpy = Sinon.spy(global, 'clearInterval');
+    monitoring.stop();
+    expect(clearSpy.calledOnce).to.be.true;
+    clearSpy.restore();
   });
 });

--- a/src/monitoring.ts
+++ b/src/monitoring.ts
@@ -359,6 +359,16 @@ export function detectMachineStatsSource(
 export class Monitoring extends EventEmitter {
   protected log = new Logger('hardware');
   protected statsSource: MachineStatsSource;
+  // EMA-smoothed CPU percent (0-100). Null until the first sample lands.
+  protected smoothedCpu: number | null = null;
+  // Most recent memory fraction (0-1). Memory is stable; no smoothing needed.
+  protected cachedMemory: number | null = null;
+  // Hysteresis state — flipped on enter/exit thresholds, not on every sample.
+  protected cpuOverloadedState = false;
+  protected samplerHandle: NodeJS.Timeout;
+  // Resolves once the first sample completes, so callers awaiting overloaded()
+  // before the timer has ticked still get a real reading instead of fail-open.
+  protected firstSamplePromise: Promise<void>;
 
   constructor(
     protected config: Config,
@@ -370,6 +380,34 @@ export class Monitoring extends EventEmitter {
       statsSource ?? detectMachineStatsSource(config.getMachineStatsSource());
     const log = logFn ?? ((msg: string) => this.log.info(msg));
     log(`Machine stats source: ${this.statsSource.name}`);
+
+    this.firstSamplePromise = this.sample();
+    this.samplerHandle = setInterval(
+      () => {
+        this.sample();
+      },
+      this.config.getCpuSampleIntervalMs(),
+    );
+    // Don't keep the event loop alive solely for this timer (test runners hang otherwise).
+    this.samplerHandle.unref();
+  }
+
+  protected async sample(): Promise<void> {
+    const { cpu, memory } = await this.statsSource.read();
+
+    if (cpu !== null) {
+      // statsSource returns 0-1 fraction; smoothed value is stored as 0-100 percent.
+      const current = cpu * 100;
+      const alpha = this.config.getCpuEmaAlpha();
+      this.smoothedCpu =
+        this.smoothedCpu === null
+          ? current
+          : alpha * current + (1 - alpha) * this.smoothedCpu;
+    }
+
+    if (memory !== null) {
+      this.cachedMemory = memory;
+    }
   }
 
   public async getMachineStats(): Promise<IResourceLoad> {
@@ -382,19 +420,40 @@ export class Monitoring extends EventEmitter {
     memoryInt: number | null;
     memoryOverloaded: boolean;
   }> {
-    const { cpu, memory } = await this.getMachineStats();
-    const cpuInt = cpu && Math.ceil(cpu * 100);
-    const memoryInt = memory && Math.ceil(memory * 100);
+    if (this.smoothedCpu === null) {
+      await this.firstSamplePromise;
+    }
 
-    this.log.debug(
-      `Checking overload status: CPU ${cpuInt}% Memory ${memoryInt}%`,
-    );
+    const cpuInt =
+      this.smoothedCpu === null ? null : Math.ceil(this.smoothedCpu);
+    const memoryInt =
+      this.cachedMemory === null ? null : Math.ceil(this.cachedMemory * 100);
 
-    const cpuOverloaded = !!(cpuInt && cpuInt >= this.config.getCPULimit());
+    const limit = this.config.getCPULimit();
+    const hysteresis = this.config.getCpuOverloadHysteresis();
+
+    if (cpuInt !== null) {
+      if (!this.cpuOverloadedState && cpuInt >= limit) {
+        this.cpuOverloadedState = true;
+      } else if (this.cpuOverloadedState && cpuInt < limit - hysteresis) {
+        this.cpuOverloadedState = false;
+      }
+    }
+
     const memoryOverloaded = !!(
       memoryInt && memoryInt >= this.config.getMemoryLimit()
     );
-    return { cpuInt, cpuOverloaded, memoryInt, memoryOverloaded };
+
+    this.log.debug(
+      `Checking overload status: CPU ${cpuInt}% (smoothed) Memory ${memoryInt}%`,
+    );
+
+    return {
+      cpuInt,
+      cpuOverloaded: this.cpuOverloadedState,
+      memoryInt,
+      memoryOverloaded,
+    };
   }
 
   /**
@@ -408,5 +467,7 @@ export class Monitoring extends EventEmitter {
   /**
    * Left blank for downstream SDK modules to optionally implement.
    */
-  public stop() {}
+  public stop() {
+    clearInterval(this.samplerHandle);
+  }
 }


### PR DESCRIPTION
## Summary

- Layers EMA smoothing, dual-threshold hysteresis, and a background sampler on top of the existing `MachineStatsSource` architecture (HostSource / CgroupV2Source / CgroupV1Source preserved).
- Eliminates spurious 429s caused by transient CPU spikes on production workers (CPU bouncing 10/90/10 within seconds previously triggered rejections).
- Backwards compatible: `getMachineStats()` (telemetry path) returns raw values; `overloaded()` keeps the same shape, only the CPU signal is smoothed.

## What changed

| File | Change |
|---|---|
| `src/monitoring.ts` | `Monitoring` class gains `smoothedCpu`, `cachedMemory`, `cpuOverloadedState`, `samplerHandle`, `firstSamplePromise`. New `sample()` method updates the EMA from `statsSource.read()`. `overloaded()` reads cached state and applies hysteresis. `stop()` clears the interval. All `MachineStatsSource` infrastructure (HostSource/CgroupV2/CgroupV1/parsers/`detectMachineStatsSource`) is untouched. |
| `src/config.ts` | Three new env vars + getters/setters: `CPU_SAMPLE_INTERVAL_MS` (1000), `CPU_EMA_ALPHA` (0.3), `CPU_OVERLOAD_HYSTERESIS` (10). Existing `MACHINE_STATS_SOURCE` knob preserved. |
| `src/monitoring.spec.ts` | New `Monitoring smoothing and hysteresis` describe block (5 tests). Existing `Monitoring source wiring` tests now call `monitoring.stop()` to clean up the new sampler interval. |
| `src/limiter.spec.ts` | `afterEach` now calls `stop()` on every `Monitoring` instance the suite created (avoids leaked intervals). |

## Behavior

With `MAX_CPU_PERCENT=80`, `CPU_EMA_ALPHA=0.3`, `CPU_OVERLOAD_HYSTERESIS=10`:

| Tick | Raw CPU | Smoothed | Today | After |
|---|---|---|---|---|
| 1 | 60 | 60.0 | normal | normal |
| 2 | 18 | 47.4 | normal | normal |
| 3 | 90 | 60.2 | **429** | normal |
| 4 | 22 | 48.7 | normal | normal |
| 5 | 85 | 59.6 | **429** | normal |
| ... sustained 85+ ... | | | | |
| 9 | 88 | 82.2 | **429** | **429** (real load) |
| 10 | 75 | 80.0 | normal | **429** (hysteresis holds) |
| 12 | 50 | 67.9 | normal | normal (exits at <70) |

## Recommended operational change

Bump `MAX_CPU_PERCENT` from 80 → 85 once this ships. The smoothed signal is a more reliable "host is genuinely under sustained pressure" indicator, so you can let it run higher before tripping. Terraform PR follows.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build:tests`
- [x] `npx mocha --no-package build/limiter.spec.js build/monitoring.spec.js` — 61/61 passing (Limiter, HostSource, parsers, CgroupV1/V2 sources, detect, source wiring, smoothing/hysteresis)
- [ ] Deploy to a v2 usage worker and verify in the saturation dashboard:
  - 429 rate drops materially compared to current baseline
  - "Checking overload status" debug logs show steady, slow-changing values rather than 10/90/10 swings
  - Real saturation events still trip overload within a few seconds

## Linear

PLT-1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU monitoring parameters for fine-tuning system load detection.
  * Implemented exponential moving average (EMA) smoothing for CPU metrics and hysteresis-based overload detection to improve stability.

* **Tests**
  * Enhanced test reliability with improved monitoring lifecycle management and comprehensive coverage of CPU monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->