### PR TITLE
fix: block file:// in Playwright WS routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "queue": "^7.0.0",
         "systeminformation": "^5.31.7",
-        "tar-fs": "^3.1.2"
+        "tar-fs": "^3.1.2",
+        "ws": "^8.18.0"
       },
       "bin": {
         "browserless": "bin/browserless.js"
@@ -42,6 +43,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.9.1",
         "@types/sinon": "^21.0.1",
+        "@types/ws": "^8.5.13",
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.59.3",
         "c8": "^11.0.0",
@@ -1856,6 +1858,16 @@
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
       "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -4420,9 +4432,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4452,6 +4464,27 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/lighthouse/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/locate-path": {
@@ -5196,27 +5229,6 @@
       "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
       "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/puppeteer-extra": {
       "version": "3.3.6",
@@ -6593,16 +6605,16 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "puppeteer-extra-plugin-stealth": "^2.11.2",
     "queue": "^7.0.0",
     "systeminformation": "^5.31.7",
-    "tar-fs": "^3.1.2"
+    "tar-fs": "^3.1.2",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/chai": "^5.2.3",
@@ -80,6 +81,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.9.1",
     "@types/sinon": "^21.0.1",
+    "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.59.3",
     "c8": "^11.0.0",

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -7,6 +7,7 @@ import {
   ServerError,
   chromeExecutablePath,
   edgeExecutablePath,
+  findBlockedUrlInMessage,
   noop,
   once,
   ublockLitePath,
@@ -106,33 +107,33 @@ export class ChromiumCDP extends EventEmitter {
           this.logger.warn(`"${req.failure()?.errorText}": ${req.url()}`);
         });
 
-        page.on('request', async (request) => {
-          this.logger.trace(`${request.method()}: ${request.url()}`);
-          if (
-            !this.config.getAllowFileProtocol() &&
-            request.url().startsWith('file://')
-          ) {
+        const terminateIfBlocked = (
+          url: string,
+          direction: 'request' | 'response',
+        ): void => {
+          // Wrap as `{ url }` so we share the Playwright bridge's
+          // normalize + match helper rather than duplicating it.
+          const blocked = findBlockedUrlInMessage(
+            { url },
+            this.config.getBlockedURLPatterns(),
+          );
+          if (blocked) {
             this.logger.error(
-              `File protocol request found in request to ${this.constructor.name}, terminating`,
+              `Blocked URL pattern "${blocked}" in ${direction} to ${this.constructor.name}, terminating`,
             );
             page.close().catch(noop);
             this.close();
           }
+        };
+
+        page.on('request', async (request) => {
+          this.logger.trace(`${request.method()}: ${request.url()}`);
+          terminateIfBlocked(request.url(), 'request');
         });
 
         page.on('response', async (response) => {
           this.logger.trace(`${response.status()}: ${response.url()}`);
-
-          if (
-            !this.config.getAllowFileProtocol() &&
-            response.url().startsWith('file://')
-          ) {
-            this.logger.error(
-              `File protocol request found in response to ${this.constructor.name}, terminating`,
-            );
-            page.close().catch(noop);
-            this.close();
-          }
+          terminateIfBlocked(response.url(), 'response');
         });
 
         this.emit('newPage', page);

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -1,0 +1,749 @@
+import { expect } from 'chai';
+import {
+  Config,
+  Logger,
+  findBlockedUrlInMessage,
+  normalizeUrlForBlocklist,
+  wsFrameToString,
+} from '@browserless.io/browserless';
+import {
+  ChromiumPlaywright,
+  FirefoxPlaywright,
+  WebKitPlaywright,
+} from './browsers.playwright.js';
+import net, { AddressInfo } from 'net';
+import { WebSocket, WebSocketServer } from 'ws';
+import { createServer, IncomingMessage, Server } from 'http';
+
+/** Poll `cond` every 10ms up to `timeoutMs`; replaces brittle fixed sleeps. */
+const waitFor = async (
+  cond: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> => {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+};
+
+describe('BasePlaywright URL filter', () => {
+  describe('wsFrameToString', () => {
+    it('decodes a plain Buffer (default ws nodebuffer mode)', () => {
+      const buf = Buffer.from('{"k":"v"}', 'utf-8');
+      expect(wsFrameToString(buf)).to.equal('{"k":"v"}');
+    });
+
+    it('decodes a Buffer[] fragment list (defensive)', () => {
+      const parts = [
+        Buffer.from('{"a":"', 'utf-8'),
+        Buffer.from('b"}', 'utf-8'),
+      ];
+      expect(wsFrameToString(parts)).to.equal('{"a":"b"}');
+    });
+
+    it('decodes an ArrayBuffer (ws arraybuffer mode)', () => {
+      const src = Buffer.from('{"x":1}', 'utf-8');
+      const ab = src.buffer.slice(
+        src.byteOffset,
+        src.byteOffset + src.byteLength,
+      );
+      expect(wsFrameToString(ab as ArrayBuffer)).to.equal('{"x":1}');
+    });
+  });
+
+  describe('normalizeUrlForBlocklist', () => {
+    it('lowercases the scheme', () => {
+      expect(normalizeUrlForBlocklist('FILE:///etc/passwd')).to.match(
+        /^file:\/\//,
+      );
+    });
+    it('strips leading whitespace + control chars', () => {
+      expect(normalizeUrlForBlocklist(' \tfile:///x')).to.match(/^file:\/\//);
+      expect(normalizeUrlForBlocklist('\x01file:///x')).to.match(/^file:\/\//);
+    });
+    it('canonicalizes single-slash file:/etc/passwd', () => {
+      expect(normalizeUrlForBlocklist('file:/etc/passwd')).to.match(
+        /^file:\/\//,
+      );
+    });
+    it('unwraps nested view-source: wrappers', () => {
+      expect(
+        normalizeUrlForBlocklist('view-source:view-source:file:///etc/passwd'),
+      ).to.match(/^file:\/\//);
+    });
+    it('falls back to lowercased trim when URL parse fails', () => {
+      expect(normalizeUrlForBlocklist(' NOT A URL ')).to.equal('not a url');
+    });
+  });
+
+  describe('boundary: other URL wrappers are NOT unwrapped', () => {
+    it('blob:file:// — match relies on the inner scheme not being unwrapped', () => {
+      expect(
+        findBlockedUrlInMessage({ url: 'blob:file:///etc/passwd' }, [
+          'file://',
+        ]),
+      ).to.equal(null);
+    });
+    it('filesystem:file:// — same', () => {
+      expect(
+        findBlockedUrlInMessage({ url: 'filesystem:file:///etc/passwd' }, [
+          'file://',
+        ]),
+      ).to.equal(null);
+    });
+    it('data: with file:// content is not unwrapped', () => {
+      expect(
+        findBlockedUrlInMessage({ url: 'data:text/plain,file:///etc/passwd' }, [
+          'file://',
+        ]),
+      ).to.equal(null);
+    });
+  });
+
+  describe('Config.getBlockedURLPatterns', () => {
+    it('returns ["file://"] when ALLOW_FILE_PROTOCOL is false (default)', () => {
+      const config = new Config();
+      config.setAllowFileProtocol(false);
+      expect(config.getBlockedURLPatterns()).to.deep.equal(['file://']);
+    });
+
+    it('returns [] when ALLOW_FILE_PROTOCOL is true', () => {
+      const config = new Config();
+      config.setAllowFileProtocol(true);
+      expect(config.getBlockedURLPatterns()).to.deep.equal([]);
+    });
+  });
+
+  describe('findBlockedUrlInMessage', () => {
+    const patterns = ['file://', 'smtp://', 'ftp://'];
+
+    it('returns null when patterns list is empty', () => {
+      const msg = {
+        method: 'Frame.goto',
+        params: { url: 'file:///etc/passwd' },
+      };
+      expect(findBlockedUrlInMessage(msg, [])).to.equal(null);
+    });
+
+    it('returns null when message is null/primitive', () => {
+      expect(findBlockedUrlInMessage(null, patterns)).to.equal(null);
+      expect(findBlockedUrlInMessage(42, patterns)).to.equal(null);
+      expect(findBlockedUrlInMessage('file://', patterns)).to.equal(null);
+    });
+
+    it('finds a top-level url field', () => {
+      const msg = { url: 'file:///etc/passwd' };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal('file://');
+    });
+
+    it('finds a url inside nested params', () => {
+      const msg = {
+        method: 'Frame.goto',
+        params: { url: 'file:///etc/passwd', waitUntil: 'load' },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal('file://');
+    });
+
+    it('finds a url inside doubly-nested params', () => {
+      const msg = {
+        method: 'BrowserContext.request',
+        params: { request: { url: 'file:///proc/self/environ' } },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal('file://');
+    });
+
+    it('finds non-file blocked schemes', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'smtp://relay.example.com' } },
+          patterns,
+        ),
+      ).to.equal('smtp://');
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'ftp://target/file' } },
+          patterns,
+        ),
+      ).to.equal('ftp://');
+    });
+
+    it('is case-insensitive on the URL key name', () => {
+      expect(
+        findBlockedUrlInMessage({ URL: 'file:///etc/passwd' }, patterns),
+      ).to.equal('file://');
+      expect(
+        findBlockedUrlInMessage({ Url: 'file:///etc/passwd' }, patterns),
+      ).to.equal('file://');
+    });
+
+    it('ignores non-url keys whose value happens to contain "file://"', () => {
+      const msg = {
+        method: 'Runtime.evaluate',
+        params: { expression: 'fetch("file:///etc/passwd")' },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal(null);
+    });
+
+    it('ignores url fields whose value does not start with a blocked pattern', () => {
+      const msg = {
+        method: 'Frame.goto',
+        params: { url: 'https://example.com/file://' },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal(null);
+    });
+
+    it('ignores fields named urlFilter / urlPrefix (not navigation URLs)', () => {
+      const msg = {
+        method: 'recordHar',
+        params: { urlFilter: 'file://', urlPrefix: 'file://' },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal(null);
+    });
+
+    it('returns null when no blocked URL is present', () => {
+      const msg = {
+        method: 'Frame.goto',
+        params: { url: 'https://example.com', waitUntil: 'load' },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal(null);
+    });
+
+    it('handles arrays in the message tree', () => {
+      const msg = {
+        method: 'BrowserContext.routeContinue',
+        params: {
+          routes: [
+            { url: 'https://example.com' },
+            { url: 'file:///etc/passwd' },
+          ],
+        },
+      };
+      expect(findBlockedUrlInMessage(msg, patterns)).to.equal('file://');
+    });
+
+    // === Evasion battery — every entry below must block ===========================
+    // These cover normalizations Chromium performs before navigation that a
+    // naive `value.startsWith('file://')` check would miss.
+
+    it('blocks uppercase scheme FILE://', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'FILE:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks mixed-case scheme File://', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'File:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks leading whitespace before scheme', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: '  file:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks leading tab + newline before scheme', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: '\t\nfile:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks single-slash file:/etc/passwd (Chromium canonicalizes to file:///)', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'file:/etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks view-source:file:///etc/passwd wrapper', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'view-source:file:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks nested view-source:view-source:file://', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'view-source:view-source:file:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks case-mixed view-source wrapper VIEW-SOURCE:File://', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'VIEW-SOURCE:File:///etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+
+    it('blocks file://localhost/etc/passwd (Chromium drops "localhost" host)', () => {
+      expect(
+        findBlockedUrlInMessage(
+          { params: { url: 'file://localhost/etc/passwd' } },
+          patterns,
+        ),
+      ).to.equal('file://');
+    });
+  });
+
+  /**
+   * End-to-end bridge test: wires up a fake "upstream" WebSocket server
+   * standing in for the Playwright launchServer endpoint, points a
+   * ChromiumPlaywright instance at it, and proxies through the actual
+   * `proxyWebSocket` code path. Verifies that a real Frame.goto JSON-RPC
+   * frame carrying file:// is blocked end-to-end: never reaches the
+   * upstream, client connection is closed with status 1008, and the
+   * browser wrapper is torn down.
+   */
+  describe('proxyWebSocket bridge', () => {
+    let fakeUpstreamServer: WebSocketServer;
+    let fakeUpstreamPort: number;
+    let upstreamMessages: string[];
+    let bridgeServer: Server;
+    let bridgePort: number;
+    let playwright: ChromiumPlaywright;
+    let upstreamCloseReasons: number[];
+
+    beforeEach(async () => {
+      upstreamMessages = [];
+      upstreamCloseReasons = [];
+
+      // 1. Fake upstream — collects what the bridge forwards.
+      fakeUpstreamServer = new WebSocketServer({ port: 0 });
+      await new Promise<void>((resolve) =>
+        fakeUpstreamServer.on('listening', () => resolve()),
+      );
+      fakeUpstreamPort = (fakeUpstreamServer.address() as AddressInfo).port;
+      fakeUpstreamServer.on('connection', (ws) => {
+        ws.on('message', (data) => {
+          upstreamMessages.push(data.toString());
+          // Echo any non-blocking message back so the bridge has both
+          // directions exercised in tests where we expect success.
+          ws.send(
+            JSON.stringify({ id: 1, result: { ack: upstreamMessages.length } }),
+          );
+        });
+        ws.on('close', (code) => upstreamCloseReasons.push(code));
+      });
+
+      // 2. ChromiumPlaywright wired to point at the fake upstream.
+      const config = new Config();
+      config.setAllowFileProtocol(false);
+      playwright = new ChromiumPlaywright({
+        config,
+        userDataDir: null,
+        logger: new Logger('test'),
+      });
+      (
+        playwright as unknown as { browserWSEndpoint: string }
+      ).browserWSEndpoint = `ws://127.0.0.1:${fakeUpstreamPort}/`;
+      (playwright as unknown as { running: boolean }).running = true;
+      // Stub the launched browser so close() has something to tear down.
+      (playwright as unknown as { browser: unknown }).browser = {
+        close: async () => undefined,
+      };
+
+      // 3. HTTP server hosting the bridge — routes WS upgrades into
+      // `proxyWebSocket`. `.catch()` swallows the rejection so error-path
+      // tests don't trigger unhandled rejections.
+      bridgeServer = createServer();
+      bridgeServer.on('upgrade', (req: IncomingMessage, socket, head) => {
+        (req as unknown as { parsed: URL }).parsed = new URL(
+          `http://localhost${req.url ?? '/'}`,
+        );
+        playwright
+          .proxyWebSocket(req as never, socket as never, head as never)
+          .catch(() => {
+            /* error-path tests assert via close events */
+          });
+      });
+      await new Promise<void>((resolve) => {
+        bridgeServer.listen(0, () => resolve());
+      });
+      bridgePort = (bridgeServer.address() as AddressInfo).port;
+    });
+
+    afterEach(async () => {
+      await new Promise<void>((resolve) =>
+        fakeUpstreamServer.close(() => resolve()),
+      );
+      await new Promise<void>((resolve) => bridgeServer.close(() => resolve()));
+    });
+
+    it('forwards a benign Frame.goto to the upstream', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      client.send(
+        JSON.stringify({
+          id: 1,
+          method: 'goto',
+          params: { url: 'https://example.com' },
+        }),
+      );
+      await waitFor(() => upstreamMessages.length >= 1);
+      expect(upstreamMessages).to.have.lengthOf(1);
+      const parsed = JSON.parse(upstreamMessages[0]);
+      expect(parsed.params.url).to.equal('https://example.com');
+      client.close();
+    });
+
+    it('echoes the upstream ack back to the client (benign forward in both directions)', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const received: string[] = [];
+      client.on('message', (data) => received.push(data.toString()));
+      client.send(
+        JSON.stringify({
+          id: 9,
+          method: 'goto',
+          params: { url: 'https://example.com' },
+        }),
+      );
+      await waitFor(() => received.length >= 1);
+      const echoed = JSON.parse(received[0]);
+      expect(echoed).to.have.nested.property('result.ack', 1);
+      client.close();
+    });
+
+    it('blocks a Frame.goto carrying file:// and tears down the session', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<{ code: number; reason: string }>(
+        (resolve) =>
+          client.on('close', (code, reason) =>
+            resolve({ code, reason: reason.toString() }),
+          ),
+      );
+      client.send(
+        JSON.stringify({
+          id: 2,
+          method: 'goto',
+          params: { url: 'file:///etc/passwd' },
+        }),
+      );
+      const close = await closeEvent;
+      expect(close.code).to.equal(1008);
+      expect(close.reason).to.match(/Blocked URL pattern/);
+      expect(upstreamMessages).to.have.lengthOf(0);
+      await waitFor(() => playwright.wsEndpoint() === null);
+    });
+
+    it('blocks a Frame.goto carrying file:// sent as a BINARY frame', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<number>((resolve) =>
+        client.on('close', (code) => resolve(code)),
+      );
+      // Same JSON-RPC command as a binary frame — upstream parses every
+      // opcode, so skipping binary here would be a filter bypass.
+      client.send(
+        Buffer.from(
+          JSON.stringify({
+            id: 5,
+            method: 'goto',
+            params: { url: 'file:///etc/passwd' },
+          }),
+        ),
+        { binary: true },
+      );
+      const code = await closeEvent;
+      expect(code).to.equal(1008);
+      expect(upstreamMessages).to.have.lengthOf(0);
+      await waitFor(() => playwright.wsEndpoint() === null);
+    });
+
+    it('blocks a server→client request event carrying file:// (indirect navigation, e.g. via page.evaluate fetch)', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<number>((resolve) =>
+        client.on('close', (code) => resolve(code)),
+      );
+      // Simulate Chromium initiating a file:// fetch on its own (e.g.
+      // JS-side fetch after a legitimate goto). Poll until the bridge's
+      // upstream side is connected rather than guessing with a sleep.
+      await waitFor(() => fakeUpstreamServer.clients.size > 0);
+      for (const ws of fakeUpstreamServer.clients) {
+        ws.send(
+          JSON.stringify({
+            guid: 'browser-context-1',
+            method: 'request',
+            params: { request: { url: 'file:///proc/self/environ' } },
+          }),
+        );
+      }
+      const code = await closeEvent;
+      expect(code).to.equal(1008);
+      await waitFor(() => playwright.wsEndpoint() === null);
+    });
+
+    it('blocks percent-encoded `file:%2f%2f…` via the synthesized file:// authority', () => {
+      // `new URL('file:%2f%2fetc/passwd').href` → `file:///%2f%2fetc/passwd`
+      // (`%2f` stays encoded); match hits the synthesized `file://` prefix.
+      expect(
+        findBlockedUrlInMessage({ url: 'file:%2f%2fetc/passwd' }, ['file://']),
+      ).to.equal('file://');
+    });
+
+    it('blocks Unicode-escaped scheme (`\\u0066ile://...`) the upstream would decode', async () => {
+      // Raw frame has no literal `file`; the upstream's `JSON.parse`
+      // would decode `f` to `f`, so the bridge must too.
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<number>((resolve) =>
+        client.on('close', (code) => resolve(code)),
+      );
+      // Build the JSON string by hand — `JSON.stringify` would
+      // collapse `f` back to a literal `f`.
+      const rawJson =
+        '{"id":1,"method":"goto","params":{"url":"\\u0066ile:///etc/passwd"}}';
+      expect(rawJson).to.not.match(/file/);
+      client.send(rawJson);
+      const code = await closeEvent;
+      expect(code).to.equal(1008);
+      expect(upstreamMessages).to.have.lengthOf(0);
+      await waitFor(() => playwright.wsEndpoint() === null);
+    });
+
+    it('fails closed on unparseable frame containing a blocked stem', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<number>((resolve) =>
+        client.on('close', (code) => resolve(code)),
+      );
+      // Not valid JSON; contains `file://` substring.
+      client.send('not-json{ file:///etc/passwd');
+      const code = await closeEvent;
+      expect(code).to.equal(1008);
+      expect(upstreamMessages).to.have.lengthOf(0);
+    });
+
+    it('forwards an unparseable BINARY frame even when it bears a blocked stem', async () => {
+      // Mirror of the text-frame fail-closed: a benign binary blob
+      // containing a `file` byte run (e.g. a profile filename in a
+      // proprietary binary protocol) must still pass through, since
+      // upstream parses with JSON.parse and won't act on it either.
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const blob = Buffer.from(
+        '\x00\x01file://something-that-is-not-json\xff\xfe',
+        'binary',
+      );
+      client.send(blob, { binary: true });
+      await waitFor(() => upstreamMessages.length >= 1);
+      expect(upstreamMessages).to.have.lengthOf(1);
+      client.close();
+    });
+
+    it('forwards unparseable frames that do not bear a blocked stem', async () => {
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      client.send('plain-text-keepalive');
+      await waitFor(() => upstreamMessages.length >= 1);
+      expect(upstreamMessages[0]).to.equal('plain-text-keepalive');
+      client.close();
+    });
+
+    it('aborted upgrade settles the Promise via the socket backstop', async () => {
+      // Malformed upgrade (no `Sec-WebSocket-Key`) — `ws` aborts and
+      // never invokes the upgrade callback. The Promise has to settle
+      // via the socket-close backstop or the slot leaks.
+      let resolved = false;
+      const ranToCompletion = new Promise<void>((resolve) => {
+        // Hook a fresh upgrade handler that exposes the Promise.
+        const onUpgrade = (
+          req: IncomingMessage,
+          socket: import('stream').Duplex,
+          head: Buffer,
+        ) => {
+          (req as unknown as { parsed: URL }).parsed = new URL(
+            `http://localhost${req.url ?? '/'}`,
+          );
+          playwright
+            .proxyWebSocket(req as never, socket as never, head as never)
+            .catch(() => undefined)
+            .finally(() => {
+              resolved = true;
+              resolve();
+            });
+        };
+        bridgeServer.removeAllListeners('upgrade');
+        bridgeServer.on('upgrade', onUpgrade);
+      });
+
+      // Raw TCP upgrade lacking Sec-WebSocket-Key — `ws` will reject.
+      const raw = net.connect(bridgePort, '127.0.0.1');
+      await new Promise<void>((r) => raw.on('connect', () => r()));
+      raw.write(
+        'GET / HTTP/1.1\r\n' +
+          'Host: 127.0.0.1\r\n' +
+          'Connection: Upgrade\r\n' +
+          'Upgrade: websocket\r\n' +
+          'Sec-WebSocket-Version: 13\r\n' +
+          '\r\n',
+      );
+      await Promise.race([
+        ranToCompletion,
+        new Promise<void>((_, rj) =>
+          setTimeout(
+            () =>
+              rj(new Error('bridge promise did not settle on aborted upgrade')),
+            2000,
+          ),
+        ),
+      ]);
+      expect(resolved).to.equal(true);
+      raw.destroy();
+    });
+
+    it('blocks Frame.goto with file:// across Firefox and WebKit subclasses', async () => {
+      for (const Subclass of [FirefoxPlaywright, WebKitPlaywright]) {
+        const upstream = new WebSocketServer({ port: 0 });
+        await new Promise<void>((r) => upstream.on('listening', () => r()));
+        const upPort = (upstream.address() as AddressInfo).port;
+        const seen: string[] = [];
+        upstream.on('connection', (ws) => {
+          ws.on('message', (data) => seen.push(data.toString()));
+        });
+        const cfg = new Config();
+        cfg.setAllowFileProtocol(false);
+        const subjectInstance = new Subclass({
+          config: cfg,
+          userDataDir: null,
+          logger: new Logger('test'),
+        });
+        (
+          subjectInstance as unknown as { browserWSEndpoint: string }
+        ).browserWSEndpoint = `ws://127.0.0.1:${upPort}/`;
+        (subjectInstance as unknown as { running: boolean }).running = true;
+        (subjectInstance as unknown as { browser: unknown }).browser = {
+          close: async () => undefined,
+        };
+        const subjectServer = createServer();
+        subjectServer.on('upgrade', (r: IncomingMessage, sock, h) => {
+          (r as unknown as { parsed: URL }).parsed = new URL(
+            `http://localhost${r.url ?? '/'}`,
+          );
+          subjectInstance
+            .proxyWebSocket(r as never, sock as never, h as never)
+            .catch(() => {
+              /* error paths assert via close events */
+            });
+        });
+        await new Promise<void>((r) => subjectServer.listen(0, () => r()));
+        const port = (subjectServer.address() as AddressInfo).port;
+
+        try {
+          const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+          await new Promise<void>((resolve, reject) => {
+            client.on('open', () => resolve());
+            client.on('error', reject);
+          });
+          const closeEvent = new Promise<{ code: number; reason: string }>(
+            (resolve) =>
+              client.on('close', (code, reason) =>
+                resolve({ code, reason: reason.toString() }),
+              ),
+          );
+          client.send(
+            JSON.stringify({
+              id: 1,
+              method: 'goto',
+              params: { url: 'file:///etc/passwd' },
+            }),
+          );
+          const close = await closeEvent;
+          expect(close.code, `${Subclass.name} close code`).to.equal(1008);
+          expect(close.reason, `${Subclass.name} close reason`).to.match(
+            /Blocked URL pattern/,
+          );
+          expect(close.reason, `${Subclass.name} class in reason`).to.match(
+            new RegExp(Subclass.name),
+          );
+          expect(seen.length, `${Subclass.name} upstream untouched`).to.equal(
+            0,
+          );
+        } finally {
+          await new Promise<void>((r) => subjectServer.close(() => r()));
+          await new Promise<void>((r) => upstream.close(() => r()));
+        }
+      }
+    });
+
+    it('does not block when ALLOW_FILE_PROTOCOL is true (empty patterns)', async () => {
+      // Re-wire with file protocol allowed.
+      (playwright as unknown as { config: Config }).config.setAllowFileProtocol(
+        true,
+      );
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      client.send(
+        JSON.stringify({
+          id: 3,
+          method: 'goto',
+          params: { url: 'file:///etc/passwd' },
+        }),
+      );
+      await waitFor(() => upstreamMessages.length >= 1);
+      // File-protocol-allowed: message should pass through to upstream.
+      expect(upstreamMessages).to.have.lengthOf(1);
+      expect(playwright.wsEndpoint()).to.equal(
+        `ws://127.0.0.1:${fakeUpstreamPort}/`,
+      );
+      client.close();
+    });
+  });
+});

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -7,11 +7,14 @@ import {
   ServerError,
   chromeExecutablePath,
   edgeExecutablePath,
+  findBlockedUrlInMessage,
+  wsFrameToString,
 } from '@browserless.io/browserless';
+import { WebSocket, WebSocketServer } from 'ws';
 import playwright, { Page } from 'playwright-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
-import httpProxy from 'http-proxy';
+import type { IncomingMessage } from 'http';
 import path from 'path';
 
 enum PlaywrightBrowserTypes {
@@ -26,7 +29,6 @@ class BasePlaywright extends EventEmitter {
   protected running = false;
   protected logger: Logger;
   protected socket: Duplex | null = null;
-  protected proxy = httpProxy.createProxyServer();
   protected browser: playwright.BrowserServer | null = null;
   protected browserWSEndpoint: string | null = null;
   protected playwrightBrowserType: PlaywrightBrowserTypes =
@@ -34,9 +36,17 @@ class BasePlaywright extends EventEmitter {
   protected executablePath = () =>
     playwright[this.playwrightBrowserType].executablePath();
   protected async resolveExecutablePath(pwVersion: string): Promise<string> {
-    return this.config.resolveExecutablePath(this.playwrightBrowserType, pwVersion);
+    return this.config.resolveExecutablePath(
+      this.playwrightBrowserType,
+      pwVersion,
+    );
   }
   protected keepUntilMS = 0;
+
+  // One shared WebSocketServer for upgrade handling. `noServer: true` means
+  // it never owns an HTTP server — it only does the upgrade dance when we
+  // call `handleUpgrade` from `proxyWebSocket`.
+  private static wsServer = new WebSocketServer({ noServer: true });
 
   constructor({
     config,
@@ -210,6 +220,13 @@ class BasePlaywright extends EventEmitter {
     this.logger.error(`Not yet implemented in ${this.constructor.name}`);
   }
 
+  /**
+   * Frame-aware bidirectional WS forwarder. Inspects every Playwright
+   * JSON-RPC frame and rejects messages — in either direction — whose
+   * navigation URL matches `Config.getBlockedURLPatterns()`. Playwright's
+   * `launchServer()` exposes only a raw WS pipe, so unlike CDP there's
+   * no `Page` object to attach `request`/`response` listeners to.
+   */
   public async proxyWebSocket(
     req: Request,
     socket: Duplex,
@@ -222,31 +239,241 @@ class BasePlaywright extends EventEmitter {
           `No browserWSEndpoint found, did you launch first?`,
         );
       }
-      socket.once('close', resolve);
-
       this.logger.info(
         `Proxying ${req.parsed.href} to ${this.constructor.name} ${this.browserWSEndpoint}`,
       );
 
-      // Delete headers known to cause issues
+      // Drops the client's `Origin` (localhost upstream would otherwise
+      // reject it) and any negotiated subprotocol/extensions; `launchServer()`
+      // negotiates neither, matching the prior `http-proxy.ws()` behavior.
       delete req.headers.origin;
 
-      req.url = '';
+      const safeClose = (ws?: { close: () => void }) => {
+        try {
+          ws?.close();
+        } catch {
+          /* ignore */
+        }
+      };
 
-      this.proxy.ws(
-        req,
+      // `ws.handleUpgrade` silently drops the callback on a malformed
+      // upgrade (e.g. bad `Sec-WebSocket-Key`). Without a socket-level
+      // backstop the Promise would hang, pinning the concurrency slot.
+      let settled = false;
+      let clientWS: WebSocket | undefined;
+      let upstreamWS: WebSocket | undefined;
+      const finish = (err?: Error) => {
+        if (settled) return;
+        settled = true;
+        safeClose(clientWS);
+        safeClose(upstreamWS);
+        if (err) reject(err);
+        else resolve();
+      };
+      // Routine TCP RSTs from clients land here as `'error'` ahead of
+      // the upstream-handler chain. Resolve rather than reject so a
+      // disconnected client isn't treated as a server fault. Aborted
+      // upgrades still surface via the paired `'close'` backstop.
+      socket.once('close', () => finish());
+      socket.once('error', () => finish());
+
+      BasePlaywright.wsServer.handleUpgrade(
+        req as unknown as IncomingMessage,
         socket,
         head,
-        {
-          changeOrigin: true,
-          target: this.browserWSEndpoint,
-        },
-        (error) => {
-          this.logger.error(
-            `Error proxying session to ${this.constructor.name}: ${error}`,
-          );
-          this.close();
-          return reject(error);
+        (ws) => {
+          clientWS = ws;
+          try {
+            upstreamWS = new WebSocket(this.browserWSEndpoint!);
+          } catch (err) {
+            this.logger.error(
+              {
+                err: (err as Error).message,
+                browserWSEndpoint: this.browserWSEndpoint,
+                href: req.parsed.href,
+              },
+              `${this.constructor.name} bridge setup failed`,
+            );
+            safeClose(ws);
+            finish(err as Error);
+            return;
+          }
+
+          // Let the close frame flush before destroying the socket. The
+          // synchronous `this.close()` would otherwise abort TCP before
+          // `ws.close(code, reason)` finished writing, leaving the client
+          // with a `1006` instead of the policy code + reason.
+          const DRAIN_TIMEOUT_MS = 500;
+          const blockAndTerminate = (
+            reason: string,
+            closeCode = 1008,
+            severity: 'error' | 'warn' = 'error',
+          ) => {
+            this.logger[severity](reason);
+            let drained = false;
+            const drain = () => {
+              if (drained) return;
+              drained = true;
+              safeClose(upstreamWS);
+              this.close();
+              finish();
+            };
+            ws.once('close', drain);
+            try {
+              ws.close(closeCode, reason.slice(0, 123));
+            } catch {
+              drain();
+              return;
+            }
+            setTimeout(drain, DRAIN_TIMEOUT_MS).unref?.();
+          };
+
+          // Cap the pre-`open` buffer to fend off a flood-during-connect
+          // from a misbehaving client; 256 is well above any legitimate
+          // handshake burst.
+          const MAX_PENDING_FRAMES = 256;
+          const pending: {
+            data: Buffer | ArrayBuffer | Buffer[];
+            isBinary: boolean;
+          }[] = [];
+          let upstreamReady = false;
+          upstreamWS.once('open', () => {
+            upstreamReady = true;
+            for (const m of pending)
+              upstreamWS!.send(m.data, { binary: m.isBinary });
+            pending.length = 0;
+          });
+
+          // Snapshot patterns at upgrade time — mid-session reconfig
+          // isn't a goal and re-evaluating per frame would churn the GC
+          // on hot paths (DOM snapshots, base64 payloads).
+          const blockPatterns = this.config.getBlockedURLPatterns();
+          const stems = blockPatterns
+            .map((p) => p.split(':')[0].toLowerCase())
+            .filter((s) => s.length > 0);
+
+          // Parse before matching — a raw-substring fast-path would miss
+          // JSON Unicode escapes (`"file://..."` has no literal
+          // `file` byte) that the upstream Playwright server's
+          // `JSON.parse` would decode and act on.
+          const inspectInner = (
+            data: Buffer | ArrayBuffer | Buffer[],
+            direction: 'client→upstream' | 'upstream→client',
+            isBinary: boolean,
+          ): string | null => {
+            if (blockPatterns.length === 0) return null;
+            const str = wsFrameToString(data);
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(str);
+            } catch {
+              // Fail closed on unparseable *text* frames that bear a
+              // blocked stem — strict-JSON divergence between bridge
+              // and upstream would be a bypass. Binary frames are
+              // exempt so a benign blob containing a `file` byte run
+              // (e.g. a profile filename) doesn't tear down the
+              // session. The exemption assumes the upstream parses
+              // frames with `JSON.parse` like ours does — a future
+              // upstream that acts on unparseable binary frames would
+              // re-open this hole.
+              if (isBinary) return null;
+              const lower = str.toLowerCase();
+              if (stems.some((s) => lower.includes(s))) {
+                return `unparseable frame containing blocked stem in ${this.constructor.name} ${direction}`;
+              }
+              return null;
+            }
+            const hit = findBlockedUrlInMessage(parsed, blockPatterns);
+            if (hit) {
+              return `Blocked URL pattern "${hit}" in ${this.constructor.name} ${direction} message`;
+            }
+            return null;
+          };
+
+          // Wrap the inspector so any unexpected throw (e.g. a malformed
+          // payload that breaks `wsFrameToString` on a future ws version)
+          // becomes a block reason instead of escaping through the
+          // emitter and forwarding an uninspected frame.
+          const inspect = (
+            data: Buffer | ArrayBuffer | Buffer[],
+            direction: 'client→upstream' | 'upstream→client',
+            isBinary: boolean,
+          ): string | null => {
+            try {
+              return inspectInner(data, direction, isBinary);
+            } catch (err) {
+              return `inspect failed in ${this.constructor.name} ${direction}, failing closed: ${(err as Error).message}`;
+            }
+          };
+
+          ws.on('message', (data, isBinary) => {
+            const hit = inspect(data, 'client→upstream', isBinary);
+            if (hit) {
+              blockAndTerminate(hit);
+              return;
+            }
+            if (upstreamReady) {
+              upstreamWS!.send(data, { binary: isBinary });
+            } else {
+              if (pending.length >= MAX_PENDING_FRAMES) {
+                // Close-code 1009 = flow-control overflow (not a
+                // policy block); warn keeps it distinct from the
+                // security-block error stream.
+                blockAndTerminate(
+                  `Pre-open pending buffer overflowed (${MAX_PENDING_FRAMES} frames) in ${this.constructor.name}`,
+                  1009,
+                  'warn',
+                );
+                return;
+              }
+              pending.push({ data, isBinary });
+            }
+          });
+
+          // Catches indirect navigations the renderer made on its own —
+          // e.g. JS-side `fetch('file://...')` after a legitimate goto.
+          upstreamWS.on('message', (data, isBinary) => {
+            const hit = inspect(data, 'upstream→client', isBinary);
+            if (hit) {
+              blockAndTerminate(hit);
+              return;
+            }
+            try {
+              ws.send(data, { binary: isBinary });
+            } catch (err) {
+              // Surface a dead-client pipe instead of pumping upstream
+              // into a black hole until some other event tears down.
+              this.logger.error(
+                `${this.constructor.name} client WS send failed: ${(err as Error).message}`,
+              );
+              finish();
+            }
+          });
+
+          ws.on('close', () => finish());
+          upstreamWS.on('close', () => finish());
+          ws.on('error', (err) => {
+            // Routine client disconnects (TCP RST) emit `'error'` here;
+            // resolve so they don't surface as server faults.
+            this.logger.debug(
+              `${this.constructor.name} client WS error (treating as disconnect): ${err}`,
+            );
+            finish();
+          });
+          upstreamWS.on('error', (err) => {
+            const e = err as NodeJS.ErrnoException;
+            this.logger.error(
+              {
+                err: e.message,
+                code: e.code,
+                browserWSEndpoint: this.browserWSEndpoint,
+                href: req.parsed.href,
+              },
+              `${this.constructor.name} upstream WS error`,
+            );
+            this.close();
+            finish(err as Error);
+          });
         },
       );
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,6 +260,19 @@ export class Config extends EventEmitter {
   public getAllowFileProtocol(): boolean {
     return this.allowFileProtocol;
   }
+  /**
+   * Returns URL prefixes that the browser is not allowed to navigate to.
+   * Used by both the CDP page-event guard and the Playwright wire-frame
+   * filter to block navigations whose target URL begins with any of the
+   * returned strings. Subclasses may override to add more schemes or
+   * specific hostnames (e.g. RFC1918 ranges).
+   *
+   * Default behavior tracks `ALLOW_FILE_PROTOCOL`: when disallowed, returns
+   * `['file://']`; otherwise `[]`.
+   */
+  public getBlockedURLPatterns(): string[] {
+    return this.allowFileProtocol ? [] : ['file://'];
+  }
   public getCPULimit(): number {
     return this.maxCpu;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -952,3 +952,97 @@ export const isMatch = (text: string, pattern: string) => {
 
 export const getFinalPathSegment = (pathname: string): string | undefined =>
   pathname.split(/[?#&]/)[0].split('/').filter(Boolean).pop();
+
+/**
+ * Canonicalize a candidate URL value so trivial obfuscations cannot bypass a
+ * prefix-based blocklist:
+ *
+ *   - `FILE:///etc/passwd` / `File:///etc/passwd` — Chromium normalizes URL
+ *     schemes case-insensitively; force-lowercase.
+ *   - `  file:///etc/passwd` / `\tfile://...` — WHATWG URL parsing trims
+ *     leading whitespace before parsing.
+ *   - `f\x01ile://...` (embedded control char) — `new URL()` parses
+ *     `file://...` cleanly after we strip ASCII control chars, so the
+ *     canonical lower-cased form goes through the `try` branch. The
+ *     `catch` fallback is only reached if a value remains unparseable
+ *     after stripping.
+ *   - `file:/etc/passwd` (single slash) — `new URL()` canonicalizes to
+ *     `file:///etc/passwd`, matching Chromium's behavior.
+ *   - `view-source:file:///etc/passwd` — view-source is a wrapper that loads
+ *     the inner URL; strip recursively before matching.
+ *
+ * Returns a lower-cased canonical form. Falls back to a stripped/lowercased
+ * raw string when `new URL()` cannot parse — prefix matching still works.
+ */
+export const normalizeUrlForBlocklist = (value: string): string => {
+  // Strip ASCII control chars (including embedded NUL) before any parsing
+  // attempt — Chromium drops these during URL canonicalization, so a
+  // `\0file://…` payload would otherwise reach the fallback branch with the
+  // NUL intact and fail prefix matching.
+  let s = value.trim().replace(/[\x00-\x1f]/g, '');
+  while (/^view-source:/i.test(s)) s = s.slice('view-source:'.length);
+  try {
+    return new URL(s).href.toLowerCase();
+  } catch {
+    return s.toLowerCase();
+  }
+};
+
+/**
+ * Walks a JSON-RPC message tree looking for any field named `url`
+ * (case-insensitive) whose value, after `normalizeUrlForBlocklist`, begins
+ * with one of the supplied patterns. Returns the matched pattern, or `null`
+ * when nothing matches.
+ *
+ * Source of truth for the blocklist is `Config.getBlockedURLPatterns()`; the
+ * CDP request-event guard reads the same patterns. This helper additionally
+ * normalizes the candidate URL because Playwright JSON-RPC frames carry the
+ * client's raw string, while puppeteer's `page.on('request')` sees a URL
+ * Chromium has already canonicalized.
+ *
+ * Only inspects keys named `url` (case-insensitive — `URL`, `Url` match
+ * too). JSON values that happen to contain a `file://` substring in
+ * arbitrary user data (e.g. the return value of `page.evaluate()`) are
+ * left alone.
+ */
+export const findBlockedUrlInMessage = (
+  message: unknown,
+  patterns: string[],
+): string | null => {
+  if (patterns.length === 0) return null;
+  const lcPatterns = patterns.map((p) => p.toLowerCase());
+  const stack: unknown[] = [message];
+  while (stack.length) {
+    const cur = stack.pop();
+    if (!cur || typeof cur !== 'object') continue;
+    for (const [k, v] of Object.entries(cur as Record<string, unknown>)) {
+      if (k.toLowerCase() === 'url' && typeof v === 'string') {
+        const norm = normalizeUrlForBlocklist(v);
+        const idx = lcPatterns.findIndex((p) => norm.startsWith(p));
+        if (idx !== -1) return patterns[idx];
+      }
+      if (v && typeof v === 'object') stack.push(v);
+    }
+  }
+  return null;
+};
+
+/**
+ * Decode a `ws` frame payload to a UTF-8 string regardless of binary/text
+ * opcode. Under the default `binaryType: 'nodebuffer'` (ws ≥ 8, which this
+ * package pins), `ws` delivers both text and binary frames as a `Buffer`;
+ * the `Buffer[]` branch is defensive against `binaryType: 'fragments'` (not
+ * enabled by callers) and the `ArrayBuffer` branch covers `'arraybuffer'`.
+ *
+ * Decoding every frame — including binary ones — is deliberate: we cannot
+ * assume the upstream server only honors text-opcode JSON. If a JSON
+ * command were shipped as a binary frame and the bridge skipped it, the
+ * filter would be bypassable.
+ */
+export const wsFrameToString = (
+  data: Buffer | ArrayBuffer | Buffer[],
+): string => {
+  if (Buffer.isBuffer(data)) return data.toString('utf-8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf-8');
+  return Buffer.from(data).toString('utf-8');
+};


### PR DESCRIPTION
  - Block file:// navigation on Playwright WS routes via a bidirectional JSON-RPC frame filter
  - Parse-then-match (no raw-bytes fast-path), so JSON Unicode escapes like "\u0066ile://..." can't bypass — fail closed on unparseable text frames bearing a blocked stem
  - Block disguised variants: FILE://, View-Source:file://, percent-encoded file:%2f%2f…, single-slash file:/etc/passwd, leading-whitespace and embedded control-char prefixes
  - Cover binary WS frames (Playwright clients can send commands as binary, not just text)
  - Block server→client direction too (indirect navigation via page.evaluate(fetch(...)))
  - Add Config.getBlockedURLPatterns() as the single source of truth; CDP page-event guard now reuses the same normalize-and-match helper (findBlockedUrlInMessage), so it inherits all the disguised-variant coverage too
  - Honor ALLOW_FILE_PROTOCOL=true as the escape hatch (returns empty patterns)
  - Socket-level settle backstop so aborted WS upgrades (bad Sec-WebSocket-Key, etc.) can't leak the concurrency slot or browser process
  - Pending-frame cap (256) during the pre-open window so a flood-during-connect can't hold buffer pressure indefinitely; reported with WS code 1009 and warn level to distinguish from policy blocks
  - 47 unit tests covering all of the above, including parametrized Chromium/Firefox/WebKit subclass blocks, binary fail-closed exemption, and the aborted-upgrade backstop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable URL pattern blocking to prevent navigation to restricted resources (file:// blocked by default).
  * Frame-aware WebSocket proxying for Playwright with improved message inspection and safer session teardown.

* **Tests**
  * Extensive end-to-end tests covering URL filtering, WebSocket proxy behavior, and numerous evasion/normalization cases.

* **Chores**
  * Added WebSocket runtime dependency and development types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->