### PR TITLE
fix: install versioned webkit outside Playwright's yauzl to avoid Node 24.16 deadlock

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
   gnupg \
   libu2f-udev \
   ssh \
+  unzip \
   wget \
   xvfb \
   libwebp-dev \

--- a/scripts/install-versioned-browsers.sh
+++ b/scripts/install-versioned-browsers.sh
@@ -82,7 +82,8 @@ install_browser() {
     echo "  Fetching $(basename "$dir")"
     fetched=0
     for url in "${urls[@]}"; do
-      if curl -fsSL --retry 3 --retry-delay 2 -o "$tmp_zip" "$url"; then fetched=1; break; fi
+      # --connect-timeout/--max-time bound a stalled transfer; --retry alone does not.
+      if curl -fsSL --connect-timeout 15 --max-time 600 --retry 3 --retry-delay 2 -o "$tmp_zip" "$url"; then fetched=1; break; fi
       echo "    mirror failed, trying next: $url" >&2
     done
     [ "$fetched" -eq 1 ] || { fail "all mirrors failed for $dir"; return 1; }

--- a/scripts/install-versioned-browsers.sh
+++ b/scripts/install-versioned-browsers.sh
@@ -2,38 +2,150 @@
 set -euo pipefail
 
 # install-versioned-browsers.sh <browser> [browser...]
-# Installs browser binaries (with system dependencies) for each versioned
-# Playwright package. This ensures protocol compatibility when older Playwright
-# clients connect — each version gets its own matching binary.
 #
-# Usage:
-#   ./scripts/install-versioned-browsers.sh webkit
-#   ./scripts/install-versioned-browsers.sh webkit firefox chromium
+# Installs each pinned Playwright version's browser binaries so older clients get
+# a matching browser. We fetch + unzip the archives ourselves instead of
+# `playwright install` because playwright-core < 1.60.0 deadlocks during zip
+# extraction on Node >= 24.16.0 (microsoft/playwright#40724, fixed in 1.60.0).
+#
+# TODO: drop this once the minimum bundled playwright-core is >= 1.60.0.
 
 if [ $# -eq 0 ]; then
   echo "Usage: $0 <browser> [browser...]"
   exit 1
 fi
+BROWSERS=("$@")
 
-BROWSERS="$*"
+CORE_CLI="node_modules/playwright-core/cli.js"
 
-echo "Installing browsers ($BROWSERS) for versioned Playwright packages..."
+# Log a per-component error. set -e is suspended inside install_browser (it is
+# called via `|| failed=1`), so callers still pair this with an explicit return.
+fail() { echo "  ERROR: $*" >&2; }
 
-for pkg_dir in node_modules/playwright-1.*/; do
-  pkg_name=$(basename "$pkg_dir")
-  cli="${pkg_dir}cli.js"
+# Parse `playwright install <browser> --dry-run` into one line per component:
+#   <install-dir>\t<url1> <url2> ...
+# A single browser can expand to several components (e.g. chromium pulls ffmpeg
+# and chromium-headless-shell), each with its own dir and ordered mirror URLs.
+# shellcheck disable=SC2016  # awk program: $0/RSTART are awk fields, not shell vars
+AWK_PARSE='
+  /Install location:/ {
+    if (dir != "") print dir "\t" urls
+    dir = $0; sub(/^.*Install location:[ \t]*/, "", dir); gsub(/\r/, "", dir); urls = ""
+    next
+  }
+  {
+    line = $0
+    while (match(line, /https:\/\/[^ \t\r"]+\.zip/)) {
+      u = substr(line, RSTART, RLENGTH)
+      urls = (urls == "" ? u : urls " " u)
+      line = substr(line, RSTART + RLENGTH)
+    }
+  }
+  END { if (dir != "") print dir "\t" urls }
+'
 
-  if [ ! -f "$cli" ]; then
-    continue
+tmp_zip="$(mktemp -t pw-browser-XXXXXX.zip)"
+trap 'rm -f "$tmp_zip"' EXIT
+
+# Download + extract every component of <browser> for the given Playwright CLI.
+# Returns non-zero (without aborting the whole script) on any failure so the
+# caller can report which version failed.
+install_browser() {
+  local cli="$1" browser="$2" dry components dir urlstr fetched url validate rc
+  local -a urls
+
+  if ! dry="$(node "$cli" install "$browser" --dry-run 2>&1)"; then
+    fail "dry-run failed for $browser via $cli:"; printf '    %s\n' "$dry" >&2
+    return 1
+  fi
+  components="$(printf '%s\n' "$dry" | awk "$AWK_PARSE")"
+  if [ -z "$components" ]; then
+    fail "parsed no components from dry-run for $browser via $cli:"; printf '    %s\n' "$dry" >&2
+    return 1
   fi
 
-  echo "  Installing $BROWSERS for $pkg_name..."
-  # shellcheck disable=SC2086
-  node "$cli" install --with-deps $BROWSERS || echo "  Warning: Failed to install $BROWSERS for $pkg_name"
+  while IFS=$'\t' read -r dir urlstr; do
+    [ -n "$dir" ] || continue
+    # Must be an absolute path inside a Playwright browsers cache; guards the
+    # `rm -rf "$dir"` below against a misparsed/unexpected directory.
+    case "$dir" in
+      */playwright-browsers/* | */ms-playwright/*) ;;
+      *) fail "refusing suspicious install dir '$dir'"; return 1 ;;
+    esac
+    if [ -e "$dir/INSTALLATION_COMPLETE" ]; then
+      echo "  already present: $dir"
+      continue
+    fi
+    read -ra urls <<< "$urlstr"
+    [ "${#urls[@]}" -gt 0 ] || { fail "no download URL for $dir"; return 1; }
+
+    echo "  Fetching $(basename "$dir")"
+    fetched=0
+    for url in "${urls[@]}"; do
+      if curl -fsSL --retry 3 --retry-delay 2 -o "$tmp_zip" "$url"; then fetched=1; break; fi
+      echo "    mirror failed, trying next: $url" >&2
+    done
+    [ "$fetched" -eq 1 ] || { fail "all mirrors failed for $dir"; return 1; }
+
+    # Extract into a clean dir and only mark complete on a verified extraction,
+    # so a partial/corrupt unzip is never cached as installed. (set -e is
+    # suspended in this function, so every mutation is checked explicitly.)
+    if ! { rm -rf "$dir" && mkdir -p "$dir"; }; then
+      fail "could not prepare clean dir $dir"; return 1
+    fi
+    if ! unzip -q -o "$tmp_zip" -d "$dir"; then
+      fail "unzip failed for $dir"; rm -rf "$dir"; return 1
+    fi
+    if [ -z "$(ls -A "$dir" 2>/dev/null)" ]; then
+      fail "empty extraction for $dir"; rm -rf "$dir"; return 1
+    fi
+    if ! touch "$dir/INSTALLATION_COMPLETE"; then
+      fail "could not write completion marker for $dir"; rm -rf "$dir"; return 1
+    fi
+  done <<< "$components"
+
+  # Let Playwright validate its own view: with every marker present this exits
+  # immediately without re-extracting. A missing component would make it
+  # re-extract (and deadlock on the broken versions), so bound it with a timeout
+  # (-k force-kills a process still stuck after SIGTERM); exit 124 == timed out.
+  rc=0
+  validate="$(timeout -k 10 120 node "$cli" install "$browser" 2>&1)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if [ "$rc" -eq 124 ]; then
+      fail "validation timed out for $browser via $cli (missing component -> re-extraction deadlock?)"
+    else
+      fail "Playwright could not validate $browser via $cli (exit $rc):"
+    fi
+    printf '    %s\n' "$validate" >&2
+    return 1
+  fi
+}
+
+# System dependencies, once. `install-deps` never extracts a browser archive, so
+# it is immune to the yauzl bug, so run it via the core CLI regardless of version.
+echo "Installing system dependencies for ${BROWSERS[*]}..."
+if ! node "$CORE_CLI" install-deps "${BROWSERS[@]}"; then
+  echo "ERROR: failed to install system dependencies for ${BROWSERS[*]}" >&2
+  exit 1
+fi
+
+# Every Playwright CLI to satisfy: the versioned aliases + playwright-core.
+clis=()
+for pkg_dir in node_modules/playwright-1.*/; do
+  [ -f "${pkg_dir}cli.js" ] && clis+=("${pkg_dir}cli.js")
+done
+clis+=("$CORE_CLI")
+
+failed=0
+for cli in "${clis[@]}"; do
+  for browser in "${BROWSERS[@]}"; do
+    echo "Installing $browser for $cli..."
+    install_browser "$cli" "$browser" || failed=1
+  done
 done
 
-echo "  Installing $BROWSERS for playwright-core..."
-# shellcheck disable=SC2086
-node node_modules/playwright-core/cli.js install --with-deps $BROWSERS
-
+if [ "$failed" -ne 0 ]; then
+  echo "ERROR: one or more versioned browser installs failed" >&2
+  exit 1
+fi
 echo "Done."


### PR DESCRIPTION
## Problem

The `webkit-heavy` / `multi-heavy` image builds **hang forever** during the versioned-browser install step (observed as CI jobs stuck 2h+).

**Root cause:** `playwright-core` 1.56.1–1.59.1 — pinned as `playwright-1.56`…`1.59` for client protocol compatibility — bundle an old `yauzl`/`fd-slicer` whose stream destroy lifecycle breaks on **Node ≥ 24.16.0**: `fd-slicer` overrides `destroy()` instead of `_destroy(err, cb)`, so `'close'` never fires after EOF and Playwright's `for await (openReadStream)` deadlocks **mid zip-extraction** (event loop parked in `epoll_pwait`, threadpool idle, ~0% CPU).

- Fixed upstream only in **`playwright-core` 1.60.0** (microsoft/playwright#40747, applying yauzl#168); no backport to the 1.56–1.59 lines.
- Node trigger: nodejs/node#63487 (an intentional semver-minor `stream` change + libuv 1.52.1).
- Surfaced now because the base image bumped Node 24.15.0 → **24.16.0**. Non-heavy images are unaffected (they only use the fixed 1.60.0); heavy images install webkit for the old pinned versions and deadlock on the first.

## Fix

`scripts/install-versioned-browsers.sh` no longer calls the broken extractor. For each pinned version it:
1. reads each component's install dir + download URL(s) from `playwright install <browser> --dry-run` (which does **not** extract),
2. fetches with `curl` (mirror fallback) and extracts with the system **`unzip`** (preserving exec bits + symlinks) into a freshly-cleaned dir,
3. writes the `INSTALLATION_COMPLETE` marker only after a verified non-empty extraction,
4. re-runs `install` (a fast no-op once markers exist) so **Playwright validates** nothing is missing — bounded by `timeout` so a missing component fails loudly instead of re-deadlocking.

`docker/base/Dockerfile` adds `unzip`. Keeps the old protocol versions **and** the latest runtime Node; needs nothing from upstream.

**Scope:** build-time only. Runtime extracts no zips; the separate `extract-zip` path (adblock/devtools) uses a non-triggering API and is unaffected.

## Verification

Reproduced the deadlock deterministically (matrix: `playwright-core@1.56.1–1.59.1` hang on Node 24.16.0; 1.60.0 + Node 20/22 pass), then validated the fix end-to-end in Docker:
- `webkit-heavy` build completes in ~90s (was ∞).
- All 5 webkit revisions + ffmpeg install with intact markers, symlinks, exec bits, `protocol.json`.
- webkit **launches and renders** a page from every pinned version (1.56–1.59 + core) inside the container.

Passed `shellcheck`, a 2-round multi-agent code review, and `/simplify`.

## Follow-up (optional)

Bump the `extract-zip` devDependency to a `yauzl ≥ 3.3.1` release to future-proof the adblock/devtools extraction against the same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the unzip utility to the base image to improve archive extraction during builds.

* **Refactor**
  * Reworked the browser installation flow for more reliable, versioned browser deployments: parallel multi-version support, per-component downloads from mirrors, safer extraction with completion markers, validation steps, and clearer failure reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->