### PR TITLE
fix: extract devtools & adblock with system unzip (Node 24.16 yauzl deadlock)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "esbuild": "^0.28.0",
         "esbuild-plugin-polyfill-node": "^0.3.0",
         "eslint": "^10.4.1",
-        "extract-zip": "^2.0.1",
         "gunzip-maybe": "^1.4.2",
         "marked": "^18.0.3",
         "mocha": "^12.0.0-beta-10",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "esbuild": "^0.28.0",
     "esbuild-plugin-polyfill-node": "^0.3.0",
     "eslint": "^10.4.1",
-    "extract-zip": "^2.0.1",
     "gunzip-maybe": "^1.4.2",
     "marked": "^18.0.3",
     "mocha": "^12.0.0-beta-10",

--- a/scripts/extract-zip-native.js
+++ b/scripts/extract-zip-native.js
@@ -20,7 +20,23 @@ const execFileAsync = promisify(execFile);
  * @param {string} destDir Directory to extract into (created if missing)
  */
 export const extractZip = async (zipPath, destDir) => {
-  // -q: quiet; -o: overwrite existing files without prompting (an interactive
-  // prompt would hang a non-interactive build).
-  await execFileAsync('unzip', ['-q', '-o', zipPath, '-d', destDir]);
+  try {
+    // -q: quiet; -o: overwrite existing files without prompting (an interactive
+    // prompt would hang a non-interactive build).
+    await execFileAsync('unzip', ['-q', '-o', zipPath, '-d', destDir]);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Cannot extract "${zipPath}": the "unzip" binary was not found on PATH. ` +
+          `Install it and re-run — e.g. "brew install unzip" (macOS), ` +
+          `"apt-get install unzip" (Debian/Ubuntu), or "apk add unzip" (Alpine).`,
+      );
+    }
+    // Non-zero exit (e.g. a corrupt/partial download): surface unzip's own
+    // stderr so the cause is visible rather than a bare exit code.
+    const detail = (err.stderr || err.message || '').toString().trim();
+    throw new Error(
+      `Failed to unzip "${zipPath}" into "${destDir}": ${detail}`,
+    );
+  }
 };

--- a/scripts/extract-zip-native.js
+++ b/scripts/extract-zip-native.js
@@ -1,0 +1,26 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Extract a `.zip` using the system `unzip` binary instead of a yauzl-based
+ * Node extractor (e.g. the `extract-zip` package).
+ *
+ * yauzl/fd-slicer rely on a stream `'close'` event that no longer fires after
+ * EOF on Node >= 24.16.0 (nodejs/node#63487), which deadlocks mid-extraction on
+ * larger archives. As a standalone build script the deadlocked promise just lets
+ * the event loop drain, so the process exits 0 with the target left empty — a
+ * silent failure. This is the same Node 24.16 bug, and the same `unzip`
+ * workaround, as scripts/install-versioned-browsers.sh (commit a261f381).
+ * `unzip` is installed in the base Docker image and ships with macOS and most
+ * Linux dev environments.
+ *
+ * @param {string} zipPath Path to the `.zip` archive
+ * @param {string} destDir Directory to extract into (created if missing)
+ */
+export const extractZip = async (zipPath, destDir) => {
+  // -q: quiet; -o: overwrite existing files without prompting (an interactive
+  // prompt would hang a non-interactive build).
+  await execFileAsync('unzip', ['-q', '-o', zipPath, '-d', destDir]);
+};

--- a/scripts/install-adblock.js
+++ b/scripts/install-adblock.js
@@ -13,8 +13,8 @@ import path, { join } from 'path';
 import { Readable } from 'stream';
 import { deleteAsync } from 'del';
 import { cp } from 'fs/promises';
+import { extractZip } from './extract-zip-native.js';
 import os from 'os';
-import unzip from 'extract-zip';
 
 (async () => {
   const extensionsDir = join(process.cwd(), 'extensions');
@@ -59,7 +59,7 @@ import unzip from 'extract-zip';
   const json = await data.json();
 
   await downloadUrlToDirectory(json.assets[0].browser_download_url, zipFile);
-  await unzip(zipFile, { dir: tmpDir });
+  await extractZip(zipFile, tmpDir);
 
   const findExtensionDir = (dir) => {
     const items = readdirSync(dir);

--- a/scripts/install-adblock.js
+++ b/scripts/install-adblock.js
@@ -90,4 +90,9 @@ import os from 'os';
   await deleteAsync(zipFile, { force: true }).catch((err) => {
     console.warn('Could not delete temporary download file: ' + err.message);
   });
-})();
+})().catch((err) => {
+  console.error(
+    `Failed to install the uBlock Origin Lite extension: ${err.message}`,
+  );
+  process.exitCode = 1;
+});

--- a/scripts/install-devtools.js
+++ b/scripts/install-devtools.js
@@ -1,5 +1,5 @@
 import { rename, rm, unlink } from 'fs/promises';
-import extract from 'extract-zip';
+import { extractZip } from './extract-zip-native.js';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import https from 'https';
@@ -42,7 +42,7 @@ const cleanup = async () => {
       response.pipe(zipStream).on('close', resolve).on('error', reject);
     }),
   );
-  await extract(zipPath, { dir: extractPath });
+  await extractZip(zipPath, extractPath);
   await rename(deepPath, finalPath);
 })()
   .catch((err) => {


### PR DESCRIPTION
## Problem — a silent release regression on Node 24.16

`npm run build` (run by every browser Docker image) extracts two downloads with `extract-zip@2.0.1` (→ yauzl → fd-slicer):

- `build:devtools` → `install-devtools.js`
- `install:adblock` → `install-adblock.js`

On **Node ≥ 24.16.0**, a stream `'close'` event no longer fires after EOF ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)), so yauzl **deadlocks mid-extraction** on larger archives. This is the **same bug** fixed for Playwright/webkit in `a261f381`.

Because these are standalone scripts, the deadlocked promise just lets the event loop drain → the process **exits 0 with the target left empty**. So it fails **silently**:

- `static/devtools/` is empty → the DevTools inspector UI (`/devtools/inspector.html`) 404s.
- `extensions/ublocklite/` is missing → the uBlock adblock extension isn't installed (breaks `?blockAds`).

The base image bumped to Node 24.16.0 (in `a261f381`), so **images built since then are affected**. No CI job caught it — the test workflow runs `build:tests`, which doesn't include `build:devtools`/`install:adblock`.

### Investigation (reproduced on real Linux + Node 24.16)

| Build step | Extractor | Node 24.15 | Node 24.16 |
|---|---|---|---|
| `install-devtools.js` | extract-zip | ✅ works | ❌ deadlock → empty |
| `install-adblock.js` | extract-zip | ✅ works | ❌ deadlock → empty |
| `install-debugger.js` | tar-fs/gunzip | ✅ | ✅ (not yauzl — unaffected) |
| `install-versioned-browsers.sh` | system `unzip` | ✅ | ✅ (already fixed in `a261f381`) |

## Fix

Extract via the system `unzip` binary instead of yauzl, in a small shared helper `scripts/extract-zip-native.js`. This matches the `install-versioned-browsers.sh` workaround. `unzip` is already installed in the base image (`docker/base/Dockerfile:60`) and ships with macOS / most Linux dev environments.

`extract-zip` is no longer imported directly, so it's dropped from `devDependencies` (still present transitively via `puppeteer-core`/`lighthouse`; lockfile diff is a single edge removal).

## Validation

- **Node 24.16 (release toolchain):** before = both deadlock to empty (exit 0); after = both extract correctly.
- **Full `npm run build`** runs green end-to-end in a Node 24.16 + unzip container — devtools 131 files, adblock manifest present, 101 schemas, TS compiled.
- **Local macOS:** both scripts produce output and clean up temp artifacts.
- `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the external `extract-zip` dependency and switched to using the system unzip utility for archive extraction during extension and tool installs.
* **Bug Fixes**
  * Improved installation error handling and logging to surface failures (sets non-zero exit code) and avoid silent crashes when extraction or required system tools are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/browserless/browserless/pull/5405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->