### PR TITLE
docs: remove duplicate Changelog header for release-please

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 # [v2.51.0](https://github.com/browserless/browserless/compare/v2.50.1...v2.51.0)
 - Dependency updates.
 - Feat: expose `route` on the `after()` AfterResponse hook.


### PR DESCRIPTION
## What
Removes the manual `# Changelog` H1 from the top of `CHANGELOG.md`.

## Why
release-please prepends its **own** `# Changelog` title and demotes every existing heading one level. The manual header I added while wiring up the automation therefore got duplicated — it shows up as a stray `## Changelog` in the generated release changelog (visible in the draft release PR #5417, between the new `2.51.1` entry and the legacy `## [v2.51.0]` entries).

With the manual header gone, the file starts directly at the version entries and release-please supplies the single canonical `# Changelog` title.

## Effect
Once merged, release-please regenerates #5417 with a single `# Changelog` heading. Typed `docs:` so this cleanup stays out of the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive release history documentation to changelog covering dependency updates, features, fixes, and browser compatibility matrices across all versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->