### PR TITLE
fix: consolidate user-data-dir cleanup across all session-end paths

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -162,10 +162,11 @@ export class ChromiumCDP extends EventEmitter {
       this.emit('close');
       this.cleanListeners();
       this.browser.removeAllListeners();
-      this.browser.close();
+      const browser = this.browser;
       this.running = false;
       this.browser = null;
       this.browserWSEndpoint = null;
+      await browser.close().catch(() => undefined);
     }
   }
 
@@ -251,6 +252,28 @@ export class ChromiumCDP extends EventEmitter {
     );
     this.browser = (await launch(finalOptions)) as Browser;
     this.browser.on('targetcreated', this.onTargetCreated.bind(this));
+    // Propagate unexpected disconnect (Chrome OOM, segfault, host SIGKILL)
+    // as a `close` event on the wrapper. Without this, a spontaneous
+    // exit leaves the BrowserlessSession in BrowserManager.browsers
+    // forever and the user-data-dir leaks. The `if (this.running)`
+    // guard skips re-entry during the normal close() path (which sets
+    // running=false before awaiting the inner close).
+    this.browser.once('disconnected', () => {
+      if (this.running) {
+        this.logger.info(
+          `${this.constructor.name} disconnected unexpectedly, emitting close`,
+        );
+        this.emit('close');
+        this.cleanListeners();
+        // `?.` because `this.emit('close')` above recursively re-enters
+        // wrapper.close() (via BrowserManager's close listener) and nulls
+        // this.browser synchronously before control returns here.
+        this.browser?.removeAllListeners();
+        this.running = false;
+        this.browser = null;
+        this.browserWSEndpoint = null;
+      }
+    });
     this.running = true;
     this.browserWSEndpoint = this.browser.wsEndpoint();
     this.logger.info(

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -105,10 +105,11 @@ class BasePlaywright extends EventEmitter {
       this.socket?.destroy();
       this.emit('close');
       this.cleanListeners();
-      this.browser.close();
+      const browser = this.browser;
       this.running = false;
       this.browser = null;
       this.browserWSEndpoint = null;
+      await browser.close().catch(() => undefined);
     }
   }
 
@@ -162,6 +163,24 @@ class BasePlaywright extends EventEmitter {
     this.running = true;
     this.browserWSEndpoint = browserWSEndpoint;
     this.browser = browser;
+
+    // Mirror ChromiumCDP: propagate unexpected playwright server exit
+    // as a wrapper-level `close` so BrowserManager can clean up the
+    // session and its user-data-dir. Guard against re-entry from the
+    // normal close() path.
+    browser.once('close', () => {
+      if (this.running) {
+        this.logger.info(
+          `${this.constructor.name} closed unexpectedly, emitting close`,
+        );
+        this.socket?.destroy();
+        this.emit('close');
+        this.cleanListeners();
+        this.running = false;
+        this.browser = null;
+        this.browserWSEndpoint = null;
+      }
+    });
 
     return browser;
   }

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -40,6 +40,11 @@ import { deleteAsync } from 'del';
 import micromatch from 'micromatch';
 import path from 'path';
 
