### PR TITLE
fix: make the ajv validator and schema generation safe for NodeNext consumers

### DIFF
--- a/scripts/build-schemas.js
+++ b/scripts/build-schemas.js
@@ -89,7 +89,19 @@ const buildSchemas = async (
       .filter((r) => r.endsWith(tsExtension))
       .map(async (route) => {
         const routeContents = (await fs.readFile(route)).toString('utf-8');
-        const program = TJS.getProgramFromFiles([route], compilerOptions, './');
+        // Schema generation must be deterministic and independent of the
+        // consumer's runtime module settings. Under moduleResolution
+        // "nodenext"/"node16", types pulled from dual CJS/ESM packages (e.g.
+        // puppeteer-core) serialize as absolute-path
+        // `import("...",{with:{"resolution-mode":"import"}}).Type` $ref names
+        // that the ajv-backed validator cannot resolve at request time. Forcing
+        // the canonical es2022/bundler resolution yields stable, named $refs for
+        // every consumer regardless of how their own tsconfig is configured.
+        const program = TJS.getProgramFromFiles(
+          [route],
+          { ...compilerOptions, module: 'es2022', moduleResolution: 'bundler' },
+          './',
+        );
 
         // prettier-ignore
         const sourceFile = ts.createSourceFile(route, routeContents, ts.ScriptTarget.Latest, true);

--- a/src/shared/utils/schema-validator.ts
+++ b/src/shared/utils/schema-validator.ts
@@ -1,4 +1,4 @@
-import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
+import { Ajv, ErrorObject, ValidateFunction } from 'ajv';
 
 interface ValidationErrorDetail {
   message: string;


### PR DESCRIPTION
## Summary

The ajv-backed validator added in #5388 broke SDK consumers whose tsconfig uses `module`/`moduleResolution: "nodenext"` (or `"node16"`) — projects that type-check against the SDK source and generate route schemas through the shipped build pipeline. Two independent root causes, both fixed here:

### 1. `schema-validator.ts` — NodeNext-unsafe ajv import
This package ships as `type: module`, so its source is ESM. `import Ajv from 'ajv'` is a **default import of a CJS module**, which is not constructable under NodeNext:

```
'typeof import("ajv/dist/ajv")' has no construct signatures.
```

The SDK's own build hides this because it compiles with `moduleResolution: "bundler"` (lenient). Any NodeNext consumer type-checking the source hits it. Fixed by using the **named** export `import { Ajv } from 'ajv'` — ajv exports it, it's valid under both resolutions, and it's identical at runtime.

### 2. `build-schemas.js` — non-deterministic schema generation
`build-schemas.js` passed the consumer's raw `compilerOptions` to `typescript-json-schema`. Under NodeNext resolution, types pulled from **dual CJS/ESM packages** (e.g. puppeteer-core 25) serialize as absolute-path `$ref` names:

```
#/definitions/import("/abs/path/puppeteer-core/lib/types",{with:{"resolution-mode":"import"}}).ScreenshotOptions
```

The ajv validator **cannot compile** these at request time, so every request to an affected route (screenshot, pdf, export, unblock, and any WS route with a query schema) returns HTTP 500. Fixed by pinning the schema-generation program to the canonical `es2022`/`bundler` resolution, so output is deterministic and uses stable, named `$refs` regardless of the consumer's runtime module config.

## Backwards compatibility

**Byte-identical** for the SDK and any bundler consumer: regenerating the SDK's 96 route schemas with the original vs patched `build-schemas.js` produces an empty `diff -r`. The pin forces the SDK's *own* `es2022`/`bundler` values, so it's a no-op for it — only previously-**broken** NodeNext output changes, and only to become correct.

## Verification

- `build:ts` compiles cleanly with the named import.
- `schema-coercion-parity` suite (16 tests) passes → validator behavior unchanged.
- SDK's 96 generated schemas byte-identical before/after.
- End-to-end against a real NodeNext consumer (browserless/enterprise on an unchanged NodeNext tsconfig): type-check passes, all generated schemas are clean (zero `import(...)` refs), and all body/query schemas compile via the runtime `compileSchema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build schema generation to use deterministic TypeScript settings, ensuring consistent schema references across different build environments.
  * Refactored internal import syntax for improved code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->