### PR TITLE
fix: allow launch options outside the documented subset

### DIFF
--- a/src/shared/tests/launch-options-passthrough.spec.ts
+++ b/src/shared/tests/launch-options-passthrough.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { compileSchema } from '../utils/schema-validator.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const wsRoutes = path.resolve(__dirname, '../../routes/chromium/ws');
+
+/**
+ * The `launch` connection parameter is a passthrough to puppeteer.launch()
+ * (CDP routes) / playwright.launchServer() (playwright routes): the parsed
+ * object is spread straight to the launcher, which ignores keys it doesn't
+ * recognize. `CDPLaunchOptions`/`BrowserServerOptions` only document a curated
+ * subset of those launcher options, so the generated schema must NOT reject
+ * unknown launch keys — otherwise a valid launcher option (or one added by a
+ * downstream image) becomes a hard 400 instead of being forwarded.
+ *
+ * These tests lock that contract in: extra keys inside `launch` are accepted,
+ * while malformed values for *known* launch fields and unknown *top-level*
+ * query params are still rejected.
+ */
+
+const loadSchema = async (file: string) =>
+  JSON.parse(await fs.readFile(path.join(wsRoutes, file), 'utf-8'));
+
+describe('launch options passthrough', function () {
+  // Single-browser docker images don't ship chromium route schemas; skip the
+  // suite in that case so firefox/webkit/edge CI doesn't choke.
+  before(async function () {
+    try {
+      await fs.access(path.join(wsRoutes, 'cdp.query.json'));
+    } catch {
+      this.skip();
+    }
+  });
+
+  it('accepts unknown launcher options inside launch (CDP)', async function () {
+    const schema = compileSchema(await loadSchema('cdp.query.json'));
+    const { error } = schema.validate({
+      token: 'token',
+      launch: JSON.stringify({
+        headless: true,
+        args: ['--window-size=1920,1080'],
+        // Real puppeteer.launch options outside the documented subset:
+        executablePath: '/usr/bin/chromium',
+        protocolTimeout: 60000,
+        // An option a future/downstream build might honor:
+        someUnknownLauncherOption: true,
+      }),
+    });
+    expect(error, error?.message).to.be.undefined;
+  });
+
+  it('still rejects a malformed value for a known launch field (CDP)', async function () {
+    const schema = compileSchema(await loadSchema('cdp.query.json'));
+    const { error } = schema.validate({
+      token: 'token',
+      // `args` is typed string[]; a bare number is neither an array nor
+      // coercible to one, so it must still fail.
+      launch: JSON.stringify({ args: 123 }),
+    });
+    expect(error, 'expected a malformed known field to be rejected').to.not.be
+      .undefined;
+  });
+
+  it('still rejects unknown top-level query params', async function () {
+    const schema = compileSchema(await loadSchema('cdp.query.json'));
+    const { error } = schema.validate({
+      token: 'token',
+      someUnknownTopLevelParam: 'true',
+    });
+    expect(error, 'expected an unknown top-level query param to be rejected').to
+      .not.be.undefined;
+  });
+
+  it('accepts unknown launchServer options inside launch (Playwright)', async function () {
+    try {
+      await fs.access(path.join(wsRoutes, 'playwright.query.json'));
+    } catch {
+      this.skip();
+    }
+    const schema = compileSchema(await loadSchema('playwright.query.json'));
+    const { error } = schema.validate({
+      token: 'token',
+      launch: JSON.stringify({
+        headless: true,
+        // Real playwright.launchServer options outside the documented subset:
+        executablePath: '/usr/bin/chromium',
+        slowMo: 50,
+        someUnknownLauncherOption: true,
+      }),
+    });
+    expect(error, error?.message).to.be.undefined;
+  });
+});

--- a/src/shim.spec.ts
+++ b/src/shim.spec.ts
@@ -193,6 +193,19 @@ describe('Request Shimming', () => {
     });
   });
 
