### PR TITLE
fix: merge --disable-features instead of clobbering Playwright's list (#5450)

### DIFF
--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -11,6 +11,7 @@ import {
   FirefoxPlaywright,
   WebKitPlaywright,
   browserlessChromiumDisabledFeatures,
+  chromiumDisabledFeaturesForPwVersion,
   parseDisableFeatures,
   playwrightChromiumDisabledFeatures,
   withMergedChromiumDisableFeatures,
@@ -21,7 +22,6 @@ import { createServer, IncomingMessage, Server } from 'http';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import playwrightCore from 'playwright-core';
 
 /** Poll `cond` every 10ms up to `timeoutMs`; replaces brittle fixed sleeps. */
 const waitFor = async (
@@ -903,6 +903,29 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       );
       expect(features.length).to.equal(new Set(features).size);
     });
+
+    it('selects the per-version disabled-features list for older pwVersions', () => {
+      // 1.57 disables AcceptCHFrame and does NOT yet disable
+      // BoundaryEventDispatchTracksNodeRemoval; the default (1.61) is the
+      // opposite. browserless's LocalNetworkAccessChecks is always present.
+      const f157 = parseDisableFeatures(
+        withMergedChromiumDisableFeatures([], '1.57'),
+      );
+      expect(f157).to.include('AcceptCHFrame');
+      expect(f157).to.not.include('BoundaryEventDispatchTracksNodeRemoval');
+      expect(f157).to.include('LocalNetworkAccessChecks');
+
+      const fDefault = parseDisableFeatures(
+        withMergedChromiumDisableFeatures([]),
+      );
+      expect(fDefault).to.not.include('AcceptCHFrame');
+      expect(fDefault).to.include('BoundaryEventDispatchTracksNodeRemoval');
+
+      // Current/unknown versions fall back to the default list.
+      expect(
+        parseDisableFeatures(withMergedChromiumDisableFeatures([], '1.61')),
+      ).to.deep.equal(fDefault);
+    });
   });
 
   describe('makeLaunchOptions', () => {
@@ -925,12 +948,41 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
     });
   });
 
