### PR TITLE
fix: add repository field to package.json for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "license": "SSPL",
   "description": "The browserless platform",
   "author": "browserless.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/browserless/browserless.git"
+  },
   "type": "module",
   "types": "./build/exports.d.ts",
   "main": "./build/exports.js",


### PR DESCRIPTION
## What
Adds a `repository` field to `package.json`:
```json
"repository": { "type": "git", "url": "git+https://github.com/browserless/browserless.git" }
```

## Why
`npm publish` with provenance (enabled via OIDC trusted publishing) validates the sigstore bundle against `package.json` and **requires `repository.url`** to match the building repo. It was missing, so the `2.51.1` publish failed at the registry:

```
npm error code E422
422 Unprocessable Entity — Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/browserless/browserless"
```

The build, tarball, and provenance signing all succeeded — npm only rejected the final upload. `2.51.1` is therefore on the git tag + GitHub Release + Docker, but **not on npm** (npm is still at `2.51.0`).

## Recovery
Roll forward: once merged, release-please cuts `2.51.2`; merging that release PR publishes `2.51.2` to npm cleanly (now with `repository`). npm skips the failed `2.51.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->