### PR TITLE
fix: right-size log levels for per-request and page-relayed logs

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -55,7 +55,7 @@ export class ChromiumCDP extends EventEmitter {
     this.blockAds = blockAds;
     this.logger = logger;
 
-    this.logger.info(`Starting new ${this.constructor.name} instance`);
+    this.logger.debug(`Starting new ${this.constructor.name} instance`);
   }
 
   protected cleanListeners() {
@@ -92,7 +92,7 @@ export class ChromiumCDP extends EventEmitter {
         });
 
         page.on('pageerror', (err) => {
-          this.logger.warn(err);
+          this.logger.debug(err);
         });
 
         page.on('framenavigated', (frame) => {
@@ -104,7 +104,7 @@ export class ChromiumCDP extends EventEmitter {
         });
 
         page.on('requestfailed', (req) => {
-          this.logger.warn(`"${req.failure()?.errorText}": ${req.url()}`);
+          this.logger.debug(`"${req.failure()?.errorText}": ${req.url()}`);
         });
 
         const terminateIfBlocked = (
@@ -157,7 +157,7 @@ export class ChromiumCDP extends EventEmitter {
 
   public async close(): Promise<void> {
     if (this.browser) {
-      this.logger.info(
+      this.logger.debug(
         `Closing ${this.constructor.name} process and all listeners`,
       );
       this.emit('close');
@@ -184,7 +184,7 @@ export class ChromiumCDP extends EventEmitter {
     stealth,
   }: BrowserLauncherOptions): Promise<Browser> {
     this.port = await getPort();
-    this.logger.info(`${this.constructor.name} got open port ${this.port}`);
+    this.logger.debug(`${this.constructor.name} got open port ${this.port}`);
 
     const extensionLaunchArgs = options.args?.find((a) =>
       a.startsWith('--load-extension'),
@@ -247,7 +247,7 @@ export class ChromiumCDP extends EventEmitter {
       ? puppeteerStealth.launch.bind(puppeteerStealth)
       : puppeteer.launch.bind(puppeteer);
 
-    this.logger.info(
+    this.logger.debug(
       finalOptions,
       `Launching ${this.constructor.name} Handler`,
     );
@@ -261,7 +261,7 @@ export class ChromiumCDP extends EventEmitter {
     // running=false before awaiting the inner close).
     this.browser.once('disconnected', () => {
       if (this.running) {
-        this.logger.info(
+        this.logger.warn(
           `${this.constructor.name} disconnected unexpectedly, emitting close`,
         );
         this.emit('close');
@@ -277,7 +277,7 @@ export class ChromiumCDP extends EventEmitter {
     });
     this.running = true;
     this.browserWSEndpoint = this.browser.wsEndpoint();
-    this.logger.info(
+    this.logger.debug(
       `${this.constructor.name} is running on ${this.browserWSEndpoint}`,
     );
 
@@ -317,7 +317,7 @@ export class ChromiumCDP extends EventEmitter {
         );
       }
       socket.once('close', resolve);
-      this.logger.info(
+      this.logger.debug(
         `Proxying ${req.parsed.href} to ${this.constructor.name}`,
       );
 
@@ -376,7 +376,7 @@ export class ChromiumCDP extends EventEmitter {
       this.browser?.process()?.once('close', close);
       socket.once('close', close);
 
-      this.logger.info(
+      this.logger.debug(
         `Proxying ${req.parsed.href} to ${this.constructor.name} ${this.browserWSEndpoint}`,
       );
 

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -63,7 +63,7 @@ class BasePlaywright extends EventEmitter {
     this.config = config;
     this.logger = logger;
 
-    this.logger.info(`Starting new ${this.constructor.name} instance`);
+    this.logger.debug(`Starting new ${this.constructor.name} instance`);
   }
 
   protected cleanListeners() {
@@ -109,7 +109,7 @@ class BasePlaywright extends EventEmitter {
 
   public async close(): Promise<void> {
     if (this.browser) {
-      this.logger.info(
+      this.logger.debug(
         `Closing ${this.constructor.name} process and all listeners`,
       );
       this.socket?.destroy();
@@ -155,7 +155,7 @@ class BasePlaywright extends EventEmitter {
     launcherOpts: BrowserLauncherOptions,
   ): Promise<playwright.BrowserServer> {
     const { options, pwVersion } = launcherOpts;
-    this.logger.info(`Launching ${this.constructor.name} Handler`);
+    this.logger.debug(`Launching ${this.constructor.name} Handler`);
 
     const versionedPw = await this.config.loadPwVersion(pwVersion!);
     const opts = this.makeLaunchOptions(options);
@@ -167,7 +167,7 @@ class BasePlaywright extends EventEmitter {
     });
     const browserWSEndpoint = browser.wsEndpoint();
 
-    this.logger.info(
+    this.logger.debug(
       `${this.constructor.name} is running on ${browserWSEndpoint}`,
     );
     this.running = true;
@@ -180,7 +180,7 @@ class BasePlaywright extends EventEmitter {
     // normal close() path.
     browser.once('close', () => {
       if (this.running) {
-        this.logger.info(
+        this.logger.warn(
           `${this.constructor.name} closed unexpectedly, emitting close`,
         );
         this.socket?.destroy();
@@ -239,7 +239,7 @@ class BasePlaywright extends EventEmitter {
           `No browserWSEndpoint found, did you launch first?`,
         );
       }
-      this.logger.info(
+      this.logger.debug(
         `Proxying ${req.parsed.href} to ${this.constructor.name} ${this.browserWSEndpoint}`,
       );
 

--- a/src/limiter.ts
+++ b/src/limiter.ts
@@ -217,7 +217,7 @@ export class Limiter extends q {
               this.webhooks.callFailedHealthURL();
               this.metrics.addRejected();
               overCapacityFn(...args);
-              return rej(new Error(`Health checks have failed, rejecting`));
+              return rej(new TooManyRequests(`Health checks have failed, rejecting`));
             }
           }
         }

--- a/src/router.ts
+++ b/src/router.ts
@@ -72,12 +72,12 @@ export class Router extends EventEmitter {
   }
 
   protected onQueueFullHTTP(_req: Request, res: Response) {
-    this.log.warn(`Queue is full, sending 429 response`);
+    this.log.debug(`Queue is full, sending 429 response`);
     return writeResponse(res, 429, 'Too many requests');
   }
 
   protected onQueueFullWebSocket(_req: Request, socket: stream.Duplex) {
-    this.log.warn(`Queue is full, sending 429 response`);
+    this.log.debug(`Queue is full, sending 429 response`);
     return writeResponse(socket, 429, 'Too many requests');
   }
 

--- a/src/routes/management/http/static.get.ts
+++ b/src/routes/management/http/static.get.ts
@@ -137,7 +137,7 @@ export default class StaticGetRoute extends HTTPRoute {
       return;
     }
 
-    logger.info(`Found new file "${foundFilePath}", caching path and serving`);
+    logger.debug(`Found new file "${foundFilePath}", caching path and serving`);
 
     const contentType = mimeTypes.get(path.extname(foundFilePath));
 

--- a/src/shared/content.http.ts
+++ b/src/shared/content.http.ts
@@ -83,7 +83,7 @@ export default class ChromiumContentPostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.info('Content API invoked with body:', req.body);
+    logger.debug('Content API invoked with body:', req.body);
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? contentTypes.html

--- a/src/shared/content.http.ts
+++ b/src/shared/content.http.ts
@@ -20,6 +20,7 @@ import {
   contentTypes,
   isBase64Encoded,
   noop,
+  redactSensitiveBodyFields,
   rejectRequestPattern,
   rejectResourceTypes,
   requestInterceptors,
@@ -83,7 +84,10 @@ export default class ChromiumContentPostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.debug('Content API invoked with body:', req.body);
+    logger.debug(
+      'Content API invoked with body:',
+      redactSensitiveBodyFields(req.body),
+    );
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? contentTypes.html

--- a/src/shared/download.http.ts
+++ b/src/shared/download.http.ts
@@ -148,7 +148,7 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
           }
         })
         .on('end', () => {
-          logger.info(`Downloads successfully sent`);
+          logger.debug(`Downloads successfully sent`);
           rmDownload();
           return resolve();
         })

--- a/src/shared/download.http.ts
+++ b/src/shared/download.http.ts
@@ -73,7 +73,7 @@ export default class ChromiumDownloadPostRoute extends BrowserHTTPRoute {
         `.browserless.download.${id()}`,
       );
 
-      logger.info(`Generating a download directory at "${downloadPath}"`);
+      logger.debug(`Generating a download directory at "${downloadPath}"`);
       await mkdir(downloadPath);
       const handler = functionHandler(config, logger, { downloadPath });
       const response = await handler(req, browser).catch((e) => {

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -81,7 +81,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
       if (!type) {
         throw new BadRequest(`Couldn't determine function's response type.`);
       } else {
-        logger.info(`Sending file-type response of "${type}"`);
+        logger.debug(`Sending file-type response of "${type}"`);
         const readStream = new Stream.PassThrough();
         readStream.end(response);
         res.setHeader('Content-Type', type);

--- a/src/shared/function.http.ts
+++ b/src/shared/function.http.ts
@@ -69,7 +69,7 @@ export default class ChromiumFunctionPostRoute extends BrowserHTTPRoute {
     });
     const { contentType, payload, page } = await handler(req, browser);
 
-    logger.info(`Got function response of "${contentType}"`);
+    logger.debug(`Got function response of "${contentType}"`);
     page.close();
     page.removeAllListeners();
 

--- a/src/shared/pdf.http.ts
+++ b/src/shared/pdf.http.ts
@@ -89,7 +89,7 @@ export default class ChromiumPDFPostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.info('PDF API invoked with body:', req.body);
+    logger.debug('PDF API invoked with body:', req.body);
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? 'application/pdf'

--- a/src/shared/pdf.http.ts
+++ b/src/shared/pdf.http.ts
@@ -21,6 +21,7 @@ import {
   dedent,
   isBase64Encoded,
   noop,
+  redactSensitiveBodyFields,
   rejectRequestPattern,
   rejectResourceTypes,
   requestInterceptors,
@@ -89,7 +90,10 @@ export default class ChromiumPDFPostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.debug('PDF API invoked with body:', req.body);
+    logger.debug(
+      'PDF API invoked with body:',
+      redactSensitiveBodyFields(req.body),
+    );
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? 'application/pdf'

--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -241,7 +241,7 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ) {
-    logger.info('Scrape API invoked with body:', req.body);
+    logger.debug('Scrape API invoked with body:', req.body);
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? contentTypes.html

--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -28,6 +28,7 @@ import {
   isBase64Encoded,
   jsonResponse,
   noop,
+  redactSensitiveBodyFields,
   rejectRequestPattern,
   rejectResourceTypes,
   requestInterceptors,
@@ -241,7 +242,10 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ) {
-    logger.debug('Scrape API invoked with body:', req.body);
+    logger.debug(
+      'Scrape API invoked with body:',
+      redactSensitiveBodyFields(req.body),
+    );
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? contentTypes.html

--- a/src/shared/screenshot.http.ts
+++ b/src/shared/screenshot.http.ts
@@ -21,6 +21,7 @@ import {
   dedent,
   isBase64Encoded,
   noop,
+  redactSensitiveBodyFields,
   rejectRequestPattern,
   rejectResourceTypes,
   requestInterceptors,
@@ -91,7 +92,10 @@ export default class ScreenshotPost extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.debug('Screenshot API invoked with body:', req.body);
+    logger.debug(
+      'Screenshot API invoked with body:',
+      redactSensitiveBodyFields(req.body),
+    );
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? 'image/png'

--- a/src/shared/screenshot.http.ts
+++ b/src/shared/screenshot.http.ts
@@ -91,7 +91,7 @@ export default class ScreenshotPost extends BrowserHTTPRoute {
     logger: Logger,
     browser: BrowserInstance,
   ): Promise<void> {
-    logger.info('Screenshot API invoked with body:', req.body);
+    logger.debug('Screenshot API invoked with body:', req.body);
     const contentType =
       !req.headers.accept || req.headers.accept?.includes('*')
         ? 'image/png'

--- a/src/shared/utils/performance/main.ts
+++ b/src/shared/utils/performance/main.ts
@@ -54,7 +54,7 @@ export default async ({
 
     child.on('message', (payload: Message) => {
       if (payload.event === 'created') {
-        logger.info(`Child process is up, sending performance request`);
+        logger.debug(`Child process is up, sending performance request`);
         return child.send({
           config,
           event: 'start',
@@ -64,7 +64,7 @@ export default async ({
       }
 
       if (payload.event === 'complete') {
-        logger.info(`Performance gathered, closing and resolving request`);
+        logger.debug(`Performance gathered, closing and resolving request`);
         close(child.pid);
         return resolve({
           data: payload.data,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -310,6 +310,35 @@ export const safeParse = (maybeJson: string): unknown | null => {
   }
 };
 
+const sensitiveBodyFields = [
+  'authenticate',
+  'authorization',
+  'cookies',
+  'headers',
+  'password',
+  'setExtraHTTPHeaders',
+  'token',
+];
+
+/**
+ * Returns a shallow copy of a request body safe for logging: fields that can
+ * carry credentials (cookies, auth headers, passwords) are replaced with a
+ * `[redacted]` marker.
+ */
+export const redactSensitiveBodyFields = (body: unknown): unknown => {
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return body;
+  }
+  return Object.fromEntries(
+    Object.entries(body).map(([key, value]) => [
+      key,
+      sensitiveBodyFields.includes(key) && value !== undefined
+        ? '[redacted]'
+        : value,
+    ]),
+  );
+};
+
 export const removeNullStringify = (
   json: unknown,
   allowNull = true,


### PR DESCRIPTION
## Summary

This PR reduces log noise from sources that scale with traffic or with the content of the pages being automated, and promotes two genuinely anomalous events to warn. No messages were reworded — only levels changed, plus one typed-error fix.

### Page event relays: warn → debug
`page.on('pageerror')` and `page.on('requestfailed')` relayed third-party page content (JS exceptions on the target site, failed analytics beacons, `net::ERR_ABORTED` subresources) at **warn**. A single session on a noisy page can emit hundreds of these, and they describe the *target site*, not service health. They now sit at debug, consistent with the existing `console`/`request`/`response` relays at trace.

### Browser lifecycle + request body dumps: info → debug
Per-session diagnostics (`Starting new X instance`, `got open port`, the full launch-options dump, `is running on ws://…`, `Closing X process`, `Proxying X to Y`) and the route-level `… API invoked with body:` payload dumps fire on every request. At info they dominate log volume at any reasonable traffic level; at debug they remain available when diagnosing a specific instance.

### Unexpected browser disconnects: info → warn
A browser process dying outside the normal close path (OOM, segfault, host kill) was logged at info. That's a real anomaly an operator should see.

### Rejection-path noise
- `Queue is full, sending 429 response` logged a **warn per rejected request**, duplicating the rejection metric and webhook; under client retry storms this floods logs. Now debug — the 429, `metrics.addRejected()`, and the alert webhook remain the operator signal.
- Health-check rejections threw a plain `Error`, so the generic 500 handler logged a **full stack trace per rejection** even though `onQueueFull` had already written a 429 to the client. The rejection now uses `TooManyRequests`, matching the adjacent at-capacity path, so it short-circuits the typed-error branch with no spurious stack trace.

## Testing
- `tsc --noEmit` clean
- `build/limiter.spec.js` and `build/router.spec.js` pass, including the health-check rejection and queue-capacity tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-body redaction for safer logs (sensitive fields masked).

* **Bug Fixes**
  * Now returns a specific TooManyRequests error when capacity limits are exceeded.

* **Chores**
  * Reduced logging verbosity across browser lifecycle, routing, and request handlers; some messages downgraded to debug and selected unexpected-close notifications now use warn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->