### PR TITLE
fix: resolve npm publish/build warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "cross-env": "^10.1.0",
         "env-cmd": "^11.0.0",
         "esbuild": "^0.28.0",
-        "esbuild-plugin-polyfill-node": "^0.3.0",
+        "esbuild-plugins-node-modules-polyfill": "^1.8.1",
         "eslint": "^10.4.1",
         "gunzip-maybe": "^1.4.2",
         "marked": "^18.0.3",
@@ -2640,6 +2640,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/configstore": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -2941,18 +2948,22 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
-    "node_modules/esbuild-plugin-polyfill-node": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/esbuild-plugin-polyfill-node/-/esbuild-plugin-polyfill-node-0.3.0.tgz",
-      "integrity": "sha512-SHG6CKUfWfYyYXGpW143NEZtcVVn8S/WHcEOxk62LuDXnY4Zpmc+WmxJKN6GMTgTClXJXhEM5KQlxKY6YjbucQ==",
+    "node_modules/esbuild-plugins-node-modules-polyfill": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugins-node-modules-polyfill/-/esbuild-plugins-node-modules-polyfill-1.8.1.tgz",
+      "integrity": "sha512-7vxzmyTFDhYUNhjlciMPmp32eUafNIHiXvo8ZD22PzccnxMoGpPnsYn17gSBoFZgpRYNdCJcAWsQ60YVKgKg3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jspm/core": "^2.0.1",
-        "import-meta-resolve": "^3.0.0"
+        "@jspm/core": "^2.1.0",
+        "local-pkg": "^1.1.2",
+        "resolve.exports": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "esbuild": "*"
+        "esbuild": ">=0.14.0 <=0.27.x"
       }
     },
     "node_modules/escalade": {
@@ -3234,6 +3245,13 @@
       "dependencies": {
         "bare-events": "^2.7.0"
       }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -3771,17 +3789,6 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-3.1.1.tgz",
-      "integrity": "sha512-qeywsE/KC3w9Fd2ORrRDUw6nS/nLwZpXgfrOc2IILvZYnCaEMd+D56Vfg9k4G29gIeVi3XKql1RQatME8iYsiw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -4487,6 +4494,24 @@
         }
       }
     },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4655,6 +4680,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/mocha": {
@@ -4933,6 +4990,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/peek-stream": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -4999,6 +5063,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/playwright-1.56": {
@@ -5366,6 +5442,23 @@
         }
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/queue/-/queue-7.0.0.tgz",
@@ -5479,6 +5572,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/reusify": {
@@ -6423,6 +6526,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ".": "./build/exports.js"
   },
   "bin": {
-    "browserless": "./bin/browserless.js"
+    "browserless": "bin/browserless.js"
   },
   "scripts": {
     "build": "npm run clean && npm run build:ts && npm run install:adblock && npm run build:schemas && npm run build:devtools && npm run build:openapi",
@@ -90,7 +90,7 @@
     "cross-env": "^10.1.0",
     "env-cmd": "^11.0.0",
     "esbuild": "^0.28.0",
-    "esbuild-plugin-polyfill-node": "^0.3.0",
+    "esbuild-plugins-node-modules-polyfill": "^1.8.1",
     "eslint": "^10.4.1",
     "gunzip-maybe": "^1.4.2",
     "marked": "^18.0.3",
@@ -99,6 +99,11 @@
     "sinon": "^22.0.0",
     "typescript": "^6.0.3",
     "typescript-json-schema": "^0.67.3"
+  },
+  "overrides": {
+    "esbuild-plugins-node-modules-polyfill": {
+      "esbuild": "$esbuild"
+    }
   },
   "playwrightVersions": {
     "default": "playwright-core",

--- a/scripts/build-function.js
+++ b/scripts/build-function.js
@@ -5,7 +5,7 @@
 import { build } from 'esbuild';
 import fs from 'fs/promises';
 import { join } from 'path';
-import { polyfillNode } from 'esbuild-plugin-polyfill-node';
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
 
 const html = (contents) => `<!DOCTYPE html>
 <html lang="en">
@@ -33,7 +33,7 @@ const htmlLocation = join(process.cwd(), 'static/function/index.html');
     entryPoints,
     outfile,
     plugins: [
-      polyfillNode({
+      nodeModulesPolyfillPlugin({
         globals: {
           process: false,
         },


### PR DESCRIPTION
## What

Eliminates the two warnings that surface during `npm publish`:

### 1. `bin[browserless]` auto-correct warning
```
npm warn publish "bin[browserless]" script name bin/browserless.js was invalid and removed
```
The `bin` path had a leading `./` (`./bin/browserless.js`), which npm flags as invalid and strips on publish. Removed the `./` prefix. (`npm pkg fix` confirms the manifest is now clean.)

### 2. `DEP0180: fs.Stats constructor is deprecated` during `build:function`
Root cause: **`esbuild-plugin-polyfill-node@0.3.0` is abandoned** — its GitHub repo is archived, last release was 2023-05-29, and it pins `import-meta-resolve@3.1.1`, which uses the deprecated `fs.Stats` constructor on Node 24.

Replaced it with the maintained successor **`esbuild-plugins-node-modules-polyfill@^1.8.1`** (last release 2026-02). That package caps its esbuild peer at `<=0.27.x` while this project is on `0.28`, so an `overrides` entry pins the peer to the project's own esbuild (`$esbuild`) — a plain `npm install` resolves cleanly with no `--legacy-peer-deps`.

## Why it's safe

`scripts/build-function.js` bundles `src/shared/utils/function/client.ts` into `static/function/client.js`, which is loaded **inside a Chrome page** (it sets `window.BrowserlessFunctionRunner` at module top level — it never runs in Node). The polyfill's only jobs there are:

- Stubbing puppeteer-core's `await import('node:util')`, which lives behind an `isNode` guard that is **dead code in the browser**.
- Injecting a `Buffer` global, which **is** live — `HTTPResponse.buffer()` calls `Buffer.from(...)` and is reachable from user `/function` code.

Behavior parity verified against the old plugin:

- ✅ `Buffer` polyfill still injected (`response.buffer()` keeps working)
- ✅ `process` still **not** injected (matches the prior `process: false` option)
- ✅ `node:util` dead branch still stubbed (no real import in output)
- ✅ `window.BrowserlessFunctionRunner` intact
- ✅ `build:function` and `npm publish --dry-run` now emit **zero** warnings
- Bundle size: 877 KB → 806 KB

## Test plan

- [x] `npm run build:function` — clean, no DEP0180
- [x] `npm publish --dry-run` — no `npm warn` lines; `bin` warning gone
- [x] `npm install` (no flags) — resolves cleanly, exit 0
- [x] `npm pkg fix` — reports no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependencies to improve tooling and build process stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->