### PR TITLE
chore: bump nvm to 0.40.5 in base Dockerfile

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get update \
   && fc-cache -f -v \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/fonts/truetype/noto
 
-RUN curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash &&\
+RUN curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash &&\
   . $NVM_DIR/nvm.sh &&\
   nvm install $NODE_VERSION &&\
   npm install -g npm@$NPM_VERSION


### PR DESCRIPTION
## Summary

Bumps the [nvm](https://github.com/nvm-sh/nvm) installer pinned in `docker/base/Dockerfile` from **v0.40.4** to **v0.40.5** (released 2026-06-04).

This is the only functional change — the historical CHANGELOG entry referencing `0.40.4` is left untouched.

## Validation (empirical)

Built the **actual edited** base image end-to-end exactly as CI does:

```
docker build -f ./docker/base/Dockerfile -t browserless-base .
```

- Build exit code: `0`
- `npm clean-install` succeeded (478 packages)
- Runtime versions confirmed inside the built image:
  - **nvm: 0.40.5**
  - **node: v24.16.0** (unchanged)
  - **npm: 11.16.0** (unchanged)

Also ran a focused image that mirrors only the nvm install step to isolate the change — same result: nvm 0.40.5, node v24.16.0, npm 11.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node Version Manager to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->