### PR TITLE
Fix ~30s build:schemas call

### DIFF
--- a/scripts/build-schemas.js
+++ b/scripts/build-schemas.js
@@ -137,7 +137,7 @@ const buildSchemas = async (
         : [];
 
       return Promise.all(
-        schemas.map((schemaName) => {
+        schemas.map(async (schemaName) => {
           // Resolve the exported name to its underlying declaration symbol,
           // following re-export aliases (`export { BodySchema } from '...'`).
           // This covers interfaces, type aliases (`export type ResponseSchema
@@ -163,7 +163,11 @@ const buildSchemas = async (
             const schema = stripHashSuffixes(
               generator.getSchemaForSymbol(uniqueName),
             );
-            return fs.writeFile(jsonPath, JSON.stringify(schema, null, '  '));
+            // Await the write inside the try so a failed write is caught here
+            // and logged, rather than rejecting the parent Promise.all and
+            // aborting the whole build.
+            await fs.writeFile(jsonPath, JSON.stringify(schema, null, '  '));
+            return jsonPath;
           } catch (e) {
             console.error(
               `Error generating schema: (${routeName}) (${jsonPath}): ${e}`,

--- a/scripts/build-schemas.js
+++ b/scripts/build-schemas.js
@@ -11,45 +11,40 @@ import ts from 'typescript';
 const moduleMain = path.normalize(import.meta.url).endsWith(process.argv[1]);
 
 /**
- * Find an exported interface in a TypeScript AST
+ * typescript-json-schema's `uniqueNames` mode appends a `.<8-hex>` hash to every
+ * definition name so that identically-named types from different files can coexist
+ * in a single program. We rely on that to disambiguate the per-route schema we want,
+ * but the emitted files must use the canonical (unsuffixed) names. This strips the
+ * hash from `definitions` keys and `$ref` targets so output is identical to building
+ * one program per route.
  *
- * @param {ts.Node} node The node to search for the exported interface
- * @param {string} interfaceName The name of the interface to search for
- * @returns {ts.InterfaceDeclaration | ts.Identifier | null}
+ * @param {*} value A parsed JSON schema (or fragment thereof)
+ * @returns {*} The same shape with hash suffixes removed
  */
-const findExportedInterface = (node, interfaceName) => {
-  if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
-    // Check if the interface is exported
-    const isExported = node.modifiers?.some(
-      (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
-    );
-    if (isExported) {
-      return node;
-    }
+const HASH_SUFFIX = /\.[0-9a-f]{8}$/;
+const stripHashSuffixes = (value) => {
+  if (Array.isArray(value)) {
+    return value.map(stripHashSuffixes);
   }
-
-  // Check for re-exported interfaces
-  if (
-    ts.isExportDeclaration(node) &&
-    node.exportClause &&
-    ts.isNamedExports(node.exportClause)
-  ) {
-    const elements = node.exportClause.elements;
-    for (const element of elements) {
-      if (element.name.text === interfaceName) {
-        return element.name;
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (key === '$ref' && typeof val === 'string') {
+        out[key] = val.replace(HASH_SUFFIX, '');
+      } else if (key === 'definitions' && val && typeof val === 'object') {
+        out[key] = Object.fromEntries(
+          Object.entries(val).map(([defName, defVal]) => [
+            defName.replace(HASH_SUFFIX, ''),
+            stripHashSuffixes(defVal),
+          ]),
+        );
+      } else {
+        out[key] = stripHashSuffixes(val);
       }
     }
+    return out;
   }
-
-  let foundNode = null;
-  node.forEachChild((child) => {
-    if (foundNode === null) {
-      foundNode = findExportedInterface(child, interfaceName);
-    }
-  });
-
-  return foundNode;
+  return value;
 };
 
 /**
@@ -80,63 +75,104 @@ const buildSchemas = async (
 
   // Depending on if we're parsing an external projects routes,
   // skip the prebuilt ones. This makes it much faster to build
-  const routesToParse = moduleMain
-    ? [...httpRoutes, ...wsRoutes]
-    : [...externalHTTPRoutes, ...externalWebSocketRoutes];
+  const routesToParse = (
+    moduleMain
+      ? [...httpRoutes, ...wsRoutes]
+      : [...externalHTTPRoutes, ...externalWebSocketRoutes]
+  ).filter((r) => r.endsWith(tsExtension));
 
-  await Promise.all(
-    routesToParse
-      .filter((r) => r.endsWith(tsExtension))
-      .map(async (route) => {
-        const routeContents = (await fs.readFile(route)).toString('utf-8');
-        // Schema generation must be deterministic and independent of the
-        // consumer's runtime module settings. Under moduleResolution
-        // "nodenext"/"node16", types pulled from dual CJS/ESM packages (e.g.
-        // puppeteer-core) serialize as absolute-path
-        // `import("...",{with:{"resolution-mode":"import"}}).Type` $ref names
-        // that the ajv-backed validator cannot resolve at request time. Forcing
-        // the canonical es2022/bundler resolution yields stable, named $refs for
-        // every consumer regardless of how their own tsconfig is configured.
-        const program = TJS.getProgramFromFiles(
-          [route],
-          { ...compilerOptions, module: 'es2022', moduleResolution: 'bundler' },
-          './',
-        );
+  if (routesToParse.length === 0) {
+    return;
+  }
 
-        // prettier-ignore
-        const sourceFile = ts.createSourceFile(route, routeContents, ts.ScriptTarget.Latest, true);
+  // Build a SINGLE TypeScript program for every route up front. Previously a
+  // fresh program was created per route, which re-parsed the entire standard
+  // lib and the large transitive `.d.ts` graph (puppeteer-core, playwright,
+  // @types/node) once per file — the dominant cost of this script. One shared
+  // program does that work a single time.
+  //
+  // Schema generation must be deterministic and independent of the consumer's
+  // runtime module settings. Under moduleResolution "nodenext"/"node16", types
+  // pulled from dual CJS/ESM packages (e.g. puppeteer-core) serialize as
+  // absolute-path `import("...",{with:{"resolution-mode":"import"}}).Type`
+  // $ref names that the ajv-backed validator cannot resolve at request time.
+  // Forcing the canonical es2022/bundler resolution yields stable, named $refs
+  // for every consumer regardless of how their own tsconfig is configured.
+  const program = TJS.getProgramFromFiles(
+    routesToParse,
+    { ...compilerOptions, module: 'es2022', moduleResolution: 'bundler' },
+    './',
+  );
 
-        return Promise.all(
-          schemas.map((schemaName) => {
-            if (findExportedInterface(sourceFile, schemaName)) {
-              const routePath = path.parse(route);
-              const routeName = routePath.name.slice(0, -2); // drop the ending .d
-              const schemaSuffix = schemaName
-                .replace('Schema', '')
-                .toLocaleLowerCase();
-              routePath.base = `${routeName}.${schemaSuffix}.json`;
-              const jsonPath = path.format(routePath);
-              try {
-                const schema = TJS.generateSchema(
-                  program,
-                  schemaName,
-                  settings,
-                );
-                return fs.writeFile(
-                  jsonPath,
-                  JSON.stringify(schema, null, '  '),
-                );
-              } catch (e) {
-                console.error(
-                  `Error generating schema: (${routeName}) (${jsonPath}): ${e}`,
-                );
-                return null;
-              }
-            }
+  // `uniqueNames` lets identically-named interfaces (e.g. every route's
+  // `BodySchema`) coexist in one program by suffixing each definition with a
+  // hash. We use it only to address the specific symbol a given route exports;
+  // the suffixes are stripped from the emitted files (see stripHashSuffixes).
+  const generator = TJS.buildGenerator(program, {
+    ...settings,
+    uniqueNames: true,
+  });
+
+  if (generator === null) {
+    throw new Error('Unable to build the JSON schema generator');
+  }
+
+  const checker = program.getTypeChecker();
+
+  // Map every interface/type symbol to its unique (hash-suffixed) name so we
+  // can resolve a route's exported schema — including re-exports from shared
+  // implementations — back to the exact definition to generate.
+  const symbolToUniqueName = new Map();
+  for (const ref of generator.getSymbols()) {
+    symbolToUniqueName.set(ref.symbol, ref.name);
+  }
+
+  return Promise.all(
+    routesToParse.map((route) => {
+      const moduleSymbol = checker.getSymbolAtLocation(
+        program.getSourceFile(route),
+      );
+      const moduleExports = moduleSymbol
+        ? checker.getExportsOfModule(moduleSymbol)
+        : [];
+
+      return Promise.all(
+        schemas.map((schemaName) => {
+          // Resolve the exported name to its underlying declaration symbol,
+          // following re-export aliases (`export { BodySchema } from '...'`).
+          // This covers interfaces, type aliases (`export type ResponseSchema
+          // = string`), and re-exports uniformly.
+          let symbol = moduleExports.find((e) => e.name === schemaName);
+          while (symbol && symbol.flags & ts.SymbolFlags.Alias) {
+            symbol = checker.getAliasedSymbol(symbol);
+          }
+          const uniqueName = symbol && symbolToUniqueName.get(symbol);
+          if (!uniqueName) {
             return;
-          }),
-        );
-      }),
+          }
+
+          const routePath = path.parse(route);
+          const routeName = routePath.name.slice(0, -2); // drop the ending .d
+          const schemaSuffix = schemaName
+            .replace('Schema', '')
+            .toLocaleLowerCase();
+          routePath.base = `${routeName}.${schemaSuffix}.json`;
+          const jsonPath = path.format(routePath);
+
+          try {
+            const schema = stripHashSuffixes(
+              generator.getSchemaForSymbol(uniqueName),
+            );
+            return fs.writeFile(jsonPath, JSON.stringify(schema, null, '  '));
+          } catch (e) {
+            console.error(
+              `Error generating schema: (${routeName}) (${jsonPath}): ${e}`,
+            );
+            return null;
+          }
+        }),
+      );
+    }),
   );
 };
 

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -3,10 +3,12 @@
 import { deleteAsync } from 'del';
 
 (async () => {
+  // Note: static/devtools is intentionally not removed here. It's a pinned
+  // snapshot that install-devtools.js downloads once and reuses, which keeps
+  // rebuilds fast. Use FORCE_DEVTOOLS=true to force a fresh download.
   await deleteAsync([
     'build',
     'static/function/*js*',
-    'static/devtools*',
     'static/debugger*',
   ]);
 })();

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -3,12 +3,16 @@
 import { deleteAsync } from 'del';
 
 (async () => {
-  // Note: static/devtools is intentionally not removed here. It's a pinned
-  // snapshot that install-devtools.js downloads once and reuses, which keeps
-  // rebuilds fast. Use FORCE_DEVTOOLS=true to force a fresh download.
+  // Note: the cached static/devtools snapshot is intentionally preserved here.
+  // install-devtools.js downloads it once and reuses it, which keeps rebuilds
+  // fast (use FORCE_DEVTOOLS=true to force a fresh download). We do still sweep
+  // the transient download artifacts (the zip and the extraction temp dir) so a
+  // previously-interrupted install can't leave them orphaned.
   await deleteAsync([
     'build',
     'static/function/*js*',
+    'static/devtools.zip',
+    'static/devtools-temp',
     'static/debugger*',
   ]);
 })();

--- a/scripts/install-adblock.js
+++ b/scripts/install-adblock.js
@@ -17,6 +17,18 @@ import os from 'os';
 import unzip from 'extract-zip';
 
 (async () => {
+  const extensionsDir = join(process.cwd(), 'extensions');
+  const uBlockLiteDir = join(extensionsDir, 'ublocklite');
+
+  // Skip the network round-trip when the extension is already installed.
+  // Set FORCE_ADBLOCK=true to re-fetch the latest uBlock Origin Lite release.
+  if (
+    existsSync(join(uBlockLiteDir, 'manifest.json')) &&
+    process.env.FORCE_ADBLOCK !== 'true'
+  ) {
+    return;
+  }
+
   const tmpDir = path.join(os.tmpdir(), '_ublite' + Date.now());
 
   // Create temporary directory if it doesn't exist
@@ -25,8 +37,6 @@ import unzip from 'extract-zip';
   }
 
   const zipFile = tmpDir + '/ublock.zip';
-  const extensionsDir = join(process.cwd(), 'extensions');
-  const uBlockLiteDir = join(extensionsDir, 'ublocklite');
 
   const downloadUrlToDirectory = (url, dir) =>
     fetch(url).then(

--- a/scripts/install-devtools.js
+++ b/scripts/install-devtools.js
@@ -44,5 +44,12 @@ const cleanup = async () => {
   );
   await extract(zipPath, { dir: extractPath });
   await rename(deepPath, finalPath);
-  await cleanup();
-})();
+})()
+  .catch((err) => {
+    console.error(`Failed to install devtools from ${devtoolsUrl}:`, err);
+    process.exitCode = 1;
+  })
+  // Always remove the transient zip/temp dir, on success and failure alike.
+  // Each op in cleanup() swallows its own error, so this never masks the
+  // failure reported above.
+  .finally(cleanup);

--- a/scripts/install-devtools.js
+++ b/scripts/install-devtools.js
@@ -19,16 +19,23 @@ const deepPath = path.join(
   'resources',
   'inspector',
 );
-const zipStream = fs.createWriteStream(zipPath);
-
 const cleanup = async () => {
   return await Promise.all([
-    unlink(zipPath),
-    rm(extractPath, { recursive: true }),
+    unlink(zipPath).catch(() => {}),
+    rm(extractPath, { recursive: true }).catch(() => {}),
   ]);
 };
 
 (async () => {
+  // The devtools snapshot is pinned to a fixed URL, so once it's been
+  // downloaded there's no need to re-fetch it on every build. Set
+  // FORCE_DEVTOOLS=true to bypass the cache.
+  if (fs.existsSync(finalPath) && process.env.FORCE_DEVTOOLS !== 'true') {
+    return;
+  }
+
+  const zipStream = fs.createWriteStream(zipPath);
+
   await rm(finalPath, { recursive: true }).catch(() => {});
   await new Promise((resolve, reject) =>
     https.get(devtoolsUrl, (response) => {
@@ -37,4 +44,5 @@ const cleanup = async () => {
   );
   await extract(zipPath, { dir: extractPath });
   await rename(deepPath, finalPath);
-})().finally(cleanup);
+  await cleanup();
+})();


### PR DESCRIPTION
Improves build:schemas call from ~30s to ~1s plus fixes some API routes that had missing schema gen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Single-pass schema generation with canonicalized references for emitted schema files (avoids duplicate failures).
  * Preserve cached devtools snapshot assets during cleanup unless explicitly forced.
  * Skip adblock/devtools installation when already present (respects FORCE flags) to speed setup.
  * Make temporary-artifact cleanup best-effort (avoid failing on removal errors) and adjust when cleanup runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->