### PR TITLE
chore: render browser versions as their own changelog section

### DIFF
--- a/scripts/changelog-browser-versions.js
+++ b/scripts/changelog-browser-versions.js
@@ -2,9 +2,9 @@
 //
 // changelog-browser-versions.js
 //
-// Emits the "Supports the following libraries and browsers:" block for the
-// CHANGELOG by introspecting a built browserless image, so the versions in a
-// release reflect what actually shipped rather than a hand-typed guess.
+// Emits the "Supported Libraries & Browsers" changelog section by introspecting
+// a built browserless image, so the versions in a release reflect what actually
+// shipped rather than a hand-typed guess.
 //
 // It runs ONE container off the multi image and, inside it:
 //   - reads puppeteer-core + the pinned playwright-core versions from
@@ -154,15 +154,19 @@ if (!data.edge)
     'WARN: Edge version unavailable (expected on a non-amd64 image).',
   );
 
+// Emitted as its own `###` section so release-please's changelog renders it
+// alongside "Features"/"Bug Fixes" rather than folding it into the previous
+// section's bullet list.
 const block = [
-  '- Supports the following libraries and browsers:',
-  `  - puppeteer-core: \`${data.puppeteer}\``,
-  `  - playwright-core: ${sentenceList(data.playwright)}`,
-  `  - Chromium: ${tick(data.chromium)}`,
-  `  - Chrome: ${amd64Only(data.chrome)}`,
-  `  - Firefox: ${tick(data.firefox)}`,
-  `  - Webkit: ${tick(data.webkit)}`,
-  `  - Edge: ${amd64Only(data.edge)}`,
+  '### Supported Libraries & Browsers',
+  '',
+  `- puppeteer-core: \`${data.puppeteer}\``,
+  `- playwright-core: ${sentenceList(data.playwright)}`,
+  `- Chromium: ${tick(data.chromium)}`,
+  `- Chrome: ${amd64Only(data.chrome)}`,
+  `- Firefox: ${tick(data.firefox)}`,
+  `- Webkit: ${tick(data.webkit)}`,
+  `- Edge: ${amd64Only(data.edge)}`,
 ].join('\n');
 
 process.stdout.write(block + '\n');

--- a/scripts/insert-changelog-browser-versions.js
+++ b/scripts/insert-changelog-browser-versions.js
@@ -2,9 +2,9 @@
 //
 // insert-changelog-browser-versions.js
 //
-// Inserts a generated "Supports the following libraries and browsers:" block
-// into the newest (top) release section of CHANGELOG.md. Reads the block from
-// stdin — pair it with changelog-browser-versions.js:
+// Inserts a generated "Supported Libraries & Browsers" section into the newest
+// (top) release section of CHANGELOG.md. Reads the block from stdin — pair it
+// with changelog-browser-versions.js:
 //
 //   node scripts/changelog-browser-versions.js \
 //     | node scripts/insert-changelog-browser-versions.js [CHANGELOG.md]


### PR DESCRIPTION
## What
`changelog-browser-versions.js` now emits the browser/library block as its own `### Supported Libraries & Browsers` section (top-level bullets) instead of a single `- Supports the following…` bullet with nested items.

## Why
The block is inserted at the end of the newest release section, *after* release-please's `### Bug Fixes`. With no heading of its own it rendered as if it were another bug fix (reported on the `2.51.1` draft release).

## Before / After (rendered)
**Before**
```
### Bug Fixes
* resolve npm publish/build warnings (#5411)
- Supports the following libraries and browsers:
  - puppeteer-core: 25.1.0
  …
```
**After**
```
### Bug Fixes
* resolve npm publish/build warnings (#5411)

### Supported Libraries & Browsers
- puppeteer-core: 25.1.0
- Chromium: 148.0.7778.96
…
```

Verified locally against the insert script (markers preserved, idempotent). `chore:` so it stays out of release notes. Heading wording is a one-line tweak if you'd prefer something else.

## Follow-up
After merge, the open release PR must be regenerated for the new section to appear (the browser-versions job runs the script from the release branch, which only refreshes when the PR is recreated from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Supported Libraries & Browsers" changelog section formatting to display as a flat bullet list for improved readability.
  * Automated the insertion of browser version compatibility information into the latest release section of the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->