-  describe('interaction with the installed Playwright version', () => {
-    // Ground truth for the installed version: capture the exact args Playwright
-    // passes to the browser by pointing launchServer at a fake executable that
-    // records its argv and exits. No internal/private imports — this reflects
-    // whatever the pinned Playwright actually emits.
-    const captureLaunchArgv = async (args: string[]): Promise<string[]> => {
+  describe('interaction with the installed Playwright versions', () => {
+    // browserless can launch any of these pinned Playwright versions; each is a
+    // real dependency installed in node_modules (see package.json
+    // `playwrightVersions`). The mirror must match each one.
+    const SUPPORTED_PW_VERSIONS: Readonly<Record<string, string>> = {
+      '1.57': 'playwright-1.57',
+      '1.58': 'playwright-1.58',
+      '1.59': 'playwright-1.59',
+      '1.60': 'playwright-1.60',
+      '1.61': 'playwright-core',
+    };
+
+    type ChromiumLauncher = {
+      launchServer: (o: {
+        args: string[];
+        executablePath: string;
+        timeout: number;
+      }) => Promise<{ close: () => Promise<void> }>;
+    };
+
+    const chromiumFor = async (modName: string): Promise<ChromiumLauncher> => {
+      const m = (await import(modName)) as {
+        chromium?: ChromiumLauncher;
+        default?: { chromium: ChromiumLauncher };
+      };
+      return m.chromium ?? m.default!.chromium;
+    };
+
+    // Ground truth for a given version: capture the exact args its launcher
+    // passes by pointing launchServer at a fake executable that records its argv
+    // and exits. No internal/private imports — reflects what that version emits.
+    const captureLaunchArgv = async (
+      chromium: ChromiumLauncher,
+      args: string[],
+    ): Promise<string[]> => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bless-pw-argv-'));
       const argvFile = path.join(dir, 'argv.json');
       const fakeBin = path.join(dir, 'fake-browser.cjs');
@@ -944,7 +996,7 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       );
       fs.chmodSync(fakeBin, 0o755);
       try {
-        const server = await playwrightCore.chromium.launchServer({
+        const server = await chromium.launchServer({
           args,
           executablePath: fakeBin,
           timeout: 15000,
@@ -963,56 +1015,59 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       return argv;
     };
 
-    const assertNoDrift = async (): Promise<void> => {
-      const live = parseDisableFeatures(await captureLaunchArgv([]));
-      expect(live, 'captured an empty Playwright --disable-features list').to
-        .not.be.empty;
-
-      const mirror = new Set(playwrightChromiumDisabledFeatures);
-      const liveSet = new Set(live);
-      const addedByPlaywright = [...liveSet].filter((f) => !mirror.has(f));
-      const removedByPlaywright = [...mirror].filter((f) => !liveSet.has(f));
-
-      expect(
-        addedByPlaywright,
-        'Playwright ADDED disabled-feature(s) not in playwrightChromiumDisabledFeatures — add them',
-      ).to.deep.equal([]);
-      expect(
-        removedByPlaywright,
-        'Playwright REMOVED disabled-feature(s) still in playwrightChromiumDisabledFeatures — remove them',
-      ).to.deep.equal([]);
-    };
-
-    const assertBrowserlessFlagWins = async (): Promise<void> => {
-      // Feed the args browserless actually passes to the real Playwright
-      // launcher. Playwright prepends its own --disable-features and appends
-      // ours after it; Chromium keeps the LAST occurrence, so the winning flag
-      // must be browserless's superset carrying BOTH lists.
-      const argv = await captureLaunchArgv(launchArgs(ChromiumPlaywright, []));
-      const disableFlags = disableFeaturesFlags(argv);
-      expect(
-        disableFlags.length,
-        'expected Playwright + browserless --disable-features flags',
-      ).to.be.greaterThan(0);
-      const winning = parseDisableFeatures([
-        disableFlags[disableFlags.length - 1],
-      ]);
-      expect(winning).to.include('RenderDocument'); // Playwright's, preserved
-      expect(winning).to.include('LocalNetworkAccessChecks'); // browserless's
-    };
-
     // Fake executable relies on a POSIX shebang; browserless runs on Linux.
     const itPosix = process.platform === 'win32' ? it.skip : it;
-    itPosix(
-      'mirror equals Playwright exactly — fails on any feature added or removed',
-      async () => {
-        await assertNoDrift();
-      },
-    ).timeout(60000);
+
+    // 1:1 drift guard per supported version — fails if a pinned Playwright adds
+    // or removes a feature relative to the mirror resolved for that version.
+    for (const [version, modName] of Object.entries(SUPPORTED_PW_VERSIONS)) {
+      itPosix(
+        `mirror for PW ${version} matches the installed Playwright exactly`,
+        async () => {
+          const live = parseDisableFeatures(
+            await captureLaunchArgv(await chromiumFor(modName), []),
+          );
+          expect(live, `empty --disable-features for ${version}`).to.not.be
+            .empty;
+
+          const expected = new Set(
+            chromiumDisabledFeaturesForPwVersion(version),
+          );
+          const liveSet = new Set(live);
+          const added = [...liveSet].filter((f) => !expected.has(f));
+          const removed = [...expected].filter((f) => !liveSet.has(f));
+
+          expect(
+            added,
+            `PW ${version} disables feature(s) not mirrored — update playwrightChromiumDisabledFeatures(ByVersion)`,
+          ).to.deep.equal([]);
+          expect(
+            removed,
+            `PW ${version} no longer disables feature(s) still mirrored — update playwrightChromiumDisabledFeatures(ByVersion)`,
+          ).to.deep.equal([]);
+        },
+      ).timeout(60000);
+    }
+
+    // End-to-end: browserless's merged flag is the one Chromium keeps, and it
+    // carries both Playwright's list and browserless's additions.
     itPosix(
       "browserless's merged --disable-features is the one Chromium keeps",
       async () => {
-        await assertBrowserlessFlagWins();
+        const argv = await captureLaunchArgv(
+          await chromiumFor(SUPPORTED_PW_VERSIONS['1.61']),
+          launchArgs(ChromiumPlaywright, []),
+        );
+        const disableFlags = disableFeaturesFlags(argv);
+        expect(
+          disableFlags.length,
+          'expected Playwright + browserless --disable-features flags',
+        ).to.be.greaterThan(0);
+        const winning = parseDisableFeatures([
+          disableFlags[disableFlags.length - 1],
+        ]);
+        expect(winning).to.include('RenderDocument'); // Playwright's, preserved
+        expect(winning).to.include('LocalNetworkAccessChecks'); // browserless's
       },
     ).timeout(60000);
   });

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -11,9 +11,7 @@ import {
   FirefoxPlaywright,
   WebKitPlaywright,
   browserlessChromiumDisabledFeatures,
-  chromiumDisabledFeaturesForPwVersion,
   parseDisableFeatures,
-  playwrightChromiumDisabledFeatures,
   withMergedChromiumDisableFeatures,
 } from './browsers.playwright.js';
 import net, { AddressInfo } from 'net';
@@ -837,9 +835,13 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
   }) => unknown;
   // Build a launcher's args, dropping the empty strings launch() filters out
   // before handing them to launchServer.
-  const launchArgs = (Ctor: PwCtor, args: string[]): string[] => {
+  const launchArgs = (
+    Ctor: PwCtor,
+    args: string[],
+    config: Config = new Config(),
+  ): string[] => {
     const instance = new Ctor({
-      config: new Config(),
+      config,
       logger: new Logger('test'),
       userDataDir: null,
     });
@@ -848,20 +850,45 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       .args.filter((a) => !!a);
   };
 
+  // The default per-version list browserless ships (current Playwright).
+  const defaultFeatures = new Config().getChromiumDisabledFeatures();
+
+  describe('Config.getChromiumDisabledFeatures (overridable seam)', () => {
+    it('returns the default list for current/unknown versions', () => {
+      const cfg = new Config();
+      for (const v of [undefined, 'default', '1.60', '1.61', '1.99']) {
+        expect(cfg.getChromiumDisabledFeatures(v)).to.deep.equal(
+          defaultFeatures,
+        );
+      }
+      expect(defaultFeatures).to.include('RenderDocument');
+      expect(defaultFeatures).to.include(
+        'BoundaryEventDispatchTracksNodeRemoval',
+      );
+      expect(defaultFeatures).to.not.include('AcceptCHFrame');
+    });
+
+    it('returns a version-specific list where it differs (1.57)', () => {
+      const f157 = new Config().getChromiumDisabledFeatures('1.57');
+      expect(f157).to.include('AcceptCHFrame');
+      expect(f157).to.not.include('BoundaryEventDispatchTracksNodeRemoval');
+    });
+  });
+
   describe('withMergedChromiumDisableFeatures', () => {
     it('collapses everything into exactly one --disable-features flag', () => {
-      const out = withMergedChromiumDisableFeatures([
-        '--disable-features=CallerOne',
-        '--foo',
-      ]);
+      const out = withMergedChromiumDisableFeatures(
+        ['--disable-features=CallerOne', '--foo'],
+        defaultFeatures,
+      );
       expect(disableFeaturesFlags(out)).to.have.lengthOf(1);
     });
 
-    it('includes every Playwright default and every browserless addition', () => {
+    it('includes the provided Playwright list and every browserless addition', () => {
       const features = parseDisableFeatures(
-        withMergedChromiumDisableFeatures([]),
+        withMergedChromiumDisableFeatures([], defaultFeatures),
       );
-      for (const f of playwrightChromiumDisabledFeatures) {
+      for (const f of defaultFeatures) {
         expect(features, `missing Playwright feature "${f}"`).to.include(f);
       }
       for (const f of browserlessChromiumDisabledFeatures) {
@@ -869,22 +896,22 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       }
     });
 
-    it('keeps RenderDocument (Playwright) AND LocalNetworkAccessChecks (browserless) together', () => {
+    it('keeps the Playwright list AND LocalNetworkAccessChecks together', () => {
       // Core regression: the old standalone
       // `--disable-features=LocalNetworkAccessChecks` overrode Playwright's list
       // and re-enabled RenderDocument.
       const features = parseDisableFeatures(
-        withMergedChromiumDisableFeatures([]),
+        withMergedChromiumDisableFeatures([], defaultFeatures),
       );
       expect(features).to.include('RenderDocument');
       expect(features).to.include('LocalNetworkAccessChecks');
     });
 
     it('merges caller-supplied --disable-features rather than dropping them', () => {
-      const out = withMergedChromiumDisableFeatures([
-        '--disable-features=CallerOne,CallerTwo',
-        '--window-size=800,600',
-      ]);
+      const out = withMergedChromiumDisableFeatures(
+        ['--disable-features=CallerOne,CallerTwo', '--window-size=800,600'],
+        defaultFeatures,
+      );
       expect(disableFeaturesFlags(out)).to.have.lengthOf(1);
       const features = parseDisableFeatures(out);
       expect(features).to.include('CallerOne');
@@ -897,34 +924,14 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
 
     it('never emits duplicate features', () => {
       const features = parseDisableFeatures(
-        withMergedChromiumDisableFeatures([
-          '--disable-features=RenderDocument,LocalNetworkAccessChecks,Translate',
-        ]),
+        withMergedChromiumDisableFeatures(
+          [
+            '--disable-features=RenderDocument,LocalNetworkAccessChecks,Translate',
+          ],
+          defaultFeatures,
+        ),
       );
       expect(features.length).to.equal(new Set(features).size);
-    });
-
-    it('selects the per-version disabled-features list for older pwVersions', () => {
-      // 1.57 disables AcceptCHFrame and does NOT yet disable
-      // BoundaryEventDispatchTracksNodeRemoval; the default (1.61) is the
-      // opposite. browserless's LocalNetworkAccessChecks is always present.
-      const f157 = parseDisableFeatures(
-        withMergedChromiumDisableFeatures([], '1.57'),
-      );
-      expect(f157).to.include('AcceptCHFrame');
-      expect(f157).to.not.include('BoundaryEventDispatchTracksNodeRemoval');
-      expect(f157).to.include('LocalNetworkAccessChecks');
-
-      const fDefault = parseDisableFeatures(
-        withMergedChromiumDisableFeatures([]),
-      );
-      expect(fDefault).to.not.include('AcceptCHFrame');
-      expect(fDefault).to.include('BoundaryEventDispatchTracksNodeRemoval');
-
-      // Current/unknown versions fall back to the default list.
-      expect(
-        parseDisableFeatures(withMergedChromiumDisableFeatures([], '1.61')),
-      ).to.deep.equal(fDefault);
     });
   });
 
@@ -935,6 +942,20 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       const features = parseDisableFeatures(args);
       expect(features).to.include('RenderDocument');
       expect(features).to.include('LocalNetworkAccessChecks');
+    });
+
+    it('resolves the list via Config#getChromiumDisabledFeatures (overridable)', () => {
+      class CustomConfig extends Config {
+        public getChromiumDisabledFeatures(): readonly string[] {
+          return ['CustomFeatureX'];
+        }
+      }
+      const features = parseDisableFeatures(
+        launchArgs(ChromiumPlaywright, [], new CustomConfig()),
+      );
+      expect(features).to.include('CustomFeatureX'); // from the override
+      expect(features).to.include('LocalNetworkAccessChecks'); // additions still merged
+      expect(features).to.not.include('RenderDocument'); // default list replaced
     });
 
     it('does not add chromium --disable-features to Firefox or WebKit', () => {
@@ -1017,9 +1038,10 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
 
     // Fake executable relies on a POSIX shebang; browserless runs on Linux.
     const itPosix = process.platform === 'win32' ? it.skip : it;
+    const config = new Config();
 
     // 1:1 drift guard per supported version — fails if a pinned Playwright adds
-    // or removes a feature relative to the mirror resolved for that version.
+    // or removes a feature relative to Config.getChromiumDisabledFeatures(version).
     for (const [version, modName] of Object.entries(SUPPORTED_PW_VERSIONS)) {
       itPosix(
         `mirror for PW ${version} matches the installed Playwright exactly`,
@@ -1030,20 +1052,18 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
           expect(live, `empty --disable-features for ${version}`).to.not.be
             .empty;
 
-          const expected = new Set(
-            chromiumDisabledFeaturesForPwVersion(version),
-          );
+          const expected = new Set(config.getChromiumDisabledFeatures(version));
           const liveSet = new Set(live);
           const added = [...liveSet].filter((f) => !expected.has(f));
           const removed = [...expected].filter((f) => !liveSet.has(f));
 
           expect(
             added,
-            `PW ${version} disables feature(s) not mirrored — update playwrightChromiumDisabledFeatures(ByVersion)`,
+            `PW ${version} disables feature(s) not in Config.getChromiumDisabledFeatures('${version}') — update config.ts`,
           ).to.deep.equal([]);
           expect(
             removed,
-            `PW ${version} no longer disables feature(s) still mirrored — update playwrightChromiumDisabledFeatures(ByVersion)`,
+            `PW ${version} no longer disables feature(s) still in Config.getChromiumDisabledFeatures('${version}') — update config.ts`,
           ).to.deep.equal([]);
         },
       ).timeout(60000);

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -10,10 +10,18 @@ import {
   ChromiumPlaywright,
   FirefoxPlaywright,
   WebKitPlaywright,
+  browserlessChromiumDisabledFeatures,
+  parseDisableFeatures,
+  playwrightChromiumDisabledFeatures,
+  withMergedChromiumDisableFeatures,
 } from './browsers.playwright.js';
 import net, { AddressInfo } from 'net';
 import { WebSocket, WebSocketServer } from 'ws';
 import { createServer, IncomingMessage, Server } from 'http';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import playwrightCore from 'playwright-core';
 
 /** Poll `cond` every 10ms up to `timeoutMs`; replaces brittle fixed sleeps. */
 const waitFor = async (
@@ -810,5 +818,202 @@ describe('BasePlaywright URL filter', () => {
       );
       client.close();
     });
+  });
+});
+
+describe('BasePlaywright --disable-features merging (issue #5450)', () => {
+  const disableFeaturesFlags = (args: string[]): string[] =>
+    args.filter((a) => a.startsWith('--disable-features='));
+
+  type Launchable = {
+    makeLaunchOptions: (o: { args?: string[]; headless?: boolean }) => {
+      args: string[];
+    };
+  };
+  type PwCtor = new (o: {
+    config: Config;
+    logger: Logger;
+    userDataDir: string | null;
+  }) => unknown;
+  // Build a launcher's args, dropping the empty strings launch() filters out
+  // before handing them to launchServer.
+  const launchArgs = (Ctor: PwCtor, args: string[]): string[] => {
+    const instance = new Ctor({
+      config: new Config(),
+      logger: new Logger('test'),
+      userDataDir: null,
+    });
+    return (instance as unknown as Launchable)
+      .makeLaunchOptions({ args })
+      .args.filter((a) => !!a);
+  };
+
+  describe('withMergedChromiumDisableFeatures', () => {
+    it('collapses everything into exactly one --disable-features flag', () => {
+      const out = withMergedChromiumDisableFeatures([
+        '--disable-features=CallerOne',
+        '--foo',
+      ]);
+      expect(disableFeaturesFlags(out)).to.have.lengthOf(1);
+    });
+
+    it('includes every Playwright default and every browserless addition', () => {
+      const features = parseDisableFeatures(
+        withMergedChromiumDisableFeatures([]),
+      );
+      for (const f of playwrightChromiumDisabledFeatures) {
+        expect(features, `missing Playwright feature "${f}"`).to.include(f);
+      }
+      for (const f of browserlessChromiumDisabledFeatures) {
+        expect(features, `missing browserless feature "${f}"`).to.include(f);
+      }
+    });
+
+    it('keeps RenderDocument (Playwright) AND LocalNetworkAccessChecks (browserless) together', () => {
+      // Core regression: the old standalone
+      // `--disable-features=LocalNetworkAccessChecks` overrode Playwright's list
+      // and re-enabled RenderDocument.
+      const features = parseDisableFeatures(
+        withMergedChromiumDisableFeatures([]),
+      );
+      expect(features).to.include('RenderDocument');
+      expect(features).to.include('LocalNetworkAccessChecks');
+    });
+
+    it('merges caller-supplied --disable-features rather than dropping them', () => {
+      const out = withMergedChromiumDisableFeatures([
+        '--disable-features=CallerOne,CallerTwo',
+        '--window-size=800,600',
+      ]);
+      expect(disableFeaturesFlags(out)).to.have.lengthOf(1);
+      const features = parseDisableFeatures(out);
+      expect(features).to.include('CallerOne');
+      expect(features).to.include('CallerTwo');
+      expect(features).to.include('RenderDocument');
+      expect(features).to.include('LocalNetworkAccessChecks');
+      // Unrelated args are preserved untouched.
+      expect(out).to.include('--window-size=800,600');
+    });
+
+    it('never emits duplicate features', () => {
+      const features = parseDisableFeatures(
+        withMergedChromiumDisableFeatures([
+          '--disable-features=RenderDocument,LocalNetworkAccessChecks,Translate',
+        ]),
+      );
+      expect(features.length).to.equal(new Set(features).size);
+    });
+  });
+
+  describe('makeLaunchOptions', () => {
+    it('Chromium emits a single merged --disable-features with both lists', () => {
+      const args = launchArgs(ChromiumPlaywright, []);
+      expect(disableFeaturesFlags(args)).to.have.lengthOf(1);
+      const features = parseDisableFeatures(args);
+      expect(features).to.include('RenderDocument');
+      expect(features).to.include('LocalNetworkAccessChecks');
+    });
+
+    it('does not add chromium --disable-features to Firefox or WebKit', () => {
+      for (const Ctor of [FirefoxPlaywright, WebKitPlaywright]) {
+        const args = launchArgs(Ctor as unknown as PwCtor, []);
+        expect(
+          disableFeaturesFlags(args),
+          `${Ctor.name} should not receive --disable-features`,
+        ).to.have.lengthOf(0);
+      }
+    });
+  });
+
+  describe('interaction with the installed Playwright version', () => {
+    // Ground truth for the installed version: capture the exact args Playwright
+    // passes to the browser by pointing launchServer at a fake executable that
+    // records its argv and exits. No internal/private imports — this reflects
+    // whatever the pinned Playwright actually emits.
+    const captureLaunchArgv = async (args: string[]): Promise<string[]> => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bless-pw-argv-'));
+      const argvFile = path.join(dir, 'argv.json');
+      const fakeBin = path.join(dir, 'fake-browser.cjs');
+      fs.writeFileSync(
+        fakeBin,
+        `#!${process.execPath}\n` +
+          `require('fs').writeFileSync(${JSON.stringify(
+            argvFile,
+          )}, JSON.stringify(process.argv.slice(2)));\n` +
+          `process.exit(1);\n`,
+      );
+      fs.chmodSync(fakeBin, 0o755);
+      try {
+        const server = await playwrightCore.chromium.launchServer({
+          args,
+          executablePath: fakeBin,
+          timeout: 15000,
+        });
+        await server.close().catch(() => undefined);
+      } catch {
+        // Expected: the fake browser exits before printing a WS endpoint.
+      }
+      if (!fs.existsSync(argvFile)) {
+        throw new Error(
+          'Playwright never invoked the fake browser — capture method needs revisiting',
+        );
+      }
+      const argv: string[] = JSON.parse(fs.readFileSync(argvFile, 'utf-8'));
+      fs.rmSync(dir, { recursive: true, force: true });
+      return argv;
+    };
+
+    const assertNoDrift = async (): Promise<void> => {
+      const live = parseDisableFeatures(await captureLaunchArgv([]));
+      expect(live, 'captured an empty Playwright --disable-features list').to
+        .not.be.empty;
+
+      const mirror = new Set(playwrightChromiumDisabledFeatures);
+      const liveSet = new Set(live);
+      const addedByPlaywright = [...liveSet].filter((f) => !mirror.has(f));
+      const removedByPlaywright = [...mirror].filter((f) => !liveSet.has(f));
+
+      expect(
+        addedByPlaywright,
+        'Playwright ADDED disabled-feature(s) not in playwrightChromiumDisabledFeatures — add them',
+      ).to.deep.equal([]);
+      expect(
+        removedByPlaywright,
+        'Playwright REMOVED disabled-feature(s) still in playwrightChromiumDisabledFeatures — remove them',
+      ).to.deep.equal([]);
+    };
+
+    const assertBrowserlessFlagWins = async (): Promise<void> => {
+      // Feed the args browserless actually passes to the real Playwright
+      // launcher. Playwright prepends its own --disable-features and appends
+      // ours after it; Chromium keeps the LAST occurrence, so the winning flag
+      // must be browserless's superset carrying BOTH lists.
+      const argv = await captureLaunchArgv(launchArgs(ChromiumPlaywright, []));
+      const disableFlags = disableFeaturesFlags(argv);
+      expect(
+        disableFlags.length,
+        'expected Playwright + browserless --disable-features flags',
+      ).to.be.greaterThan(0);
+      const winning = parseDisableFeatures([
+        disableFlags[disableFlags.length - 1],
+      ]);
+      expect(winning).to.include('RenderDocument'); // Playwright's, preserved
+      expect(winning).to.include('LocalNetworkAccessChecks'); // browserless's
+    };
+
+    // Fake executable relies on a POSIX shebang; browserless runs on Linux.
+    const itPosix = process.platform === 'win32' ? it.skip : it;
+    itPosix(
+      'mirror equals Playwright exactly — fails on any feature added or removed',
+      async () => {
+        await assertNoDrift();
+      },
+    ).timeout(60000);
+    itPosix(
+      "browserless's merged --disable-features is the one Chromium keeps",
+      async () => {
+        await assertBrowserlessFlagWins();
+      },
+    ).timeout(60000);
   });
 });

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -25,9 +25,11 @@ enum PlaywrightBrowserTypes {
 }
 
 /**
- * Chromium features Playwright disables by default — a 1:1 mirror of
- * playwright-core's internal `chromiumSwitches` `disabledFeatures` list
- * (verified against playwright-core 1.61.0).
+ * Chromium features Playwright disables by default, mirrored per supported
+ * Playwright version. browserless can launch any of several pinned Playwright
+ * versions (see `Config.loadPwVersion` / the `playwrightVersions` map in
+ * package.json), and their `chromiumSwitches` `disabledFeatures` lists differ
+ * slightly between versions.
  *
  * Why browserless re-declares them: `--disable-features` is a single-valued
  * Chromium switch. When it appears more than once on the command line, Chrome
@@ -38,9 +40,13 @@ enum PlaywrightBrowserTypes {
  * is silently re-enabled.
  * See https://github.com/browserless/browserless/issues/5450
  *
- * This list MUST stay 1:1 with the installed Playwright version. The drift test
- * in browsers.playwright.spec.ts launches Playwright and fails if it adds or
- * removes any feature relative to this array.
+ * These lists MUST stay 1:1 with the installed Playwright versions. The drift
+ * test in browsers.playwright.spec.ts launches each pinned version and fails if
+ * any adds or removes a feature relative to the mirror for that version.
+ *
+ * This is the default list — what the pinned `playwright-core` emits (currently
+ * 1.61, and identical for 1.60). Versions whose list differs are overridden in
+ * {@link playwrightChromiumDisabledFeaturesByVersion}.
  */
 export const playwrightChromiumDisabledFeatures: readonly string[] = [
   'AvoidUnnecessaryBeforeUnloadCheckSync',
@@ -60,6 +66,66 @@ export const playwrightChromiumDisabledFeatures: readonly string[] = [
   'msForceBrowserSignIn',
   'msEdgeUpdateLaunchServicesPreferredVersion',
 ];
+
+// 1.58 and 1.59 match the default except the ms*/Edge features, which Playwright
+// began disabling in 1.60.
+const playwright158And159DisabledFeatures: readonly string[] = [
+  'AvoidUnnecessaryBeforeUnloadCheckSync',
+  'BoundaryEventDispatchTracksNodeRemoval',
+  'DestroyProfileOnBrowserClose',
+  'DialMediaRouteProvider',
+  'GlobalMediaControls',
+  'HttpsUpgrades',
+  'LensOverlay',
+  'MediaRouter',
+  'PaintHolding',
+  'ThirdPartyStoragePartitioning',
+  'Translate',
+  'AutoDeElevate',
+  'RenderDocument',
+  'OptimizationHints',
+];
+
+/**
+ * Per-version overrides for Playwright versions whose `disabledFeatures` list
+ * differs from {@link playwrightChromiumDisabledFeatures}. Keyed by the
+ * major.minor `pwVersion` (see `pwVersionRegex`). Versions not listed here
+ * (e.g. '1.60', '1.61', 'default') use the default list.
+ */
+export const playwrightChromiumDisabledFeaturesByVersion: Readonly<
+  Record<string, readonly string[]>
+> = {
+  // 1.57 still disables AcceptCHFrame (crbug.com/1348106) and does not yet
+  // disable BoundaryEventDispatchTracksNodeRemoval or the ms*/Edge features.
+  '1.57': [
+    'AcceptCHFrame',
+    'AvoidUnnecessaryBeforeUnloadCheckSync',
+    'DestroyProfileOnBrowserClose',
+    'DialMediaRouteProvider',
+    'GlobalMediaControls',
+    'HttpsUpgrades',
+    'LensOverlay',
+    'MediaRouter',
+    'PaintHolding',
+    'ThirdPartyStoragePartitioning',
+    'Translate',
+    'AutoDeElevate',
+    'RenderDocument',
+    'OptimizationHints',
+  ],
+  '1.58': playwright158And159DisabledFeatures,
+  '1.59': playwright158And159DisabledFeatures,
+};
+
+/**
+ * Resolve the disabled-features mirror for a `pwVersion` key ('1.57', '1.61',
+ * 'default', …). Falls back to the default list for current/unknown versions.
+ */
+export const chromiumDisabledFeaturesForPwVersion = (
+  pwVersion?: string,
+): readonly string[] =>
+  (pwVersion && playwrightChromiumDisabledFeaturesByVersion[pwVersion]) ||
+  playwrightChromiumDisabledFeatures;
 
 /**
  * Features browserless disables on top of Playwright's defaults. Chrome For Test
@@ -86,17 +152,18 @@ export const parseDisableFeatures = (args: readonly string[]): string[] =>
 
 /**
  * Collapse every `--disable-features` token in `args` into a single trailing
- * flag holding the union of Playwright's defaults, browserless's additions, and
- * any caller-supplied features. The merged flag is appended last so it is the
- * `--disable-features` occurrence Chromium keeps (see the note on
- * {@link playwrightChromiumDisabledFeatures}).
+ * flag holding the union of the launched Playwright version's defaults,
+ * browserless's additions, and any caller-supplied features. The merged flag is
+ * appended last so it is the `--disable-features` occurrence Chromium keeps (see
+ * the note on {@link playwrightChromiumDisabledFeatures}).
  */
 export const withMergedChromiumDisableFeatures = (
   args: readonly string[],
+  pwVersion?: string,
 ): string[] => {
   const merged = [
     ...new Set([
-      ...playwrightChromiumDisabledFeatures,
+      ...chromiumDisabledFeaturesForPwVersion(pwVersion),
       ...browserlessChromiumDisabledFeatures,
       ...parseDisableFeatures(args),
     ]),
@@ -154,7 +221,7 @@ class BasePlaywright extends EventEmitter {
     this.removeAllListeners();
   }
 
-  protected makeLaunchOptions(opts: BrowserServerOptions) {
+  protected makeLaunchOptions(opts: BrowserServerOptions, pwVersion?: string) {
     // Strip headless=old as it'll cause issues with newer Chromium
     const args = (opts.args ?? []).filter((a) => !a.includes('--headless=old'));
     const hasHeadless =
@@ -170,10 +237,11 @@ class BasePlaywright extends EventEmitter {
       args: [
         // Merge browserless's required toggles into a single --disable-features
         // flag. Chromium keeps only the LAST --disable-features on the command
-        // line, so a standalone flag would clobber the list Playwright passes,
-        // re-enabling features it disables (e.g. RenderDocument).
+        // line, so a standalone flag would clobber the list the launched
+        // Playwright version passes, re-enabling features it disables (e.g.
+        // RenderDocument). The list is version-specific, hence pwVersion.
         // See https://github.com/browserless/browserless/issues/5450
-        ...withMergedChromiumDisableFeatures(args),
+        ...withMergedChromiumDisableFeatures(args, pwVersion),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ],
       executablePath: this.executablePath(),
@@ -248,7 +316,7 @@ class BasePlaywright extends EventEmitter {
     this.logger.debug(`Launching ${this.constructor.name} Handler`);
 
     const versionedPw = await this.config.loadPwVersion(pwVersion!);
-    const opts = this.makeLaunchOptions(options);
+    const opts = this.makeLaunchOptions(options, pwVersion);
     const executablePath = await this.resolveExecutablePath(pwVersion!);
     const browser = await versionedPw[this.playwrightBrowserType].launchServer({
       ...opts,

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -24,6 +24,89 @@ enum PlaywrightBrowserTypes {
   webkit = 'webkit',
 }
 
+/**
+ * Chromium features Playwright disables by default — a 1:1 mirror of
+ * playwright-core's internal `chromiumSwitches` `disabledFeatures` list
+ * (verified against playwright-core 1.61.0).
+ *
+ * Why browserless re-declares them: `--disable-features` is a single-valued
+ * Chromium switch. When it appears more than once on the command line, Chrome
+ * keeps ONLY the last occurrence — the values are not unioned. Playwright emits
+ * its `--disable-features=<list>` first and appends caller args after it, so the
+ * flag browserless adds is the one Chrome keeps. If that flag does not itself
+ * carry Playwright's list, every feature Playwright disables (e.g. RenderDocument)
+ * is silently re-enabled.
+ * See https://github.com/browserless/browserless/issues/5450
+ *
+ * This list MUST stay 1:1 with the installed Playwright version. The drift test
+ * in browsers.playwright.spec.ts launches Playwright and fails if it adds or
+ * removes any feature relative to this array.
+ */
+export const playwrightChromiumDisabledFeatures: readonly string[] = [
+  'AvoidUnnecessaryBeforeUnloadCheckSync',
+  'BoundaryEventDispatchTracksNodeRemoval',
+  'DestroyProfileOnBrowserClose',
+  'DialMediaRouteProvider',
+  'GlobalMediaControls',
+  'HttpsUpgrades',
+  'LensOverlay',
+  'MediaRouter',
+  'PaintHolding',
+  'ThirdPartyStoragePartitioning',
+  'Translate',
+  'AutoDeElevate',
+  'RenderDocument',
+  'OptimizationHints',
+  'msForceBrowserSignIn',
+  'msEdgeUpdateLaunchServicesPreferredVersion',
+];
+
+/**
+ * Features browserless disables on top of Playwright's defaults. Chrome For Test
+ * (used by Playwright 1.57+) enforces Local Network Access checks that block
+ * WebSocket connections to localhost, which browserless relies on.
+ * See https://github.com/browserless/browserless/issues/5450
+ */
+export const browserlessChromiumDisabledFeatures: readonly string[] = [
+  'LocalNetworkAccessChecks',
+];
+
+const DISABLE_FEATURES_FLAG = '--disable-features';
+
+/**
+ * Extract every comma-joined value across all `--disable-features=` tokens in
+ * `args` (e.g. `['--disable-features=A,B', '--disable-features=C']` -> `['A','B','C']`).
+ */
+export const parseDisableFeatures = (args: readonly string[]): string[] =>
+  args
+    .filter((arg) => arg.startsWith(`${DISABLE_FEATURES_FLAG}=`))
+    .flatMap((arg) => arg.slice(arg.indexOf('=') + 1).split(','))
+    .map((feature) => feature.trim())
+    .filter(Boolean);
+
+/**
+ * Collapse every `--disable-features` token in `args` into a single trailing
+ * flag holding the union of Playwright's defaults, browserless's additions, and
+ * any caller-supplied features. The merged flag is appended last so it is the
+ * `--disable-features` occurrence Chromium keeps (see the note on
+ * {@link playwrightChromiumDisabledFeatures}).
+ */
+export const withMergedChromiumDisableFeatures = (
+  args: readonly string[],
+): string[] => {
+  const merged = [
+    ...new Set([
+      ...playwrightChromiumDisabledFeatures,
+      ...browserlessChromiumDisabledFeatures,
+      ...parseDisableFeatures(args),
+    ]),
+  ];
+  return [
+    ...args.filter((arg) => !arg.startsWith(`${DISABLE_FEATURES_FLAG}=`)),
+    `${DISABLE_FEATURES_FLAG}=${merged.join(',')}`,
+  ];
+};
+
 class BasePlaywright extends EventEmitter {
   protected config: Config;
   protected userDataDir: string | null;
@@ -85,10 +168,12 @@ class BasePlaywright extends EventEmitter {
     return {
       ...opts,
       args: [
-        ...args,
-        // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
-        // This is needed to allow WebSocket connections to localhost.
-        `--disable-features=LocalNetworkAccessChecks`,
+        // Merge browserless's required toggles into a single --disable-features
+        // flag. Chromium keeps only the LAST --disable-features on the command
+        // line, so a standalone flag would clobber the list Playwright passes,
+        // re-enabling features it disables (e.g. RenderDocument).
+        // See https://github.com/browserless/browserless/issues/5450
+        ...withMergedChromiumDisableFeatures(args),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ],
       executablePath: this.executablePath(),

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -25,113 +25,10 @@ enum PlaywrightBrowserTypes {
 }
 
 /**
- * Chromium features Playwright disables by default, mirrored per supported
- * Playwright version. browserless can launch any of several pinned Playwright
- * versions (see `Config.loadPwVersion` / the `playwrightVersions` map in
- * package.json), and their `chromiumSwitches` `disabledFeatures` lists differ
- * slightly between versions.
- *
- * Why browserless re-declares them: `--disable-features` is a single-valued
- * Chromium switch. When it appears more than once on the command line, Chrome
- * keeps ONLY the last occurrence — the values are not unioned. Playwright emits
- * its `--disable-features=<list>` first and appends caller args after it, so the
- * flag browserless adds is the one Chrome keeps. If that flag does not itself
- * carry Playwright's list, every feature Playwright disables (e.g. RenderDocument)
- * is silently re-enabled.
- * See https://github.com/browserless/browserless/issues/5450
- *
- * These lists MUST stay 1:1 with the installed Playwright versions. The drift
- * test in browsers.playwright.spec.ts launches each pinned version and fails if
- * any adds or removes a feature relative to the mirror for that version.
- *
- * This is the default list — what the pinned `playwright-core` emits (currently
- * 1.61, and identical for 1.60). Versions whose list differs are overridden in
- * {@link playwrightChromiumDisabledFeaturesByVersion}.
- */
-export const playwrightChromiumDisabledFeatures: readonly string[] = [
-  'AvoidUnnecessaryBeforeUnloadCheckSync',
-  'BoundaryEventDispatchTracksNodeRemoval',
-  'DestroyProfileOnBrowserClose',
-  'DialMediaRouteProvider',
-  'GlobalMediaControls',
-  'HttpsUpgrades',
-  'LensOverlay',
-  'MediaRouter',
-  'PaintHolding',
-  'ThirdPartyStoragePartitioning',
-  'Translate',
-  'AutoDeElevate',
-  'RenderDocument',
-  'OptimizationHints',
-  'msForceBrowserSignIn',
-  'msEdgeUpdateLaunchServicesPreferredVersion',
-];
-
-// 1.58 and 1.59 match the default except the ms*/Edge features, which Playwright
-// began disabling in 1.60.
-const playwright158And159DisabledFeatures: readonly string[] = [
-  'AvoidUnnecessaryBeforeUnloadCheckSync',
-  'BoundaryEventDispatchTracksNodeRemoval',
-  'DestroyProfileOnBrowserClose',
-  'DialMediaRouteProvider',
-  'GlobalMediaControls',
-  'HttpsUpgrades',
-  'LensOverlay',
-  'MediaRouter',
-  'PaintHolding',
-  'ThirdPartyStoragePartitioning',
-  'Translate',
-  'AutoDeElevate',
-  'RenderDocument',
-  'OptimizationHints',
-];
-
-/**
- * Per-version overrides for Playwright versions whose `disabledFeatures` list
- * differs from {@link playwrightChromiumDisabledFeatures}. Keyed by the
- * major.minor `pwVersion` (see `pwVersionRegex`). Versions not listed here
- * (e.g. '1.60', '1.61', 'default') use the default list.
- */
-export const playwrightChromiumDisabledFeaturesByVersion: Readonly<
-  Record<string, readonly string[]>
-> = {
-  // 1.57 still disables AcceptCHFrame (crbug.com/1348106) and does not yet
-  // disable BoundaryEventDispatchTracksNodeRemoval or the ms*/Edge features.
-  '1.57': [
-    'AcceptCHFrame',
-    'AvoidUnnecessaryBeforeUnloadCheckSync',
-    'DestroyProfileOnBrowserClose',
-    'DialMediaRouteProvider',
-    'GlobalMediaControls',
-    'HttpsUpgrades',
-    'LensOverlay',
-    'MediaRouter',
-    'PaintHolding',
-    'ThirdPartyStoragePartitioning',
-    'Translate',
-    'AutoDeElevate',
-    'RenderDocument',
-    'OptimizationHints',
-  ],
-  '1.58': playwright158And159DisabledFeatures,
-  '1.59': playwright158And159DisabledFeatures,
-};
-
-/**
- * Resolve the disabled-features mirror for a `pwVersion` key ('1.57', '1.61',
- * 'default', …). Falls back to the default list for current/unknown versions.
- */
-export const chromiumDisabledFeaturesForPwVersion = (
-  pwVersion?: string,
-): readonly string[] =>
-  (pwVersion && playwrightChromiumDisabledFeaturesByVersion[pwVersion]) ||
-  playwrightChromiumDisabledFeatures;
-
-/**
- * Features browserless disables on top of Playwright's defaults. Chrome For Test
- * (used by Playwright 1.57+) enforces Local Network Access checks that block
- * WebSocket connections to localhost, which browserless relies on.
- * See https://github.com/browserless/browserless/issues/5450
+ * Features browserless disables on top of the launched Playwright version's
+ * defaults. Chrome For Test (used by Playwright 1.57+) enforces Local Network
+ * Access checks that block WebSocket connections to localhost, which browserless
+ * relies on. See https://github.com/browserless/browserless/issues/5450
  */
 export const browserlessChromiumDisabledFeatures: readonly string[] = [
   'LocalNetworkAccessChecks',
@@ -152,18 +49,24 @@ export const parseDisableFeatures = (args: readonly string[]): string[] =>
 
 /**
  * Collapse every `--disable-features` token in `args` into a single trailing
- * flag holding the union of the launched Playwright version's defaults,
- * browserless's additions, and any caller-supplied features. The merged flag is
- * appended last so it is the `--disable-features` occurrence Chromium keeps (see
- * the note on {@link playwrightChromiumDisabledFeatures}).
+ * flag holding the union of the launched Playwright version's disabled features
+ * (resolved via `Config#getChromiumDisabledFeatures`), browserless's additions,
+ * and any caller-supplied features.
+ *
+ * `--disable-features` is single-valued on Chromium's command line: when it
+ * appears more than once Chrome keeps ONLY the last occurrence (values are not
+ * unioned). Playwright emits its own list first and appends caller args after
+ * it, so this merged flag — appended last — is the one Chromium keeps, and must
+ * therefore carry Playwright's list or those features are silently re-enabled
+ * (e.g. RenderDocument). See https://github.com/browserless/browserless/issues/5450
  */
 export const withMergedChromiumDisableFeatures = (
   args: readonly string[],
-  pwVersion?: string,
+  playwrightDisabledFeatures: readonly string[],
 ): string[] => {
   const merged = [
     ...new Set([
-      ...chromiumDisabledFeaturesForPwVersion(pwVersion),
+      ...playwrightDisabledFeatures,
       ...browserlessChromiumDisabledFeatures,
       ...parseDisableFeatures(args),
     ]),
@@ -239,9 +142,12 @@ class BasePlaywright extends EventEmitter {
         // flag. Chromium keeps only the LAST --disable-features on the command
         // line, so a standalone flag would clobber the list the launched
         // Playwright version passes, re-enabling features it disables (e.g.
-        // RenderDocument). The list is version-specific, hence pwVersion.
+        // RenderDocument). The list is version-specific, resolved via Config.
         // See https://github.com/browserless/browserless/issues/5450
-        ...withMergedChromiumDisableFeatures(args, pwVersion),
+        ...withMergedChromiumDisableFeatures(
+          args,
+          this.config.getChromiumDisabledFeatures(pwVersion),
+        ),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ],
       executablePath: this.executablePath(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,86 @@ const getDebug = () => {
   return process.env.DEBUG;
 };
 
+/**
+ * Chromium features Playwright disables by default, mirrored per supported
+ * Playwright version (verified against playwright-core 1.57–1.61).
+ *
+ * `--disable-features` is a single-valued Chromium switch: when it appears more
+ * than once on the command line Chrome keeps ONLY the last occurrence — the
+ * values are not unioned. browserless merges these into a single trailing
+ * `--disable-features` flag at launch (see browsers.playwright.ts), which is the
+ * occurrence Chromium keeps, so the list must match what the launched Playwright
+ * version itself disables or those features are silently re-enabled (e.g.
+ * RenderDocument). See https://github.com/browserless/browserless/issues/5450
+ *
+ * The default is what the pinned playwright-core emits (1.61, identical for
+ * 1.60); versions whose list differs are overridden below. These lists must
+ * stay 1:1 with the installed Playwright versions — see the drift test in
+ * browsers.playwright.spec.ts.
+ */
+const defaultChromiumDisabledFeatures: readonly string[] = [
+  'AvoidUnnecessaryBeforeUnloadCheckSync',
+  'BoundaryEventDispatchTracksNodeRemoval',
+  'DestroyProfileOnBrowserClose',
+  'DialMediaRouteProvider',
+  'GlobalMediaControls',
+  'HttpsUpgrades',
+  'LensOverlay',
+  'MediaRouter',
+  'PaintHolding',
+  'ThirdPartyStoragePartitioning',
+  'Translate',
+  'AutoDeElevate',
+  'RenderDocument',
+  'OptimizationHints',
+  'msForceBrowserSignIn',
+  'msEdgeUpdateLaunchServicesPreferredVersion',
+];
+
+// 1.58 and 1.59 match the default except the ms*/Edge features, which Playwright
+// began disabling in 1.60.
+const playwright158And159DisabledFeatures: readonly string[] = [
+  'AvoidUnnecessaryBeforeUnloadCheckSync',
+  'BoundaryEventDispatchTracksNodeRemoval',
+  'DestroyProfileOnBrowserClose',
+  'DialMediaRouteProvider',
+  'GlobalMediaControls',
+  'HttpsUpgrades',
+  'LensOverlay',
+  'MediaRouter',
+  'PaintHolding',
+  'ThirdPartyStoragePartitioning',
+  'Translate',
+  'AutoDeElevate',
+  'RenderDocument',
+  'OptimizationHints',
+];
+
+const chromiumDisabledFeaturesByPwVersion: Readonly<
+  Record<string, readonly string[]>
+> = {
+  // 1.57 still disables AcceptCHFrame (crbug.com/1348106) and does not yet
+  // disable BoundaryEventDispatchTracksNodeRemoval or the ms*/Edge features.
+  '1.57': [
+    'AcceptCHFrame',
+    'AvoidUnnecessaryBeforeUnloadCheckSync',
+    'DestroyProfileOnBrowserClose',
+    'DialMediaRouteProvider',
+    'GlobalMediaControls',
+    'HttpsUpgrades',
+    'LensOverlay',
+    'MediaRouter',
+    'PaintHolding',
+    'ThirdPartyStoragePartitioning',
+    'Translate',
+    'AutoDeElevate',
+    'RenderDocument',
+    'OptimizationHints',
+  ],
+  '1.58': playwright158And159DisabledFeatures,
+  '1.59': playwright158And159DisabledFeatures,
+};
+
 export class Config extends EventEmitter {
   protected readonly debug = getDebug();
   protected readonly host = process.env.HOST ?? 'localhost';
@@ -227,6 +307,22 @@ export class Config extends EventEmitter {
 
   public getPwVersions() {
     return this.pwVersions;
+  }
+
+  /**
+   * The Chromium features to disable for a given Playwright `pwVersion`
+   * (e.g. '1.57'; 'default'/undefined resolves to the current version).
+   * browserless merges this into a single `--disable-features` flag at launch.
+   *
+   * Override to support additional Playwright versions or to adjust the list;
+   * call `super.getChromiumDisabledFeatures(pwVersion)` to reuse the built-in
+   * lists — e.g. delegate versions you don't add, or extend the default.
+   */
+  public getChromiumDisabledFeatures(pwVersion?: string): readonly string[] {
+    return (
+      (pwVersion && chromiumDisabledFeaturesByPwVersion[pwVersion]) ||
+      defaultChromiumDisabledFeatures
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes #5450.

## Problem
`makeLaunchOptions` (Playwright launcher) appended a standalone `--disable-features=LocalNetworkAccessChecks` flag. `--disable-features` is **single-valued** on Chromium's command line — only the *last* occurrence is honored; values are not unioned. Playwright emits its own `--disable-features=<list>` first and appends caller args after it, so browserless's flag won and **discarded Playwright's entire stabilization list**, silently re-enabling features Playwright disables (e.g. `RenderDocument`, cf. microsoft/playwright#40194). This affected every Chromium-over-Playwright session since the 1.57 bump (#5131).

## Fix
Merge browserless's required toggles into a **single** `--disable-features` flag that supersets Playwright's defaults + browserless additions + any caller-supplied features. Because browserless's flag is last, it now wins *while carrying the full list*, so nothing is dropped.

- Scoped to the Chromium family only (base `makeLaunchOptions`); `FirefoxPlaywright`/`WebKitPlaywright` overrides are untouched.
- The **CDP/Puppeteer path is not affected** — `puppeteer-core` merges `--disable-features` internally (verified against 25.1.0), so `browsers.cdp.ts` is left as-is.

## Why a maintained mirror + drift test
Playwright's internal `disabledFeatures` list isn't importable (bundled into `coreBundle`, package `exports` blocks deep imports, and there's no `defaultArgs` API). So browserless keeps a 1:1 mirror, guarded by a drift test that launches the *real* pinned Playwright (via a fake executable that records the emitted argv) and fails — in both directions — if Playwright adds or removes a feature relative to the mirror. Derivation/verification happens at CI time; runtime `makeLaunchOptions` stays synchronous and spawn-free.

## Tests
New suite in `browsers.playwright.spec.ts` (9 cases): merge produces exactly one flag, includes all Playwright + browserless features, merges caller-supplied `--disable-features`, dedups, `makeLaunchOptions` wiring, Firefox/WebKit exclusion, the 1:1 drift guard, and an end-to-end check that browserless's merged flag is the one Chromium keeps. The drift guard was verified to fail when a feature is added to *or* removed from the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Chromium launch handling so multiple sources of `--disable-features` are correctly combined into a single consolidated flag.
  * Ensures browser-required feature interactions are preserved while avoiding duplicate or conflicting feature entries.
  * Applies version-specific Chromium disabled-features lists based on the detected Playwright version.

* **Tests**
  * Added Playwright end-to-end coverage validating exact Chromium launch arguments.
  * Added checks to detect “install drift” by comparing live Chromium disable-features against the configured list across pinned Playwright versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->