+  describe('malformed launch', () => {
+    it('falls back to an empty launch object when launch is not a JSON object', () => {
+      // `?launch="foo"` parses to the primitive string "foo"; a legacy param
+      // triggers the shim, which then writes onto the parsed launch value. It
+      // must fall back to {} rather than throw on the non-object.
+      const url = 'wss://localhost?stealth=true&launch="foo"';
+      const final = 'wss://localhost/?launch={"stealth":true}';
+      const shimmed = shimLegacyRequests(new URL(url));
+
+      expect(decodeURIComponent(shimmed.href)).to.equal(final);
+    });
+  });
+
   describe('token shimming', () => {
     it('converts token query parameters to an authorization header', () => {
       const url = 'wss://localhost?token=12345';

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -47,8 +47,9 @@ export function shimLegacyRequests(url: URL): URL {
     cliSwitches.length || shimParam.some((name) => names.includes(name));
 
   if (hasLegacyParams) {
-    const launchParams: CDPLaunchOptions =
-      safeParse(convertIfBase64(searchParams.get('launch') || '{}')) || {};
+    const launchParams = (safeParse(
+      convertIfBase64(searchParams.get('launch') || '{}'),
+    ) || {}) as CDPLaunchOptions;
     const ignoreDefaultArgs =
       searchParams.get('ignoreDefaultArgs') ?? launchParams.ignoreDefaultArgs;
     const ignoreHTTPSErrors =

--- a/src/shim.ts
+++ b/src/shim.ts
@@ -47,9 +47,18 @@ export function shimLegacyRequests(url: URL): URL {
     cliSwitches.length || shimParam.some((name) => names.includes(name));
 
   if (hasLegacyParams) {
-    const launchParams = (safeParse(
+    const parsedLaunch = safeParse(
       convertIfBase64(searchParams.get('launch') || '{}'),
-    ) || {}) as CDPLaunchOptions;
+    );
+    // The shim writes onto launchParams below, so fall back to {} unless the
+    // parsed value is a plain object — a primitive/array `launch` would throw.
+    const launchParams = (
+      parsedLaunch &&
+      typeof parsedLaunch === 'object' &&
+      !Array.isArray(parsedLaunch)
+        ? parsedLaunch
+        : {}
+    ) as CDPLaunchOptions;
     const ignoreDefaultArgs =
       searchParams.get('ignoreDefaultArgs') ?? launchParams.ignoreDefaultArgs;
     const ignoreHTTPSErrors =

--- a/src/types.ts
+++ b/src/types.ts
@@ -396,6 +396,11 @@ export interface CDPLaunchOptions extends BrowserlessLaunch {
   timeout?: number;
   userDataDir?: string;
   waitForInitialPage?: boolean;
+  // `launch` is a passthrough to puppeteer.launch(): the parsed object is
+  // spread straight to the launcher, which ignores keys it doesn't recognize.
+  // Forward launcher options outside this documented subset rather than
+  // rejecting the connection.
+  [key: string]: unknown;
 }
 
 export interface BrowserLauncherOptions {
@@ -420,6 +425,11 @@ export interface BrowserServerOptions {
   };
   timeout?: number;
   tracesDir?: string;
+  // `launch` is a passthrough to playwright.launchServer(): the parsed object
+  // is spread straight to the launcher, which ignores keys it doesn't
+  // recognize. Forward launcher options outside this documented subset rather
+  // than rejecting the connection.
+  [key: string]: unknown;
 }
 
 export interface BrowserlessSession {


### PR DESCRIPTION
## What

Stop rejecting `launch` options that fall outside the documented subset (`CDPLaunchOptions` / `BrowserServerOptions`). These options were always forwarded to the browser launcher at runtime — tightened query validation had begun rejecting the connection before the request reached the launcher. This restores the pre-validation behavior for the launch object.

## Why

`launch` is a passthrough: the handler JSON-parses it and spreads it straight to `puppeteer.launch()` (CDP routes) / `playwright.launchServer()` (Playwright routes), both of which ignore options they don't recognize.

The query-validation layer validates `launch` against `CDPLaunchOptions` / `BrowserServerOptions` with `additionalProperties: false`. Those types document only a subset of launcher options, so a valid option outside the subset — e.g. `executablePath`, `env`, `protocolTimeout`, `channel`, `chromiumSandbox` — is rejected before the request reaches the launcher:

```
Query-parameter validation failed: "launch" must NOT have additional properties
```

The earlier validator matched `launch` as a string and left parsing to the handler, so these options passed validation and reached the launcher. This change restores that for the launch object while keeping the rest of query validation strict.

## How

Add an index signature (`[key: string]: unknown`) to `CDPLaunchOptions` and `BrowserServerOptions`. `typescript-json-schema` then emits `additionalProperties: {}` for the launch object, so:

- launch options outside the documented subset are accepted and forwarded (as before query validation was tightened);
- known launch fields keep their type checks (e.g. a non-array `args` is still rejected);
- unknown **top-level** query params are still rejected (top-level schemas are unchanged).

## Tests

`src/shared/tests/launch-options-passthrough.spec.ts` locks the contract against the generated CDP and Playwright query schemas: launch options outside the subset accepted, malformed known launch fields rejected, unknown top-level params rejected.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launch options now accept and pass through additional undocumented launcher configurations, enabling greater flexibility when customizing launcher parameters.

* **Tests**
  * Added comprehensive validation tests ensuring launch options are correctly handled and processed according to schema specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->