### PR TITLE
feat: Add a new in-house docker pull aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
   <p>
     <a href="https://hub.docker.com/r/browserless/chrome">
-      <img src="https://img.shields.io/docker/pulls/browserless/chrome?style=flat-square" alt="Docker pulls" />
+      <img src="https://img.shields.io/endpoint?url=https://browserless-docker-pulls.netlify.app/pulls&style=flat-square" alt="Docker pulls" />
     </a>
     <a href="https://github.com/browserless/browserless">
       <img src="https://img.shields.io/github/stars/browserless/browserless?style=flat-square" alt="GitHub stars" />

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@
   </p>
 
   <p>
+    <!--
+      Docker pulls badge.
+      `browserless-docker-pulls.netlify.app/pulls` is browserless's own in-house
+      aggregator (see commit "Add a new in-house docker pull aggregator"),
+      maintained by the browserless team and hosted on Netlify. It sums the pull
+      counts of the browserless Docker Hub repositories and returns them as a
+      shields.io endpoint payload. If the endpoint is unavailable the badge simply
+      renders shields.io's default error state; to drop the dependency entirely,
+      swap this for shields.io's native `https://img.shields.io/docker/pulls/browserless/chrome`
+      badge (single repo) instead.
+    -->
     <a href="https://hub.docker.com/r/browserless/chrome">
       <img src="https://img.shields.io/endpoint?url=https://browserless-docker-pulls.netlify.app/pulls&style=flat-square" alt="Docker pulls" />
     </a>


### PR DESCRIPTION
Adds a new aggregator for all docker pulls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker pull statistics badge in the README header to use a new pulls-metrics endpoint (backed by shields.io).
  * Added an HTML comment describing the pull aggregation approach and a suggested fallback to the native single-repo badge if the endpoint is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->