### PR TITLE
fix: PRD-432 install ttf-mscorefonts-installer for Times New Roman + MS core fonts

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update \
   fonts-ubuntu \
   fonts-wqy-zenhei \
   fonts-open-sans \
+  ttf-mscorefonts-installer \
   && update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 \
   && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
   && fc-cache -f -v \


### PR DESCRIPTION
Closes PRD-432

## Problem

A customer rendering PDFs via `/pdf` reported Times New Roman is unavailable on our Linux instances — Chrome falls back to a generic serif font.

## Root cause

`docker/base/Dockerfile` pre-accepts the `ttf-mscorefonts-installer` EULA (`debconf-set-selections`) and enables the `multiverse` repo, but the package itself was never added to the `apt-get install` list — it was dropped during the layer-reduction refactor (ca87a5b2). So the MS core fonts were never installed.

## Fix

Add `ttf-mscorefonts-installer` to the existing font install list. All browser images inherit from this base, so this covers `/pdf`, `/screenshot`, and every render path. Provides Times New Roman, Arial, Courier New, Georgia, Verdana, Trebuchet, Comic Sans, Impact, Andale Mono, Arial Black, and Webdings (~5 MB).

## Verification

Replicated the Dockerfile's apt steps in a clean `ubuntu:24.04` container (same base as `docker/base/Dockerfile`):

\`\`\`
$ fc-list | grep -i "times new roman"
/usr/share/fonts/truetype/msttcorefonts/Times_New_Roman.ttf: Times New Roman:style=Regular,...
/usr/share/fonts/truetype/msttcorefonts/Times_New_Roman_Bold.ttf: Times New Roman:style=Bold,...
/usr/share/fonts/truetype/msttcorefonts/Times_New_Roman_Italic.ttf: Times New Roman:style=Italic,...
/usr/share/fonts/truetype/msttcorefonts/Times_New_Roman_Bold_Italic.ttf: Times New Roman:style=Bold Italic,...
\`\`\`

## Test plan

- [x] `ttf-mscorefonts-installer` installs cleanly with `--no-install-recommends` on `ubuntu:24.04`
- [x] `fc-list` reports Times New Roman (Regular/Bold/Italic/Bold-Italic) after install
- [ ] Build the actual base image and confirm `fc-list | grep 'Times New Roman'` (CI / reviewer — SourceForge download is flaky; CI has 5-attempt retry)
- [ ] `/pdf` render with `font-family: 'Times New Roman'` no longer falls back to generic serif

## Notes

- `fonts.conf` serif fallback left as-is — customers specify `Times New Roman` explicitly, so only the font needs to be present.
- `ttf-mscorefonts-installer` downloads from SourceForge at build time (known flaky); the existing CI retry logic mitigates this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image dependencies to include Microsoft Core Fonts support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->