### PR TITLE
feat: Add EXPOSE to Dockerfile

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -103,3 +103,5 @@ COPY scripts scripts
 COPY static static
 
 COPY CHANGELOG.md LICENSE NOTICE.txt README.md tsconfig.json ./
+
+EXPOSE $PORT


### PR DESCRIPTION
An explicit `EXPOSE` keyword makes it easier for automated tools to find the relevant port, in cases where this can't be set through a `docker run` argument (e.g. GitLab CI services)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container configuration to properly declare the exposed port.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->