### PR TITLE
feat: expose the matched route on the after() AfterResponse

### DIFF
--- a/src/limiter.ts
+++ b/src/limiter.ts
@@ -5,6 +5,7 @@ import {
   Logger,
   Metrics,
   Monitoring,
+  Route,
   TooManyRequests,
   WebHooks,
 } from '@browserless.io/browserless';
@@ -22,6 +23,7 @@ interface Job {
   onTimeoutFn(job: Job): unknown;
   start: number;
   timeout: number;
+  route?: Route;
 }
 
 export class Limiter extends q {
@@ -100,6 +102,7 @@ export class Limiter extends q {
       req: job.args[0],
       start: job.start,
       status: 'successful',
+      route: job.route,
     } as AfterResponse);
   }
 
@@ -120,6 +123,7 @@ export class Limiter extends q {
       req: job.args[0],
       start: job.start,
       status: 'timedout',
+      route: job.route,
     } as AfterResponse);
 
     next();
@@ -139,6 +143,7 @@ export class Limiter extends q {
       req: job.args[0],
       start: job.start,
       status: 'error',
+      route: job.route,
       error:
         error instanceof Error
           ? error
@@ -178,6 +183,7 @@ export class Limiter extends q {
     onTimeoutFn: ErrorFn<TArgs>,
     timeoutOverrideFn: (...args: TArgs) => number | undefined,
     bypassLimitsFn?: (...args: TArgs) => boolean,
+    route?: Route,
   ): LimitFn<TArgs, unknown> {
     return (...args: TArgs) =>
       new Promise(async (res, rej) => {
@@ -261,6 +267,7 @@ export class Limiter extends q {
           onTimeoutFn: () => onTimeoutFn(...args),
           start: Date.now(),
           timeout,
+          route,
         });
 
         this.push(job);

--- a/src/router.ts
+++ b/src/router.ts
@@ -13,6 +13,7 @@ import {
   PathTypes,
   Request,
   Response,
+  Route,
   WebSocketRoute,
   contentTypes,
   isConnected,
@@ -102,6 +103,7 @@ export class Router extends EventEmitter {
    */
   protected wrapWithAfterHook<TArgs extends [Request, ...unknown[]], TResult>(
     handler: (...args: TArgs) => Promise<TResult | typeof ROUTE_DID_NOT_RUN>,
+    route?: Route,
   ): (...args: TArgs) => Promise<TResult | typeof ROUTE_DID_NOT_RUN> {
     return async (...args: TArgs) => {
       const start = Date.now();
@@ -109,7 +111,7 @@ export class Router extends EventEmitter {
       try {
         const result = await handler(...args);
         if (result !== ROUTE_DID_NOT_RUN) {
-          this.fireAfterHook({ req, start, status: 'successful' });
+          this.fireAfterHook({ req, start, status: 'successful', route });
         }
         return result;
       } catch (err) {
@@ -124,7 +126,7 @@ export class Router extends EventEmitter {
                 ),
                 { cause: err },
               );
-        this.fireAfterHook({ req, start, status: 'error', error });
+        this.fireAfterHook({ req, start, status: 'error', error, route });
         throw error;
       }
     };
@@ -259,8 +261,9 @@ export class Router extends EventEmitter {
           this.onHTTPTimeout.bind(this),
           this.getTimeout.bind(this),
           route.bypassLimits?.bind(route),
+          route,
         )
-      : this.wrapWithAfterHook(wrapped);
+      : this.wrapWithAfterHook(wrapped, route);
     route.path = Array.isArray(route.path) ? route.path : [route.path];
     const registeredPaths = this.httpRoutes.map((r) => r.path).flat();
     const duplicatePaths = registeredPaths.filter((path) =>
@@ -292,8 +295,9 @@ export class Router extends EventEmitter {
           this.onWebsocketTimeout.bind(this),
           this.getTimeout.bind(this),
           route.bypassLimits?.bind(route),
+          route,
         )
-      : this.wrapWithAfterHook(wrapped);
+      : this.wrapWithAfterHook(wrapped, route);
     route.path = Array.isArray(route.path) ? route.path : [route.path];
     const registeredPaths = this.webSocketRoutes.map((r) => r.path).flat();
     const duplicatePaths = registeredPaths.filter((path) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,12 @@ export interface AfterResponse {
   start: number;
   status: 'successful' | 'error' | 'timedout';
   error?: Error;
+  /**
+   * The route that handled the request, when one matched — so `after()`
+   * consumers can identify which route ran without re-matching the request
+   * against the router. Omitted when no route ran (e.g. an unmatched 404).
+   */
+  route?: Route;
 }
 
 export interface BrowserHook {
@@ -92,7 +98,7 @@ type defaultLaunchOptions =
   | BrowserlessLaunch
   | ((req: Request) => CDPLaunchOptions | BrowserlessLaunch);
 
-abstract class Route {
+export abstract class Route {
   constructor(
     protected _browserManager: Browserless['browserManager'],
     protected _config: Browserless['config'],


### PR DESCRIPTION
## What

Expose the matched `Route` on the `after()` lifecycle payload as an optional `AfterResponse.route`, so consumers can tell which route handled a request without re-matching it against the router.

## Why

`AfterResponse` currently carries only `req` / `start` / `status` / `error`. A consumer that needs per-route context inside `after()` has to re-run the router's matching against `req` — wasteful, and it couples the consumer to router internals.

## How

The matched route is threaded through **both** `after()`-firing paths:

- **`concurrency = false`** routes (`Router.wrapWithAfterHook`): the route is passed through and included in `fireAfterHook`.
- **`concurrency = true`** routes (`Limiter`): the `Limiter` only had the `Job`, not the route, so the route is now stored on the `Job` and emitted from the success / timeout / error job-end handlers.

`registerHTTPRoute` / `registerWebSocketRoute` pass the route into both paths, and the `Route` base class is exported so consumers can name the type.

## Backwards compatibility

Every addition is optional/additive — **non-breaking, minor-version**:

- `AfterResponse.route?` is optional → existing `after()` overrides and any code that constructs an `AfterResponse` are unaffected.
- `export Route` is additive (auto-surfaced via `export * from './types.js'`).
- `Limiter.limit(…, route?)` and `Router.wrapWithAfterHook(handler, route?)` gain optional trailing params, so existing/subclass callers keep working.

No runtime behavior change for existing consumers — the router/limiter already have the route in scope, so populating it is free. `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced route context tracking throughout the request lifecycle
  * Route information is now available to request lifecycle hooks for both concurrency-controlled and bypass requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->