### PR TITLE
feat: opt-in private-network navigation guard with 403 for blocked navigations

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -7,7 +7,7 @@ import {
   ServerError,
   chromeExecutablePath,
   edgeExecutablePath,
-  findBlockedUrlInMessage,
+  findBlockedNavigationUrl,
   noop,
   once,
   ublockLitePath,
@@ -111,19 +111,22 @@ export class ChromiumCDP extends EventEmitter {
           url: string,
           direction: 'request' | 'response',
         ): void => {
-          // Read patterns per call (they can change at runtime) but skip
-          // the normalize/match work entirely in the common empty case —
-          // this runs for every network request and response.
+          // Read config per call (it can change at runtime) but skip the
+          // normalize/match work entirely in the common case where nothing is
+          // configured to block — this runs for every request and response.
           const patterns = this.config.getBlockedURLPatterns();
-          if (!patterns.length) {
+          const ranges = this.config.getBlockedNetworkRanges();
+          if (!patterns.length && !ranges) {
             return;
           }
-          // Wrap as `{ url }` so we share the Playwright bridge's
-          // normalize + match helper rather than duplicating it.
-          const blocked = findBlockedUrlInMessage({ url }, patterns);
+          // Scheme blocklist (e.g. file://) plus the private-network classifier.
+          // Top-level navigations are rejected earlier (with a clean status) by
+          // the route handlers; this is the runtime backstop for subresources
+          // and mid-flight redirects, so it terminates the session.
+          const blocked = findBlockedNavigationUrl(url, patterns, ranges);
           if (blocked) {
             this.logger.error(
-              `Blocked URL pattern "${blocked}" in ${direction} to ${this.constructor.name}, terminating`,
+              `Blocked URL "${blocked}" in ${direction} to ${this.constructor.name}, terminating`,
             );
             page.close().catch(noop);
             this.close();
@@ -147,6 +150,10 @@ export class ChromiumCDP extends EventEmitter {
 
   public isRunning(): boolean {
     return this.running;
+  }
+
+  public getConfig(): Config {
+    return this.config;
   }
 
   public async newPage(): Promise<Page> {

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -461,6 +461,71 @@ describe('BasePlaywright URL filter', () => {
       await waitFor(() => playwright.wsEndpoint() === null);
     });
 
+    it('blocks a Frame.goto to a private host when network ranges are configured', async () => {
+      // A consumer opts in by overriding getBlockedNetworkRanges() — the same
+      // mechanism a downstream SDK consumer uses to enable SSRF blocking.
+      (
+        playwright as unknown as { config: Config }
+      ).config.getBlockedNetworkRanges = () => ({
+        ipv4Prefixes: ['0.', '127.', '169.254.'],
+        ipv6Prefixes: ['::1', '::', 'fc', 'fd', 'fe80:', '::ffff:'],
+        protocols: [],
+        hostnames: ['localhost'],
+      });
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      const closeEvent = new Promise<{ code: number; reason: string }>(
+        (resolve) =>
+          client.on('close', (code, reason) =>
+            resolve({ code, reason: reason.toString() }),
+          ),
+      );
+      client.send(
+        JSON.stringify({
+          id: 3,
+          method: 'goto',
+          params: { url: 'http://169.254.169.254/latest/meta-data' },
+        }),
+      );
+      const close = await closeEvent;
+      expect(close.code).to.equal(1008);
+      expect(close.reason).to.match(/Blocked navigation/);
+      expect(upstreamMessages).to.have.lengthOf(0);
+      await waitFor(() => playwright.wsEndpoint() === null);
+    });
+
+    it('forwards a Frame.goto to a public host even with network ranges configured', async () => {
+      (
+        playwright as unknown as { config: Config }
+      ).config.getBlockedNetworkRanges = () => ({
+        ipv4Prefixes: ['127.', '169.254.'],
+        ipv6Prefixes: ['::1'],
+        protocols: [],
+        hostnames: ['localhost'],
+      });
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      client.send(
+        JSON.stringify({
+          id: 4,
+          method: 'goto',
+          params: { url: 'https://example.com/' },
+        }),
+      );
+      await waitFor(() => upstreamMessages.length >= 1);
+      expect(upstreamMessages).to.have.lengthOf(1);
+      expect(JSON.parse(upstreamMessages[0]).params.url).to.equal(
+        'https://example.com/',
+      );
+      client.close();
+    });
+
     it('blocks a Frame.goto carrying file:// sent as a BINARY frame', async () => {
       const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
       await new Promise<void>((resolve, reject) => {

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -7,6 +7,7 @@ import {
   ServerError,
   chromeExecutablePath,
   edgeExecutablePath,
+  findBlockedNavigationInMessage,
   findBlockedUrlInMessage,
   wsFrameToString,
 } from '@browserless.io/browserless';
@@ -105,6 +106,10 @@ class BasePlaywright extends EventEmitter {
 
   public isRunning(): boolean {
     return this.running;
+  }
+
+  public getConfig(): Config {
+    return this.config;
   }
 
   public async close(): Promise<void> {
@@ -366,6 +371,15 @@ class BasePlaywright extends EventEmitter {
           const stems = blockPatterns
             .map((p) => p.split(':')[0].toLowerCase())
             .filter((s) => s.length > 0);
+          // Opt-in private-network ranges (null = disabled). Scheme blocking
+          // stays in `blockPatterns` above. Unlike the CDP page-event guard —
+          // which sees every request/response URL — the range check here is
+          // scoped to explicit navigation frames (see findBlockedNavigationInMessage)
+          // so it cannot over-block non-navigation frames that carry a `url`
+          // (cookies, routes). The trade-off: a server-initiated redirect to a
+          // private host (a request event, not a `goto`) is not caught on this
+          // path; explicit navigations are.
+          const blockRanges = this.config.getBlockedNetworkRanges();
 
           // Parse before matching — a raw-substring fast-path would miss
           // JSON Unicode escapes (`"file://..."` has no literal
@@ -376,7 +390,7 @@ class BasePlaywright extends EventEmitter {
             direction: 'client→upstream' | 'upstream→client',
             isBinary: boolean,
           ): string | null => {
-            if (blockPatterns.length === 0) return null;
+            if (blockPatterns.length === 0 && !blockRanges) return null;
             const str = wsFrameToString(data);
             let parsed: unknown;
             try {
@@ -401,6 +415,10 @@ class BasePlaywright extends EventEmitter {
             const hit = findBlockedUrlInMessage(parsed, blockPatterns);
             if (hit) {
               return `Blocked URL pattern "${hit}" in ${this.constructor.name} ${direction} message`;
+            }
+            const navHit = findBlockedNavigationInMessage(parsed, blockRanges);
+            if (navHit) {
+              return `Blocked navigation to "${navHit}" in ${this.constructor.name} ${direction} message`;
             }
             return null;
           };

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import {
   untildify,
 } from '@browserless.io/browserless';
 import { EventEmitter } from 'events';
+import type { NetworkRangeSet } from './network-security.js';
 import debug from 'debug';
 import { fileURLToPath } from 'url';
 import { mkdir } from 'fs/promises';
@@ -272,6 +273,18 @@ export class Config extends EventEmitter {
    */
   public getBlockedURLPatterns(): string[] {
     return this.allowFileProtocol ? [] : ['file://'];
+  }
+  /**
+   * Returns the private-network destinations the browser is not allowed to
+   * navigate to, or `null` to disable private-network navigation blocking
+   * entirely (the default). Subclasses opt in by returning a
+   * {@link NetworkRangeSet} describing the loopback / link-local / cloud-
+   * metadata / RFC1918 ranges to block — the matcher never changes, only the
+   * range set fed to it. Scheme blocking (e.g. `file://`) stays in
+   * {@link getBlockedURLPatterns}.
+   */
+  public getBlockedNetworkRanges(): NetworkRangeSet | null {
+    return null;
   }
   public getCPULimit(): number {
     return this.maxCpu;

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -10,6 +10,7 @@ export * from './logger.js';
 export * from './metrics.js';
 export * from './mime-types.js';
 export * from './monitoring.js';
+export * from './network-security.js';
 export * from './router.js';
 export * from './sdk-utils.js';
 export * from './server.js';

--- a/src/http.ts
+++ b/src/http.ts
@@ -16,6 +16,11 @@ export const errorCodes = {
     description: `The request is missing, or contains bad, authorization credentials.`,
     message: 'HTTP/1.1 401 Unauthorized',
   },
+  403: {
+    code: 403,
+    description: `The request targets a destination that is not allowed.`,
+    message: 'HTTP/1.1 403 Forbidden',
+  },
   404: {
     code: 404,
     description: `Resource couldn't be found.`,

--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -1,0 +1,271 @@
+import { expect } from 'chai';
+import {
+  NetworkRangeSet,
+  findBlockedNavigationInMessage,
+  findBlockedNavigationUrl,
+  isBlockedNavigationIP,
+  isBlockedNavigationUrl,
+  looksLikeIPv4Literal,
+} from '@browserless.io/browserless';
+
+// A representative opt-in range set: loopback, link-local/cloud-metadata,
+// 0.0.0.0/8, the 172.16-31 RFC1918 block, dangerous IPv6, smtp/ftp, localhost.
+// It deliberately OMITS 10.x and 192.168.x to exercise a carve-out (a consumer
+// that lets the browser reach those LANs while still blocking metadata).
+const RANGES: NetworkRangeSet = {
+  ipv4Prefixes: [
+    '0.',
+    '127.',
+    '169.254.',
+    ...Array.from({ length: 16 }, (_, i) => `172.${16 + i}.`),
+  ],
+  ipv6Prefixes: ['::1', '::', 'fc', 'fd', 'fe80:', '::ffff:'],
+  protocols: ['smtp://', 'ftp://'],
+  hostnames: ['localhost'],
+};
+
+describe('Network Security', () => {
+  describe('looksLikeIPv4Literal', () => {
+    it('treats all-numeric/dotted hosts as literals, names as not', () => {
+      expect(looksLikeIPv4Literal('169.254.169.254')).to.be.true;
+      expect(looksLikeIPv4Literal('0.0.0.0')).to.be.true;
+      expect(looksLikeIPv4Literal('0.gravatar.com')).to.be.false;
+      expect(looksLikeIPv4Literal('example.com')).to.be.false;
+    });
+  });
+
+  describe('isBlockedNavigationUrl', () => {
+    it('blocks IPv6-mapped metadata (and textual variants)', () => {
+      expect(
+        isBlockedNavigationUrl(
+          'http://[::ffff:169.254.169.254]/latest',
+          RANGES,
+        ),
+      ).to.be.true;
+      expect(isBlockedNavigationUrl('http://[::ffff:a9fe:a9fe]/', RANGES)).to.be
+        .true;
+      expect(
+        isBlockedNavigationUrl(
+          'http://[0:0:0:0:0:ffff:169.254.169.254]/',
+          RANGES,
+        ),
+      ).to.be.true;
+    });
+
+    it('blocks plain metadata + link-local', () => {
+      expect(isBlockedNavigationUrl('http://169.254.169.254/meta', RANGES)).to
+        .be.true;
+      expect(isBlockedNavigationUrl('http://169.254.0.1/', RANGES)).to.be.true;
+    });
+
+    it('blocks alternate IPv4 encodings (decimal/hex/octal)', () => {
+      expect(isBlockedNavigationUrl('http://2852039166/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://0xA9FEA9FE/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://0251.0376.0251.0376/', RANGES)).to
+        .be.true;
+    });
+
+    it('blocks loopback in all forms', () => {
+      expect(isBlockedNavigationUrl('http://127.0.0.1/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://127.1/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://localhost/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://LOCALHOST:3000/', RANGES)).to.be
+        .true;
+      expect(isBlockedNavigationUrl('http://app.localhost/', RANGES)).to.be
+        .true;
+      expect(isBlockedNavigationUrl('http://[::1]/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://[::ffff:127.0.0.1]:3000/', RANGES))
+        .to.be.true;
+    });
+
+    it('blocks 0.0.0.0/8 and the unspecified IPv6 address', () => {
+      expect(isBlockedNavigationUrl('http://0.0.0.0:3000/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://[::]:3000/', RANGES)).to.be.true;
+    });
+
+    it('blocks 172.16.0.0/12 and dangerous IPv6 ranges', () => {
+      expect(isBlockedNavigationUrl('http://172.16.0.1/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://172.31.255.255/', RANGES)).to.be
+        .true;
+      expect(isBlockedNavigationUrl('http://[fe80::1]/', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('http://[fc00::1]/', RANGES)).to.be.true;
+    });
+
+    it('blocks configured protocols (view-source unwrapped)', () => {
+      expect(isBlockedNavigationUrl('smtp://internal/x', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('ftp://internal/x', RANGES)).to.be.true;
+      expect(
+        isBlockedNavigationUrl('view-source:http://169.254.169.254/', RANGES),
+      ).to.be.true;
+    });
+
+    it('allows ranges omitted from the set (carve-out) and public hosts', () => {
+      expect(isBlockedNavigationUrl('http://10.0.0.5/', RANGES)).to.be.false;
+      expect(isBlockedNavigationUrl('http://192.168.1.1/', RANGES)).to.be.false;
+      expect(isBlockedNavigationUrl('http://172.32.0.1/', RANGES)).to.be.false;
+      expect(isBlockedNavigationUrl('https://example.com/', RANGES)).to.be
+        .false;
+      expect(isBlockedNavigationUrl('http://8.8.8.8/', RANGES)).to.be.false;
+      expect(isBlockedNavigationUrl('http://[2001:db8::1]/', RANGES)).to.be
+        .false;
+    });
+
+    it('keys on the host, not URL substrings (userinfo cannot fool it)', () => {
+      expect(
+        isBlockedNavigationUrl('http://169.254.169.254@example.com/', RANGES),
+      ).to.be.false;
+      expect(
+        isBlockedNavigationUrl('http://example.com@169.254.169.254/', RANGES),
+      ).to.be.true;
+    });
+
+    it('fails closed on unparseable URLs', () => {
+      expect(isBlockedNavigationUrl('not-a-url', RANGES)).to.be.true;
+      expect(isBlockedNavigationUrl('', RANGES)).to.be.true;
+    });
+
+    it('blocks NOTHING when ranges is null (default off)', () => {
+      expect(isBlockedNavigationUrl('http://169.254.169.254/', null)).to.be
+        .false;
+      expect(isBlockedNavigationUrl('http://127.0.0.1/', null)).to.be.false;
+      expect(isBlockedNavigationUrl('http://[::ffff:169.254.169.254]/', null))
+        .to.be.false;
+      expect(isBlockedNavigationUrl('not-a-url', null)).to.be.false;
+    });
+  });
+
+  describe('isBlockedNavigationIP', () => {
+    it('blocks private/metadata IPs and allows public/carve-out', () => {
+      expect(isBlockedNavigationIP('127.0.0.1', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('169.254.169.254', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('172.22.0.3', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('0.0.0.0', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('::1', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('fe80::1', RANGES)).to.be.true;
+      expect(isBlockedNavigationIP('::ffff:169.254.169.254', RANGES)).to.be
+        .true;
+      expect(isBlockedNavigationIP('8.8.8.8', RANGES)).to.be.false;
+      expect(isBlockedNavigationIP('10.0.0.5', RANGES)).to.be.false;
+      expect(isBlockedNavigationIP('192.168.1.1', RANGES)).to.be.false;
+      expect(isBlockedNavigationIP('2001:db8::1', RANGES)).to.be.false;
+    });
+
+    it('blocks NOTHING when ranges is null (default off)', () => {
+      expect(isBlockedNavigationIP('169.254.169.254', null)).to.be.false;
+      expect(isBlockedNavigationIP('::1', null)).to.be.false;
+    });
+  });
+
+  describe('findBlockedNavigationUrl', () => {
+    it('returns the matched scheme pattern (file:// governed by patterns)', () => {
+      expect(
+        findBlockedNavigationUrl('file:///etc/passwd', ['file://'], RANGES),
+      ).to.equal('file://');
+    });
+
+    it('respects an empty pattern list (ALLOW_FILE_PROTOCOL) for file://', () => {
+      expect(findBlockedNavigationUrl('file:///etc/passwd', [], RANGES)).to.be
+        .null;
+    });
+
+    it('returns the URL for a private/metadata host via ranges', () => {
+      expect(
+        findBlockedNavigationUrl(
+          'http://[::ffff:169.254.169.254]/',
+          [],
+          RANGES,
+        ),
+      ).to.equal('http://[::ffff:169.254.169.254]/');
+      expect(
+        findBlockedNavigationUrl('http://0.0.0.0:3000/', [], RANGES),
+      ).to.equal('http://0.0.0.0:3000/');
+    });
+
+    it('returns null for allowed/public destinations', () => {
+      expect(
+        findBlockedNavigationUrl('https://example.com/', ['file://'], RANGES),
+      ).to.be.null;
+      expect(findBlockedNavigationUrl('http://10.0.0.5/', ['file://'], RANGES))
+        .to.be.null;
+    });
+
+    it('with null ranges + empty patterns blocks nothing (OSS default)', () => {
+      expect(findBlockedNavigationUrl('http://169.254.169.254/', [], null)).to
+        .be.null;
+    });
+  });
+
+  // Used by the CDP and Playwright WebSocket bridges to reject private-network
+  // navigations from raw protocol frames, scoped to navigation methods.
+  describe('findBlockedNavigationInMessage', () => {
+    it('blocks a Playwright goto to a private host (both wire spellings)', () => {
+      for (const method of ['goto', 'Frame.goto']) {
+        const frame = {
+          guid: 'frame@abc',
+          method,
+          params: { url: 'http://169.254.169.254/latest', waitUntil: 'load' },
+        };
+        expect(findBlockedNavigationInMessage(frame, RANGES)).to.equal(
+          'http://169.254.169.254/latest',
+        );
+      }
+    });
+
+    it('blocks CDP Page.navigate and Target.createTarget to a private host', () => {
+      expect(
+        findBlockedNavigationInMessage(
+          { method: 'Page.navigate', params: { url: 'http://127.0.0.1/' } },
+          RANGES,
+        ),
+      ).to.equal('http://127.0.0.1/');
+      expect(
+        findBlockedNavigationInMessage(
+          {
+            method: 'Target.createTarget',
+            params: { url: 'http://[::ffff:169.254.169.254]/' },
+          },
+          RANGES,
+        ),
+      ).to.equal('http://[::ffff:169.254.169.254]/');
+    });
+
+    it('allows a goto to a public host', () => {
+      expect(
+        findBlockedNavigationInMessage(
+          { method: 'goto', params: { url: 'https://example.com/' } },
+          RANGES,
+        ),
+      ).to.be.null;
+    });
+
+    it('does NOT fire on non-navigation methods that carry a url', () => {
+      // A cookie/route frame pointed at localhost must not tear down the session.
+      expect(
+        findBlockedNavigationInMessage(
+          { method: 'addCookies', params: { url: 'http://localhost/' } },
+          RANGES,
+        ),
+      ).to.be.null;
+      expect(
+        findBlockedNavigationInMessage(
+          { method: 'setNetworkCookie', params: { url: 'http://127.0.0.1/' } },
+          RANGES,
+        ),
+      ).to.be.null;
+    });
+
+    it('returns null for malformed frames and when ranges is null', () => {
+      expect(findBlockedNavigationInMessage({ method: 'goto' }, RANGES)).to.be
+        .null;
+      expect(findBlockedNavigationInMessage(null, RANGES)).to.be.null;
+      expect(findBlockedNavigationInMessage('not-an-object', RANGES)).to.be
+        .null;
+      expect(
+        findBlockedNavigationInMessage(
+          { method: 'goto', params: { url: 'http://169.254.169.254/' } },
+          null,
+        ),
+      ).to.be.null;
+    });
+  });
+});

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -1,0 +1,178 @@
+import {
+  Forbidden,
+  findBlockedUrlInMessage,
+  normalizeUrlForBlocklist,
+} from './utils.js';
+
+/**
+ * Describes the network destinations the browser is not allowed to navigate to
+ * (or load subresources from). Supplied by `Config.getBlockedNetworkRanges()`.
+ *
+ * A `null` range set — the default — disables private-network navigation
+ * blocking entirely, so the matcher is inert unless a consumer opts in.
+ *
+ * - `ipv4Prefixes` — dotted-decimal prefixes matched against a canonicalized
+ *   IPv4 literal host (e.g. `'127.'`, `'169.254.'`, `'0.'`). Decimal, octal,
+ *   hex and short-form IPv4 are canonicalized to dotted-quad before matching,
+ *   so only the canonical form needs listing.
+ * - `ipv6Prefixes` — prefixes matched against the bracket-stripped IPv6 host
+ *   (e.g. `'::1'`, `'fe80:'`, `'::ffff:'`).
+ * - `protocols` — URL schemes blocked outright (e.g. `'smtp://'`, `'ftp://'`).
+ *   `file://` is governed separately, by `Config.getBlockedURLPatterns()`.
+ * - `hostnames` — blocked by exact match or as a dot-suffix (e.g. `'localhost'`
+ *   blocks both `localhost` and `*.localhost`, which resolve to loopback).
+ */
+export interface NetworkRangeSet {
+  ipv4Prefixes: string[];
+  ipv6Prefixes: string[];
+  protocols: string[];
+  hostnames: string[];
+}
+
+/**
+ * A host made only of digits and dots is an IPv4 literal — `new URL()` has
+ * already canonicalized decimal/octal/hex/short forms to dotted-quad by the
+ * time this is tested. A hostname that merely starts with digits (e.g.
+ * `0.example.com`) is not, and must NOT be prefix-matched against IPv4 ranges.
+ */
+export const looksLikeIPv4Literal = (host: string): boolean =>
+  /^[0-9.]+$/.test(host);
+
+const isBlockedNavigationHost = (
+  host: string,
+  ranges: NetworkRangeSet,
+): boolean => {
+  if (host.startsWith('[')) {
+    // IPv6 literal — covers ::1, ::ffff:<v4>, fc/fd ULA, fe80 link-local, etc.
+    const inner = host.slice(1, -1);
+    return ranges.ipv6Prefixes.some((prefix) => inner.startsWith(prefix));
+  }
+  if (looksLikeIPv4Literal(host)) {
+    return ranges.ipv4Prefixes.some((prefix) => host.startsWith(prefix));
+  }
+  return ranges.hostnames.some(
+    (name) => host === name || host.endsWith(`.${name}`),
+  );
+};
+
+/**
+ * Decides whether the browser may navigate to (or load a subresource from) a
+ * URL, given a {@link NetworkRangeSet}. Robust against IPv6-mapped (`::ffff:`),
+ * alternate-encoding (decimal/octal/hex) and `view-source:` / control-char
+ * obfuscations — candidate canonicalization is shared with the scheme blocklist
+ * via {@link normalizeUrlForBlocklist}.
+ *
+ * Returns `false` when `ranges` is `null` (blocking disabled). Returns `true`
+ * (blocked) for unparseable URLs as a safety measure.
+ */
+export const isBlockedNavigationUrl = (
+  rawUrl: string,
+  ranges: NetworkRangeSet | null,
+): boolean => {
+  if (!ranges) return false;
+  const normalized = normalizeUrlForBlocklist(rawUrl);
+  if (ranges.protocols.some((proto) => normalized.startsWith(proto))) {
+    return true;
+  }
+  try {
+    return isBlockedNavigationHost(new URL(normalized).hostname, ranges);
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Decides whether a raw IP address (e.g. puppeteer's
+ * `response.remoteAddress().ip`) is blocked. The browser reports a canonical
+ * IP, so no encoding normalization is needed. Returns `false` when `ranges` is
+ * `null`.
+ */
+export const isBlockedNavigationIP = (
+  ip: string,
+  ranges: NetworkRangeSet | null,
+): boolean => {
+  if (!ranges) return false;
+  const host = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host.includes(':')) {
+    return ranges.ipv6Prefixes.some((prefix) => host.startsWith(prefix));
+  }
+  if (looksLikeIPv4Literal(host)) {
+    return ranges.ipv4Prefixes.some((prefix) => host.startsWith(prefix));
+  }
+  return false;
+};
+
+/**
+ * Composes both navigation blocklists for a single candidate URL: the
+ * scheme/prefix list from `Config.getBlockedURLPatterns()` (e.g. `file://`) and
+ * the private-network host classifier from `Config.getBlockedNetworkRanges()`.
+ * Returns the offending pattern or URL, or `null`. This is the single check a
+ * route should run before navigating, to reject with a clean status rather than
+ * relying on a mid-navigation teardown.
+ */
+export const findBlockedNavigationUrl = (
+  url: string,
+  patterns: string[],
+  ranges: NetworkRangeSet | null,
+): string | null =>
+  findBlockedUrlInMessage({ url }, patterns) ??
+  (isBlockedNavigationUrl(url, ranges) ? url : null);
+
+/**
+ * Whether a wire-protocol method initiates a navigation, across the CDP and
+ * Playwright JSON-RPC formats. {@link findBlockedNavigationInMessage} is scoped
+ * to these so the host check never fires on a frame that merely carries a `url`
+ * field for some non-navigation purpose (e.g. setting a cookie). Matches both
+ * Playwright spellings (`goto` and the channel-qualified `Frame.goto`).
+ */
+const isNavigationMethod = (method: string): boolean =>
+  method === 'Page.navigate' || // CDP
+  method === 'Target.createTarget' || // CDP
+  method === 'goto' ||
+  method.endsWith('.goto'); // Playwright Frame.goto
+
+/**
+ * Returns the blocked navigation target inside a wire-protocol message (a CDP
+ * or Playwright JSON-RPC frame), or `null`. Only inspects navigation-creating
+ * methods, so it cannot over-block on frames that incidentally carry a `url`.
+ * Returns `null` when `ranges` is `null` (guard disabled). Lets a route's
+ * WebSocket bridge reject private-network navigations the same way the HTTP
+ * handlers do.
+ */
+export const findBlockedNavigationInMessage = (
+  message: unknown,
+  ranges: NetworkRangeSet | null,
+): string | null => {
+  if (!ranges || !message || typeof message !== 'object') return null;
+  const { method, params } = message as {
+    method?: unknown;
+    params?: { url?: unknown };
+  };
+  if (
+    typeof method === 'string' &&
+    isNavigationMethod(method) &&
+    typeof params?.url === 'string' &&
+    isBlockedNavigationUrl(params.url, ranges)
+  ) {
+    return params.url;
+  }
+  return null;
+};
+
+/**
+ * Throws {@link Forbidden} (→ HTTP 403) when `url` is a blocked navigation
+ * target, so route handlers can reject before navigating rather than letting a
+ * mid-navigation teardown surface as a 500. No-op when `url` is empty (e.g. an
+ * `html`-only request that never navigates).
+ */
+export const assertNavigationAllowed = (
+  url: string | undefined,
+  patterns: string[],
+  ranges: NetworkRangeSet | null,
+): void => {
+  if (!url) return;
+  const blocked = findBlockedNavigationUrl(url, patterns, ranges);
+  if (blocked) {
+    throw new Forbidden(`Navigation to "${blocked}" is not allowed`);
+  }
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import {
   BadRequest,
   Logger as BlessLogger,
   Config,
+  Forbidden,
   HTTPRoute,
   Hooks,
   Metrics,
@@ -74,6 +75,10 @@ export class HTTPServer extends EventEmitter {
 
     if (e instanceof NotFound) {
       return writeResponse(res, 404, e.message, contentType);
+    }
+
+    if (e instanceof Forbidden) {
+      return writeResponse(res, 403, e.message, contentType);
     }
 
     if (e instanceof Unauthorized) {

--- a/src/shared/content.http.ts
+++ b/src/shared/content.http.ts
@@ -15,6 +15,7 @@ import {
   WaitForEventOptions,
   WaitForFunctionOptions,
   WaitForSelectorOptions,
+  assertNavigationAllowed,
   bestAttempt,
   bestAttemptCatch,
   contentTypes,
@@ -127,6 +128,13 @@ export default class ChromiumContentPostRoute extends BrowserHTTPRoute {
     if (!content) {
       throw new BadRequest(`One of "url" or "html" properties are required.`);
     }
+
+    const config = browser.getConfig();
+    assertNavigationAllowed(
+      url,
+      config.getBlockedURLPatterns(),
+      config.getBlockedNetworkRanges(),
+    );
 
     const page = (await browser.newPage()) as UnwrapPromise<
       ReturnType<ChromiumCDP['newPage']>

--- a/src/shared/pdf.http.ts
+++ b/src/shared/pdf.http.ts
@@ -15,6 +15,7 @@ import {
   WaitForEventOptions,
   WaitForFunctionOptions,
   WaitForSelectorOptions,
+  assertNavigationAllowed,
   bestAttempt,
   bestAttemptCatch,
   contentTypes,
@@ -140,6 +141,13 @@ export default class ChromiumPDFPostRoute extends BrowserHTTPRoute {
         `"fullPage" option cannot be used with "height" or "format" options.`,
       );
     }
+
+    const config = browser.getConfig();
+    assertNavigationAllowed(
+      url,
+      config.getBlockedURLPatterns(),
+      config.getBlockedNetworkRanges(),
+    );
 
     const page = (await browser.newPage()) as UnwrapPromise<
       ReturnType<ChromiumCDP['newPage']>

--- a/src/shared/performance.http.ts
+++ b/src/shared/performance.http.ts
@@ -10,6 +10,7 @@ import {
   Methods,
   Request,
   SystemQueryParameters,
+  assertNavigationAllowed,
   contentTypes,
   jsonResponse,
 } from '@browserless.io/browserless';
@@ -52,6 +53,13 @@ export default class PerformancePost extends BrowserHTTPRoute {
     browser: BrowserInstance,
   ): Promise<void> {
     const config = this.config();
+    const { url } = req.body as BodySchema;
+    assertNavigationAllowed(
+      url,
+      config.getBlockedURLPatterns(),
+      config.getBlockedNetworkRanges(),
+    );
+
     const response = await main({
       browser,
       context: req.body as BodySchema,

--- a/src/shared/scrape.http.ts
+++ b/src/shared/scrape.http.ts
@@ -20,6 +20,7 @@ import {
   WaitForEventOptions,
   WaitForFunctionOptions,
   WaitForSelectorOptions,
+  assertNavigationAllowed,
   bestAttempt,
   bestAttemptCatch,
   contentTypes,
@@ -287,6 +288,13 @@ export default class ChromiumScrapePostRoute extends BrowserHTTPRoute {
     if (!content) {
       throw new BadRequest(`One of "url" or "html" properties are required.`);
     }
+
+    const config = browser.getConfig();
+    assertNavigationAllowed(
+      url,
+      config.getBlockedURLPatterns(),
+      config.getBlockedNetworkRanges(),
+    );
 
     const page = (await browser.newPage()) as UnwrapPromise<
       ReturnType<ChromiumCDP['newPage']>

--- a/src/shared/screenshot.http.ts
+++ b/src/shared/screenshot.http.ts
@@ -15,6 +15,7 @@ import {
   WaitForEventOptions,
   WaitForFunctionOptions,
   WaitForSelectorOptions,
+  assertNavigationAllowed,
   bestAttempt,
   bestAttemptCatch,
   contentTypes,
@@ -142,6 +143,13 @@ export default class ScreenshotPost extends BrowserHTTPRoute {
     if (!content) {
       throw new BadRequest(`One of "url" or "html" properties are required.`);
     }
+
+    const config = browser.getConfig();
+    assertNavigationAllowed(
+      url,
+      config.getBlockedURLPatterns(),
+      config.getBlockedNetworkRanges(),
+    );
 
     const page = (await browser.newPage()) as UnwrapPromise<
       ReturnType<ChromiumCDP['newPage']>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -765,6 +765,14 @@ export class NotFound extends Error {
     errorLog(this.message);
   }
 }
+export class Forbidden extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'Forbidden';
+    this.message = message;
+    errorLog(this.message);
+  }
+}
 export class Timeout extends Error {
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
## Summary

Adds an **opt-in** guard that prevents the browser from navigating to private/internal network destinations (loopback, link-local / cloud-metadata, RFC1918, IPv6 ULA / link-local, the unspecified address) — a building block for SSRF hardening. Blocked navigations — including the existing `file://` block — now fail with a clean **403 Forbidden** instead of surfacing as a `500`.

The guard is **off by default**, so existing behavior is unchanged. A consumer opts in by overriding `Config.getBlockedNetworkRanges()`.

## What's added

- **`network-security.ts`** — a host classifier (`isBlockedNavigationUrl`, `isBlockedNavigationIP`, `findBlockedNavigationUrl`, `findBlockedNavigationInMessage`, `assertNavigationAllowed`) driven by a `NetworkRangeSet`. URLs are canonicalized first (reusing `normalizeUrlForBlocklist`), so IPv6-mapped (`[::ffff:…]`), decimal/octal/hex IPv4, `view-source:` wrappers and control-char tricks all resolve to the real host before matching. Scheme blocking (`file://`) stays governed by `getBlockedURLPatterns()`.
- **`Config.getBlockedNetworkRanges(): NetworkRangeSet | null`** — `null` by default (guard disabled). Subclasses opt in by returning the ranges to block; the matcher never changes, only the range set fed to it.
- **`Forbidden` error class → HTTP 403** — added to the error set and the server error mapper.
- **Pre-navigation checks** in the `screenshot` / `content` / `pdf` / `scrape` handlers — a blocked top-level `url` is rejected with `403` before the browser navigates, instead of being torn down mid-navigation (which produced a `500`).
- **Every browser family inherits the guard:** the CDP page-event guard and the Playwright wire-frame filter both consult `getBlockedNetworkRanges()` (in addition to the existing scheme patterns). The Playwright check is scoped to navigation frames, so it can't over-block on non-navigation frames that happen to carry a `url`.

## Behavior

| Config | Result |
| --- | --- |
| default (`getBlockedNetworkRanges()` → `null`) | unchanged — nothing new is blocked; `file://` (when disallowed) now returns `403` instead of `500` |
| opt-in range set | matching navigations rejected with `403 Forbidden` (HTTP) / session closed `1008` (WS) |

## Tests

- `network-security.spec.ts` — 24 unit tests: IPv6-mapped / alternate-encoding bypasses, `0.0.0.0/8`, loopback variants, `view-source:`, host-vs-userinfo, fail-closed parsing, the RFC1918 carve-out boundary, the navigation-method scoping (no over-block on non-navigation frames), and a proof that a `null` range set blocks nothing.
- `browsers.playwright.spec.ts` — added two cases to the existing `proxyWebSocket` bridge suite: a `goto` to a private host is torn down (`1008`, not forwarded upstream) when ranges are configured, and a public `goto` still forwards.

## Notes

- `isBlockedNavigationUrl` is intentionally synchronous and literal-only (no DNS resolution on the navigation path); DNS-rebinding defense belongs to the server-side fetch helpers, not the per-navigation hot path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network-range-based navigation blocking (for both URL patterns and private/metadata-style targets).
  * Added pre-navigation validation to content endpoints (proxying, PDF, scraping, screenshots, and performance).
  * Exposed configuration accessors to support the new blocking checks.

* **Bug Fixes / Behavior**
  * Blocked navigation now consistently returns HTTP **403 (Forbidden)**.

* **Tests**
  * Added end-to-end coverage for network-range blocking/allowing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->