### PR TITLE
feat: bypass limiter for /devtools/browser/* reconnect route

### DIFF
--- a/src/shared/browser.ws.ts
+++ b/src/shared/browser.ws.ts
@@ -21,6 +21,7 @@ export default class ChromiumBrowserWebSocketRoute extends BrowserWebsocketRoute
   auth = true;
   browser = ChromiumCDP;
   concurrency = true;
+  bypassLimits = (): boolean => true;
   description = dedent(
     `Connect to an already-running Chromium process with a library like
     puppeteer, or others, that work over chrome-devtools-protocol. Chromium


### PR DESCRIPTION
## Summary

`ChromiumBrowserWebSocketRoute` (the shared base for Chromium/Chrome/Edge `/devtools/browser/*`) only serves reconnect traffic to an already-launched browser — it returns 404 otherwise (per its own description). Rejecting these requests when the host is overloaded or the queue is full strands a session the customer is already running.

Sets `bypassLimits = () => true` unconditionally on the shared base class. Chrome and Edge variants extend it and inherit the predicate.

This follows the same pattern as the per-request `bypassLimits` predicate added in [#5387](https://github.com/browserless/browserless/pull/5387) and used in enterprise's BQL reconnect routes.

## Test plan

- [x] `npx mocha build/limiter.spec.js` — 17 passing (no regression to the existing bypass plumbing)
- [ ] CI test pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced WebSocket connection handling for Chromium browsers to better manage request routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->