### PR TITLE
chore: build/v2.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# [Latest](https://github.com/browserless/browserless/compare/v2.50.1...main)
+# [Latest](https://github.com/browserless/browserless/compare/v2.51.0...main)
+
+# [v2.51.0](https://github.com/browserless/browserless/compare/v2.50.1...v2.51.0)
+- Dependency updates.
+- Feat: expose `route` on the `after()` AfterResponse hook.
+- Feat: add a new `watch` command with live reload for development.
+- Fix: block `file://` URLs in Playwright WebSocket routes.
+- Fix: extract devtools and adblock with the system `unzip`.
+- Fix: speed up `build:schemas` call.
+- Supports the following libraries and browsers:
+  - puppeteer-core: `25.1.0`
+  - playwright-core: `1.60.0`, `1.59.1`, `1.58.2`, `1.57.0`, and `1.56.1`.
+  - Chromium: `148.0.7778.0`
+  - Chrome: `149.0.7827.53` (amd64 only)
+  - Firefox: `150.0.2`
+  - Webkit: `26.4`
+  - Edge: `148.0.3967.96` (amd64 only)
 
 # [v2.50.1](https://github.com/browserless/browserless/compare/v2.50.0...v2.50.1)
 - Dependency updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.50.1",
+  "version": "2.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserless.io/browserless",
-      "version": "2.50.1",
+      "version": "2.51.0",
       "license": "SSPL",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserless.io/browserless",
-  "version": "2.50.1",
+  "version": "2.51.0",
   "license": "SSPL",
   "description": "The browserless platform",
   "author": "browserless.io",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5409" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `watch` command with live reload capability
  * Exposed `route` on the `after()` AfterResponse hook

* **Bug Fixes**
  * Fixed blocking of `file://` URLs in Playwright WebSocket routes
  * Improved devtools/adblock extraction using system utilities
  * Enhanced `build:schemas` performance

* **Chores**
  * Updated dependencies including puppeteer-core, playwright-core, and browser version support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->