### PR TITLE
fix: serve /function and /download page via local server address to avoid mixed-content block on HTTPS deployments

### DIFF
--- a/src/routes/chromium/tests/download.spec.ts
+++ b/src/routes/chromium/tests/download.spec.ts
@@ -108,4 +108,41 @@ describe('/chromium/download API', function () {
       expect(await res.text()).to.equal('Hello world!');
     });
   });
+
+  it('runs downloads when behind an HTTPS external load-balancer URL', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    // An HTTPS external address would make the in-page client a secure
+    // context and forbid the ws://localhost:<port> WebSocket as mixed
+    // content unless the page is navigated via the local server address.
+    config.setExternalAddress(
+      'https://test-external.invalid:9999/e/abc123def456',
+    );
+    const metrics = new Metrics();
+    await start({ config, metrics });
+
+    await fetch('http://localhost:3000/chromium/download?token=browserless', {
+      body: `export default async ({ page }) => {
+        await page.evaluate(() => {
+          const txtContent = "data:text/plain;charset=utf-8,Hello world!";
+          const encodedUri = encodeURI(txtContent);
+          const link = document.createElement("a");
+          link.setAttribute("href", encodedUri);
+          link.setAttribute("download", "data.txt");
+          document.body.appendChild(link);
+
+          link.click();
+        });
+        await new Promise(r => setTimeout(r, 1000));
+      }`,
+      headers: {
+        'content-type': 'application/javascript',
+      },
+      method: 'POST',
+    }).then(async (res) => {
+      expect(res.status).to.equal(200);
+      expect(res.headers.get('content-type')).to.equal('text/plain');
+      expect(await res.text()).to.equal('Hello world!');
+    });
+  });
 });

--- a/src/routes/chromium/tests/function.spec.ts
+++ b/src/routes/chromium/tests/function.spec.ts
@@ -386,4 +386,42 @@ describe('/chromium/function API', function () {
       expect(res.status).to.equal(200);
     });
   });
+
+  it('runs functions when behind an HTTPS external load-balancer URL', async () => {
+    const config = new Config();
+    config.setToken('browserless');
+    // With an HTTPS external address, navigating the in-page client to the
+    // external URL would make the page a secure context, which then forbids
+    // an in-page WebSocket to ws://localhost:<port> as mixed content. The
+    // handler must therefore navigate the page via the local server address
+    // so the page origin matches the in-page WebSocket origin.
+    config.setExternalAddress(
+      'https://test-external.invalid:9999/e/abc123def456',
+    );
+    const metrics = new Metrics();
+    await start({ config, metrics });
+    const body = {
+      code: `export default async function ({ page }) {
+        return Promise.resolve({
+          data: "ok",
+          type: "application/text",
+        });
+      }`,
+      context: {},
+    };
+
+    await fetch('http://localhost:3000/chromium/function?token=browserless', {
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+      },
+      method: 'POST',
+    }).then(async (res) => {
+      const json = await res.json();
+
+      expect(json).to.have.property('data');
+      expect(json.data).to.equal('ok');
+      expect(res.status).to.equal(200);
+    });
+  });
 });

--- a/src/shared/utils/function/handler.ts
+++ b/src/shared/utils/function/handler.ts
@@ -46,12 +46,18 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
     const isJson = req.headers['content-type']?.includes('json');
     const functionPath = HTTPRoutes.function.replace('?(/)', '');
     const functionAssetLocation = path.join(config.getStatic(), 'function');
+    // Page navigation and the in-page WebSocket both stay on the local
+    // server: the page is served entirely via setRequestInterception, so
+    // there is no reason for its origin to be the external LB. Keeping the
+    // origin local (http://localhost:<port>) also means the in-page WS to
+    // ws://localhost:<port> is same-origin — an HTTPS external address
+    // would otherwise trigger a mixed-content block.
     const functionRequestPath = makeExternalURL(
-      config.getExternalAddress(),
+      config.getServerAddress(),
       functionPath,
     );
     const functionIndexHTML = makeExternalURL(
-      config.getExternalAddress(),
+      config.getServerAddress(),
       functionPath,
       '/index.html',
     );


### PR DESCRIPTION
Follow-up to #5359, which moved the in-page `/function/connect` WebSocket from the external address to the local server address (`getServerWebSocketAddress()`). That fixed the LB-WS-upgrade failure for proxies with an opaque path prefix, but only patched half the flow: `page.goto(functionIndexHTML)` still navigates to the external address. On HTTPS deployments this makes the page a secure context, which then forbids the in-page WebSocket to `ws://localhost:<port>` as mixed content. The HTTP-external test in #5359 doesn't exercise this path, so the regression slipped through CI.

  This PR moves `functionRequestPath` (the request-interception prefix) and `functionIndexHTML` (the `page.goto` URL) to `getServerAddress()` as well. The entire flow now stays on the local server:

  - Page navigates to `http://localhost:<port>/function/index.html` — origin is local, not a secure context.
  - Page imports `./browserless-function-<id>.js` — resolves to `http://localhost:<port>/function/browserless-function-<id>.js`, still caught by the interception prefix and
  served from in-memory code.
  - In-page WebSocket opens `ws://localhost:<port>/function/connect/<id>?token=...` — same origin as the page, so no mixed-content block, and same box as the browser, so no LB
  traversal.

  Both the original LB-WS-upgrade bug (#5359) and the HTTPS mixed-content regression introduced by it are resolved together; no per-fork override needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved mixed-content issues when using external HTTPS load-balancer URLs.

* **Tests**
  * Added test coverage for download and function APIs with HTTPS external load-balancer configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5377)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->