### PR TITLE
fix(ci): use squash strategy for dependabot auto-merge

### DIFF
--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Enable auto-merge for Dependabot PRs
         # Playwright updates should be manually reviewed
         if: "!contains(steps.metadata.outputs.dependency-names, 'playwright-core')"
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Problem

The dependabot auto-merge workflow (`.github/workflows/merge-dependabot.yml`) calls:

```sh
gh pr merge --auto --merge "$PR_URL"
```

But this repository **disallows merge commits** — only squash merges are permitted (`allow_merge_commit: false`, `allow_squash_merge: true`). As a result, every dependabot auto-merge attempt fails with:

```
GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
```

This means **no dependabot PR has been auto-merging** — the `automerge / dependabot` check goes red on all of them (e.g. #5440).

## Fix

Switch the merge strategy from `--merge` to `--squash` so it matches the repo's allowed merge method. Repo-level "Allow auto-merge" is already enabled, so this one line is all that's needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->