+// Chrome releases its profile-dir file handles within a few hundred ms
+// of `browser.close()` resolving, so 200/400/800 ms covers the realistic
+// EBUSY/ENOTEMPTY window.
+const REMOVE_RETRY_BACKOFF_MS = [200, 400, 800];
+
 export class BrowserManager {
   protected reconnectionPatterns = ['/devtools/browser', '/function/connect'];
   protected browsers: Map<BrowserInstance, BrowserlessSession> = new Map();
@@ -67,13 +72,29 @@ export class BrowserManager {
   }
 
   protected async removeUserDataDir(userDataDir: string | null) {
-    if (userDataDir && (await exists(userDataDir))) {
-      this.log.debug(`Deleting data directory "${userDataDir}"`);
-      await deleteAsync(userDataDir, { force: true }).catch((err) => {
-        this.log.error(
-          `Error cleaning up user-data-dir "${err}" at ${userDataDir}`,
+    if (!userDataDir || !(await exists(userDataDir))) return;
+    this.log.debug(`Deleting data directory "${userDataDir}"`);
+
+    // Retry with backoff to absorb the transient EBUSY/ENOTEMPTY window
+    // that `del` sometimes hits while Chrome is still releasing handles
+    // on the profile directory. Without retries this manifests as a
+    // single logged error and a leaked dir.
+    const totalAttempts = REMOVE_RETRY_BACKOFF_MS.length + 1;
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      try {
+        await deleteAsync(userDataDir, { force: true });
+        return;
+      } catch (err) {
+        if (attempt === totalAttempts - 1) {
+          this.log.error(
+            `Failed to remove user-data-dir "${userDataDir}" after ${totalAttempts} attempts: ${err}`,
+          );
+          return;
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, REMOVE_RETRY_BACKOFF_MS[attempt]),
         );
-      });
+      }
     }
   }
 
@@ -309,12 +330,12 @@ export class BrowserManager {
     const connected = session.numbConnected;
     const hasKeepUntil = keepUntil > now;
     const keepOpen = (connected > 0 || hasKeepUntil) && !force;
-    const cleanupACtions: Array<() => Promise<void>> = [];
     const priorTimer = this.timers.get(session.id);
 
     if (priorTimer) {
       this.log.debug(`Deleting prior keep-until timer for "${session.id}"`);
       global.clearTimeout(priorTimer);
+      this.timers.delete(session.id);
     }
 
     this.log.debug(
@@ -332,7 +353,11 @@ export class BrowserManager {
           const session = this.browsers.get(browser);
           if (session) {
             this.log.trace(`Timer hit for "${session.id}"`);
-            this.close(browser, session);
+            this.close(browser, session).catch((err) =>
+              this.log.error(
+                `Error closing session "${session.id}" from timer: ${err}`,
+              ),
+            );
           }
         }, timeout),
       );
@@ -340,17 +365,33 @@ export class BrowserManager {
 
     if (!keepOpen) {
       this.log.debug(`Closing browser session`);
-      cleanupACtions.push(() => browser.close());
+      // Evict synchronously, before any `await`. Both `killSessions` and
+      // `complete` invoke this.close() without awaiting; if eviction ran
+      // after the first yield, a `/kill` would return 204 with the
+      // session still visible to subsequent `/sessions` and trackingId
+      // checks for the duration of browser.close() (hundreds of ms).
+      this.browsers.delete(browser);
 
-      if (session.isTempDataDir) {
-        this.log.debug(
-          `Deleting "${session.userDataDir}" user-data-dir and session from memory`,
+      // Serialise browser shutdown then data-dir removal: chromium
+      // releases its file handles when `browser.close()` resolves, so
+      // running `removeUserDataDir` in parallel produced silent EBUSY
+      // failures and orphaned profile directories. The `finally` block
+      // guarantees data-dir cleanup runs even if `browser.close()`
+      // rejects (process already gone, IPC error, etc.).
+      try {
+        await browser.close();
+      } catch (err) {
+        this.log.warn(
+          `browser.close() rejected for session "${session.id}": ${err}; proceeding with data-dir cleanup`,
         );
-        this.browsers.delete(browser);
-        cleanupACtions.push(() => this.removeUserDataDir(session.userDataDir));
+      } finally {
+        if (session.isTempDataDir) {
+          this.log.debug(
+            `Deleting "${session.userDataDir}" user-data-dir`,
+          );
+          await this.removeUserDataDir(session.userDataDir);
+        }
       }
-
-      await Promise.all(cleanupACtions.map((a) => a()));
     }
   }
 
@@ -367,7 +408,11 @@ export class BrowserManager {
         this.log.debug(
           `Closing browser via killSessions BrowserId: "${session.id}", trackingId: "${session.trackingId}"`,
         );
-        this.close(browser, session, true);
+        this.close(browser, session, true).catch((err) =>
+          this.log.error(
+            `Error in killSessions for "${session.id}": ${err}`,
+          ),
+        );
         closed++;
       }
     }
@@ -413,7 +458,11 @@ export class BrowserManager {
 
     --session.numbConnected;
 
-    this.close(browser, session);
+    this.close(browser, session).catch((err) =>
+      this.log.error(
+        `Error completing session "${session.id}": ${err}`,
+      ),
+    );
   }
 
   public async getBrowserForRequest(
@@ -622,13 +671,30 @@ export class BrowserManager {
     const match = (req.headers['user-agent'] || '').match(pwVersionRegex);
     const pwVersion = match ? match[1] : 'default';
 
-    await browser.launch({
-      options: launchOptions as BrowserServerOptions,
-      pwVersion,
-      req,
-      stealth: launchOptions?.stealth,
-    });
-    await this.hooks.browser({ browser, req });
+    try {
+      await browser.launch({
+        options: launchOptions as BrowserServerOptions,
+        pwVersion,
+        req,
+        stealth: launchOptions?.stealth,
+      });
+      await this.hooks.browser({ browser, req });
+    } catch (err) {
+      // No BrowserlessSession exists yet at this point, so the normal
+      // close path cannot reclaim the auto-generated user-data-dir.
+      // Tear down both explicitly before rethrowing. Manual data-dirs
+      // (caller-supplied via --user-data-dir or launchOptions.userDataDir)
+      // are the caller's lifecycle to manage and stay put.
+      await browser.close().catch((closeErr) =>
+        this.log.debug(
+          `browser.close() during launch-failure cleanup also failed: ${closeErr}`,
+        ),
+      );
+      if (!manualUserDataDir && userDataDir) {
+        await this.removeUserDataDir(userDataDir);
+      }
+      throw err;
+    }
 
     const sessionId = getFinalPathSegment(browser.wsEndpoint()!)!;
     const session: BrowserlessSession = {
@@ -659,15 +725,43 @@ export class BrowserManager {
       (router.onNewPage || noop)(req.parsed || '', page);
     });
 
+    // A still-present session here means nobody called close() — the
+    // underlying process exited on its own (OOM, segfault, SIGKILL).
+    // Route through the unified close path so SDK overrides participate.
+    browser.once('close', () => {
+      const orphaned = this.browsers.get(browser);
+      if (!orphaned) return;
+      this.log.info(
+        `Session "${orphaned.id}" closed unexpectedly, cleaning up`,
+      );
+      this.close(browser, orphaned, true).catch((err) =>
+        this.log.error(
+          `Error cleaning up orphaned session "${orphaned.id}": ${err}`,
+        ),
+      );
+    });
+
     return browser;
   }
 
   public async shutdown(): Promise<void> {
     this.log.info(`Closing down browser instances`);
     const sessions = Array.from(this.browsers);
-    await Promise.all(sessions.map(([b]) => b.close()));
-    const timers = Array.from(this.timers);
-    await Promise.all(timers.map(([, timer]) => clearInterval(timer)));
+    // Route each session through `this.close(..., force=true)` so the
+    // unified close path runs: synchronous eviction, serialised browser
+    // shutdown then data-dir removal, retries, and the `finally` guard.
+    // Errors per-session are logged and do not abort the rest of
+    // shutdown — losing one session's cleanup must not block the
+    // others or leave the process hanging.
+    await Promise.all(
+      sessions.map(([browser, session]) =>
+        this.close(browser, session, true).catch((err) =>
+          this.log.error(
+            `Error during shutdown cleanup for session "${session.id}": ${err}`,
+          ),
+        ),
+      ),
+    );
     this.timers.forEach((t) => clearTimeout(t));
     this.browsers = new Map();
     this.timers = new Map();

--- a/src/routes/chromium/tests/websocket.spec.ts
+++ b/src/routes/chromium/tests/websocket.spec.ts
@@ -2,6 +2,7 @@ import {
   Browserless,
   BrowserlessSessionJSON,
   Config,
+  Hooks,
   Metrics,
   exists,
   fetchJson,
@@ -10,6 +11,7 @@ import {
 import { chromium } from 'playwright-core';
 import { deleteAsync } from 'del';
 import { expect } from 'chai';
+import fs from 'fs/promises';
 import puppeteer from 'puppeteer-core';
 
 describe('Chromium WebSocket API', function () {
@@ -17,10 +19,27 @@ describe('Chromium WebSocket API', function () {
 
   const start = ({
     config = new Config(),
+    hooks,
     metrics = new Metrics(),
-  }: { config?: Config; metrics?: Metrics } = {}) => {
-    browserless = new Browserless({ config, metrics });
+  }: { config?: Config; hooks?: Hooks; metrics?: Metrics } = {}) => {
+    browserless = new Browserless({ config, hooks, metrics });
     return browserless.start();
+  };
+
+  // Bounded polling for cleanup assertions. Filesystem + process-exit
+  // timing is non-deterministic, so a fixed sleep flakes on slower CI.
+  // Throws on timeout so a failure is loud, not silent.
+  const waitFor = async (
+    predicate: () => Promise<boolean>,
+    timeoutMs = 5000,
+    intervalMs = 50,
+  ): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (await predicate()) return;
+      await sleep(intervalMs);
+    }
+    throw new Error(`waitFor timed out after ${timeoutMs}ms`);
   };
 
   afterEach(async () => {
@@ -218,9 +237,158 @@ describe('Chromium WebSocket API', function () {
     expect(await exists(userDataDir)).to.be.true;
 
     await browser.disconnect();
-    await sleep(1000);
+    await waitFor(async () => !(await exists(userDataDir)));
+  });
 
-    expect(await exists(userDataDir)).to.be.false;
+  it('deletes user-data-dirs when launch fails', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    const hooks = new Hooks();
+    hooks.browser = async () => {
+      throw new Error('simulated post-launch hook failure');
+    };
+    await start({ config, hooks, metrics });
+
+    const baseDir = await config.getDataDir();
+    const before = await fs.readdir(baseDir).catch((): string[] => []);
+
+    const attempts = 3;
+    const results = await Promise.all(
+      Array.from({ length: attempts }, () =>
+        puppeteer
+          .connect({
+            browserWSEndpoint: `ws://localhost:3000/chromium?token=browserless`,
+          })
+          .then(() => 'connected')
+          .catch((err: Error) => err.message),
+      ),
+    );
+    expect(results.every((r) => r !== 'connected')).to.be.true;
+    // Distinguish from infrastructure failures (ECONNREFUSED, bad
+    // token → 401, etc.) which would never have produced a data-dir
+    // in the first place. The hook throwing produces a 500 from the
+    // route handler.
+    expect(results.every((r) => r.includes('500'))).to.be.true;
+
+    await waitFor(async () => {
+      const after = await fs.readdir(baseDir).catch((): string[] => []);
+      return after.every((entry) => before.includes(entry));
+    });
+
+    const after = await fs.readdir(baseDir).catch(() => []);
+    const leaked = after.filter((entry) => !before.includes(entry));
+    expect(leaked).to.deep.equal([]);
+  });
+
+  it('deletes user-data-dirs when the server shuts down with active sessions', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const baseDir = await config.getDataDir();
+    const before = await fs.readdir(baseDir).catch((): string[] => []);
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=browserless`,
+    });
+
+    const sessionsRes = await fetch(
+      'http://localhost:3000/sessions?token=browserless',
+    );
+    expect(sessionsRes.status).to.equal(200);
+    const [{ userDataDir }] = await sessionsRes.json();
+    expect(await exists(userDataDir)).to.be.true;
+
+    // Stop WITHOUT first disconnecting the client; mirrors the
+    // SIGTERM-with-active-sessions case that was leaking.
+    await browserless.stop();
+
+    await waitFor(async () => !(await exists(userDataDir)));
+    const after = await fs.readdir(baseDir).catch(() => []);
+    expect(after.filter((e) => !before.includes(e))).to.deep.equal([]);
+
+    await browser.disconnect().catch(() => undefined);
+
+    // Replace the shared `browserless` with a stub so the global
+    // `afterEach` does not call stop() a second time on an already
+    // shut-down HTTP server.
+    browserless = {
+      stop: () => Promise.resolve([]),
+    } as unknown as Browserless;
+  });
+
+  it('deletes user-data-dirs when the session is killed via /kill', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=browserless`,
+    });
+
+    const preKillRes = await fetch(
+      'http://localhost:3000/sessions?token=browserless',
+    );
+    expect(preKillRes.status).to.equal(200);
+    const [session] = await preKillRes.json();
+    const userDataDir: string = session.userDataDir;
+    const killURL: string = session.killURL;
+    expect(await exists(userDataDir)).to.be.true;
+
+    const killResponse = await fetch(`${killURL}?token=browserless`, {
+      method: 'GET',
+    });
+    expect(killResponse.status).to.equal(204);
+
+    // Synchronous-eviction contract: by the time /kill returns, the
+    // session must no longer be visible to /sessions, even though
+    // browser.close() may still be running.
+    const postKillRes = await fetch(
+      'http://localhost:3000/sessions?token=browserless',
+    );
+    expect(postKillRes.status).to.equal(200);
+    expect(await postKillRes.json()).to.deep.equal([]);
+
+    await waitFor(async () => !(await exists(userDataDir)));
+    await browser.disconnect().catch(() => undefined);
+  });
+
+  it('deletes user-data-dirs when the browser exits unexpectedly', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    const client = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=browserless`,
+    });
+
+    const sessionsRes = await fetch(
+      'http://localhost:3000/sessions?token=browserless',
+    );
+    expect(sessionsRes.status).to.equal(200);
+    const [{ userDataDir }] = await sessionsRes.json();
+    expect(await exists(userDataDir)).to.be.true;
+
+    // Reach into the manager to grab the wrapper, then kill the
+    // underlying chromium process directly. This simulates an OOM
+    // kill from the kernel: no graceful shutdown, no WebSocket close
+    // initiated by the peer.
+    const browserManager = (
+      browserless as unknown as { browserManager: { browsers: Map<unknown, unknown> } }
+    ).browserManager;
+    const [wrapper] = Array.from(browserManager.browsers.keys()) as Array<{
+      process: () => { kill: (sig: string) => void } | null;
+    }>;
+    const chromiumProcess = wrapper.process();
+    expect(chromiumProcess).to.not.be.null;
+    chromiumProcess!.kill('SIGKILL');
+
+    await waitFor(async () => !(await exists(userDataDir)), 10000);
+    await client.disconnect().catch(() => undefined);
   });
 
   it('allows specified user-data-dirs', async () => {


### PR DESCRIPTION
## Summary

`/tmp/browserless-data-dirs/*` entries can accumulate over long-lived deployments
because cleanup runs were missing or racy on several lifecycle paths. Reported
in #2622. Three open PRs were targeting overlapping pieces (#5343, #5344,
#5350). This PR consolidates the strongest piece from each onto a single
trunk so they don't conflict at merge.

## Failure modes addressed

1. **Server shutdown with active sessions.** `BrowserManager.shutdown` called
   `b.close()` and dropped the `BrowserlessSession` on the floor — every
   `SIGTERM` / `SIGINT` / process exit leaked one auto-generated data-dir per
   attached session.
2. **FD-release race in `close()`.** `browser.close()` and `removeUserDataDir`
   ran in parallel via `Promise.all`, so `del` walked the directory while
   chromium was still releasing file handles into it (silent `EBUSY` /
   `ENOTEMPTY`).
3. **Inner `browser.close()` was fire-and-forgot** in `ChromiumCDP.close` and
   `BasePlaywright.close` — the wrapper resolved before chromium had actually
   exited, which is what made (2) reachable in the first place.
4. **Spontaneous browser exit** (OOM, segfault, host SIGKILL on the chromium
   process). The `BrowserlessSession` stayed in `this.browsers` forever and
   the data-dir leaked, because nothing invoked `BrowserManager.close()`.
5. **Launch failure.** When `browser.launch()` or `hooks.browser` threw, no
   `BrowserlessSession` existed yet to drive the normal close path, so the
   auto-generated data-dir leaked even though no usable session was returned.

## Changes

### `src/browsers/browsers.cdp.ts` — `ChromiumCDP`
- `close()` now awaits the inner puppeteer `Browser.close()` instead of
  fire-and-forget.
- After launch, install a `disconnected` listener that re-emits `close` on
  the wrapper if the underlying process exits unexpectedly.

### `src/browsers/browsers.playwright.ts` — `BasePlaywright`
- Mirror of the above for Playwright's `BrowserServer` (`.once('close')`).

### `src/browsers/index.ts` — `BrowserManager`
- `removeUserDataDir` now does 4 attempts total with `[200, 400, 800] ms`
  backoff between retries. Absorbs the transient `EBUSY` / `ENOTEMPTY` window
  while chromium releases handles. Final-attempt failures log at `error`
  (the only signal for a genuine leak after retries exhaust).
- `close()`:
  - **Synchronous registry eviction** — `this.browsers.delete(browser)` runs
    before any `await`. Both `killSessions` and `complete` call `close()`
    fire-and-forget; a post-yield delete would leave the session externally
    visible to `/sessions` and `trackingId` checks for the duration of
    `browser.close()`.
  - **Serialized cleanup** — `await browser.close()` then
    `await removeUserDataDir`. The previous `Promise.all` raced.
  - **`finally`-guarded data-dir removal** — a `browser.close()` rejection
    no longer skips the delete.
  - Cleared keep-until timer's Map entry is now removed (small bundled
    bookkeeping fix — `clearTimeout` previously left a stale Map entry).
- Launch path wrapped in `try/catch`: on throw from `browser.launch()` or
  `hooks.browser`, explicitly closes the wrapper and removes the
  auto-generated user-data-dir before rethrowing. Manual data-dirs (caller-
  supplied via `--user-data-dir` or `launchOptions.userDataDir`) are the
  caller's lifecycle and left alone.
- `getBrowserForRequest` installs `browser.once('close', ...)` that detects
  spontaneous exit (a session still present in `this.browsers` at this point
  means nobody called `close()`). Routes through `this.close(..., force=true)`
  so SDK subclasses overriding `close()` still participate.
- `shutdown()` routes each session through `this.close(b, s, true)`. Per-
  session errors are caught so one stuck cleanup can't block the rest.
- The three fire-and-forget `this.close()` call sites (keep-until timer,
  `killSessions`, `complete`) now have `.catch()` handlers logging at
  `error` with the session id, preventing unhandled rejections.

### `src/routes/chromium/tests/websocket.spec.ts`
- New `waitFor(predicate, timeoutMs, intervalMs)` helper that throws on
  timeout (replaces fixed `sleep(1000)` in the existing test — flake-prone
  on slower CI).
- 4 new regression tests:
  - `deletes user-data-dirs when launch fails` — installs a `Hooks` override
    that throws from `browser()`. Asserts no leaked entries after 3
    concurrent attempts. Asserts each rejection contains `'500'`, which
    discriminates the hook-throw from infrastructure failures
    (`ECONNREFUSED`, bad token → 401, etc.) that would never have produced
    a data-dir.
  - `deletes user-data-dirs when the server shuts down with active sessions`
    — connects a client then calls `browserless.stop()` without disconnecting.
  - `deletes user-data-dirs when the session is killed via /kill` — asserts
    `status === 204` AND `GET /sessions` returns `[]` immediately after,
    proving the synchronous-eviction contract holds.
  - `deletes user-data-dirs when the browser exits unexpectedly` — reaches
    into `browserManager.browsers` to grab the wrapper, then calls
    `wrapper.process()!.kill('SIGKILL')` to simulate kernel OOM-kill.
- All new `/sessions` fetches assert `res.status === 200` before consuming
  JSON (prevents a server 500 from masquerading as an unexpected JSON shape
  in the test).

## Out of scope (follow-up)

Three pieces present in #5343 are intentionally deferred:

1. Startup orphan sweep — recovers data-dirs left over after a hard crash
   that bypassed graceful shutdown.
2. Periodic sweep over `/tmp/org.chromium.Chromium.*` — chromium-internal
   subprocess orphans.
3. `shuttingDown` flag + `getBrowserForRequest` race guard — only useful
   alongside (1).

These bring cross-instance mtime safety reasoning and opt-in env-var gates
that deserve their own review cycle. They are additive to this PR and won't
conflict.

## ⚠ Operational note: stop grace period

With this PR, shutdown actually **waits** for active sessions to close
gracefully (previously it returned immediately and orphaned them). When a
WebSocket client is still attached at SIGTERM time, the shutdown waits for
the in-flight job's request-timeout (default 30 s via the limiter) before
the close path proceeds; cleanup then completes in ~10 ms.

**Docker's default 10-second `stop` grace is too short** to let this complete.
Production deployments should set:

- `docker stop --time=35` (or higher) for one-off restarts
- Compose: `stop_grace_period: 35s`
- Kubernetes: `terminationGracePeriodSeconds: 35` (or `≥ config.getTimeout() / 1000 + 5`)

Pre-PR, cleanup did **not** run on SIGTERM-with-active-sessions at all — the
container exited quickly and the data-dirs were only reclaimed if `/tmp` was
ephemeral. With bind-mounted or persistent `/tmp`, this was the dominant
leak source. This PR trades a longer graceful-stop window for deterministic
cleanup; if the grace expires, docker falls back to `SIGKILL` and the
container terminates as before — no regression versus current behavior.

## Risk

- **SDK extension surface.** `close()` now evicts from `this.browsers`
  unconditionally and synchronously; pre-PR it only evicted when
  `isTempDataDir === true`. Any SDK override that observed `this.browsers`
  during a `close()` would see different timing — but the previous timing
  was a real bug (fire-and-forget callers saw stale sessions).
- **`shutdown()` now invokes `this.close(...)`** per session. SDK extensions
  that override `close()` will see their override called during shutdown
  too. This is typically the desired behavior (metrics, audit logs).
- **`close()` is now serialized.** Adds ~one `browser.close()` duration
  (100–300 ms typical) to the critical path before `removeUserDataDir`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` chromium WebSocket suite: 520 passing, 4 pending, 0 failing
- [x] Docker chromium image built and validated end-to-end:
  - `/kill/<id>` with attached client → data-dir cleaned up; `/sessions`
    returns `[]` immediately after the 204 (synchronous-eviction contract)
  - `kill -9` on chromium PID inside container → data-dir cleaned up
    (confirms the disconnect listener works in the production environment)
  - `SIGTERM` with attached client → `/tmp/browserless-data-dirs/` is empty
    after `docker stop --time=35`

## Closes

- #5343
- #5344
- #5350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup and temporary file removal reliability
  * Enhanced handling of unexpected browser process exits and crashes
  * Better error recovery and logging during shutdown operations
  * Fixed potential race conditions in session teardown

* **Tests**
  * Expanded test coverage for cleanup scenarios across various shutdown paths and process failure conditions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->