### PR TITLE
fix: allow the server's own origin through the opt-in navigation guard

### DIFF
--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -122,8 +122,15 @@ export class ChromiumCDP extends EventEmitter {
           // Scheme blocklist (e.g. file://) plus the private-network classifier.
           // Top-level navigations are rejected earlier (with a clean status) by
           // the route handlers; this is the runtime backstop for subresources
-          // and mid-flight redirects, so it terminates the session.
-          const blocked = findBlockedNavigationUrl(url, patterns, ranges);
+          // and mid-flight redirects, so it terminates the session. The server's
+          // own origin is exempt so this can't sever browserless's own pages
+          // (e.g. the /function runtime, which loads from the local server).
+          const blocked = findBlockedNavigationUrl(
+            url,
+            patterns,
+            ranges,
+            this.config.getSelfNavigationHosts(),
+          );
           if (blocked) {
             this.logger.error(
               `Blocked URL "${blocked}" in ${direction} to ${this.constructor.name}, terminating`,

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -532,7 +532,7 @@ describe('BasePlaywright URL filter', () => {
       client.close();
     });
 
-    it("forwards a Frame.goto to the server's own origin even when localhost is blocked", async () => {
+    it('forwards a Frame.goto to the server origin even when localhost is blocked', async () => {
       // The self-origin allowance (Config.getSelfNavigationHosts) must flow
       // through the bridge so a Playwright session can still load browserless's
       // own pages — matching the CDP guard.
@@ -547,6 +547,7 @@ describe('BasePlaywright URL filter', () => {
       const [selfHost] = (
         playwright as unknown as { config: Config }
       ).config.getSelfNavigationHosts();
+      expect(selfHost).to.be.a('string').and.not.be.empty;
       const selfUrl = `http://${selfHost}/function/index.html`;
       const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
       await new Promise<void>((resolve, reject) => {

--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -532,6 +532,36 @@ describe('BasePlaywright URL filter', () => {
       client.close();
     });
 
+    it("forwards a Frame.goto to the server's own origin even when localhost is blocked", async () => {
+      // The self-origin allowance (Config.getSelfNavigationHosts) must flow
+      // through the bridge so a Playwright session can still load browserless's
+      // own pages — matching the CDP guard.
+      (
+        playwright as unknown as { config: Config }
+      ).config.getBlockedNetworkRanges = () => ({
+        ipv4Prefixes: ['0.', '127.', '169.254.'],
+        ipv6Prefixes: ['::1'],
+        protocols: [],
+        hostnames: ['localhost'],
+      });
+      const [selfHost] = (
+        playwright as unknown as { config: Config }
+      ).config.getSelfNavigationHosts();
+      const selfUrl = `http://${selfHost}/function/index.html`;
+      const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
+      await new Promise<void>((resolve, reject) => {
+        client.on('open', () => resolve());
+        client.on('error', reject);
+      });
+      client.send(
+        JSON.stringify({ id: 5, method: 'goto', params: { url: selfUrl } }),
+      );
+      await waitFor(() => upstreamMessages.length >= 1);
+      expect(upstreamMessages).to.have.lengthOf(1);
+      expect(JSON.parse(upstreamMessages[0]).params.url).to.equal(selfUrl);
+      client.close();
+    });
+
     it('blocks a Frame.goto carrying file:// sent as a BINARY frame', async () => {
       const client = new WebSocket(`ws://127.0.0.1:${bridgePort}/`);
       await new Promise<void>((resolve, reject) => {

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -439,6 +439,9 @@ class BasePlaywright extends EventEmitter {
           // private host (a request event, not a `goto`) is not caught on this
           // path; explicit navigations are.
           const blockRanges = this.config.getBlockedNetworkRanges();
+          // The server's own origin is exempt (same as the CDP guard) so a
+          // navigation to browserless's own pages is never blocked.
+          const selfHosts = this.config.getSelfNavigationHosts();
 
           // Parse before matching — a raw-substring fast-path would miss
           // JSON Unicode escapes (`"file://..."` has no literal
@@ -475,7 +478,11 @@ class BasePlaywright extends EventEmitter {
             if (hit) {
               return `Blocked URL pattern "${hit}" in ${this.constructor.name} ${direction} message`;
             }
-            const navHit = findBlockedNavigationInMessage(parsed, blockRanges);
+            const navHit = findBlockedNavigationInMessage(
+              parsed,
+              blockRanges,
+              selfHosts,
+            );
             if (navHit) {
               return `Blocked navigation to "${navHit}" in ${this.constructor.name} ${direction} message`;
             }

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -21,5 +21,16 @@ describe('Config', () => {
       expect(hosts).to.have.lengthOf(1);
       expect(hosts[0]).to.match(/:54321$/);
     });
+
+    it('reflects a runtime port change rather than serving a stale memo', () => {
+      const config = new Config();
+      config.setPort(3000);
+      expect(config.getSelfNavigationHosts()[0]).to.match(/:3000$/);
+      // The result is memoized per request on the navigation hot path, but the
+      // server binds its real port via #setPort, so the memo must key off the
+      // current host:port and recompute when it changes.
+      config.setPort(4000);
+      expect(config.getSelfNavigationHosts()[0]).to.match(/:4000$/);
+    });
   });
 });

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -6,17 +6,20 @@ describe('Config', () => {
     it('returns the server own host:port, deduped across the http + ws address', () => {
       const config = new Config();
       config.setPort(3000);
-      // getServerAddress() and getServerWebSocketAddress() share host:port, so
-      // the set collapses to a single entry.
-      expect(config.getSelfNavigationHosts()).to.deep.equal(['localhost:3000']);
+      // Derive the expected host from the server address itself so the
+      // assertion holds regardless of the HOST env (CI may set it). The http
+      // and ws addresses share host:port, so the set collapses to one entry.
+      const expected = new URL(config.getServerAddress()).host;
+      expect(config.getSelfNavigationHosts()).to.deep.equal([expected]);
+      expect(expected).to.match(/:3000$/);
     });
 
     it('is port-specific so other services on the same host are not allowed', () => {
       const config = new Config();
       config.setPort(54321);
-      expect(config.getSelfNavigationHosts()).to.deep.equal([
-        'localhost:54321',
-      ]);
+      const hosts = config.getSelfNavigationHosts();
+      expect(hosts).to.have.lengthOf(1);
+      expect(hosts[0]).to.match(/:54321$/);
     });
   });
 });

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { Config } from '@browserless.io/browserless';
+
+describe('Config', () => {
+  describe('getSelfNavigationHosts', () => {
+    it('returns the server own host:port, deduped across the http + ws address', () => {
+      const config = new Config();
+      config.setPort(3000);
+      // getServerAddress() and getServerWebSocketAddress() share host:port, so
+      // the set collapses to a single entry.
+      expect(config.getSelfNavigationHosts()).to.deep.equal(['localhost:3000']);
+    });
+
+    it('is port-specific so other services on the same host are not allowed', () => {
+      const config = new Config();
+      config.setPort(54321);
+      expect(config.getSelfNavigationHosts()).to.deep.equal([
+        'localhost:54321',
+      ]);
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -789,14 +789,16 @@ export class Config extends EventEmitter {
    */
   public getSelfNavigationHosts(): string[] {
     const hosts = new Set<string>();
-    for (const address of [
-      this.getServerAddress(),
-      this.getServerWebSocketAddress(),
+    for (const getAddress of [
+      () => this.getServerAddress(),
+      () => this.getServerWebSocketAddress(),
     ]) {
       try {
-        hosts.add(new URL(address).host);
+        // Resolve each address inside the try so a throwing getter (e.g. an
+        // unparseable server address) is contained rather than escaping.
+        hosts.add(new URL(getAddress()).host);
       } catch {
-        // Skip an unparseable address rather than fail the guard.
+        // Skip a throwing/unparseable address rather than fail the guard.
       }
     }
     return [...hosts];

--- a/src/config.ts
+++ b/src/config.ts
@@ -778,6 +778,31 @@ export class Config extends EventEmitter {
   }
 
   /**
+   * The `host[:port]` values that resolve to this server itself. The navigation
+   * guard treats these as always-allowed so the browser can load browserless's
+   * own pages — e.g. the `/function` runtime page and its same-origin
+   * WebSocket — even when the server binds an address the blocklist would
+   * otherwise reject (commonly `0.0.0.0`/`localhost`). Port-specific, so other
+   * services sharing the loopback host stay blocked.
+   *
+   * @returns {string[]} The server's own host[:port] values
+   */
+  public getSelfNavigationHosts(): string[] {
+    const hosts = new Set<string>();
+    for (const address of [
+      this.getServerAddress(),
+      this.getServerWebSocketAddress(),
+    ]) {
+      try {
+        hosts.add(new URL(address).host);
+      } catch {
+        // Skip an unparseable address rather than fail the guard.
+      }
+    }
+    return [...hosts];
+  }
+
+  /**
    * When CORS is enabled, returns relevant CORS headers
    * to requests and for the OPTIONS call. Values can be
    * overridden by specifying `CORS_ALLOW_METHODS`, `CORS_ALLOW_ORIGIN`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -777,6 +777,8 @@ export class Config extends EventEmitter {
     return httpAddress.href;
   }
 
+  private selfNavigationHostsMemo?: { key: string; hosts: string[] };
+
   /**
    * The `host[:port]` values that resolve to this server itself. The navigation
    * guard treats these as always-allowed so the browser can load browserless's
@@ -788,6 +790,14 @@ export class Config extends EventEmitter {
    * @returns {string[]} The server's own host[:port] values
    */
   public getSelfNavigationHosts(): string[] {
+    // The navigation backstop calls this for every request and response when
+    // the guard is active, so memoize the URL parsing. `host` is readonly and
+    // `port` is fixed once the server binds, but key the memo on host:port so a
+    // runtime #setPort still recomputes rather than serving a stale value.
+    const key = `${this.host}:${this.port}`;
+    if (this.selfNavigationHostsMemo?.key === key) {
+      return this.selfNavigationHostsMemo.hosts;
+    }
     const hosts = new Set<string>();
     for (const getAddress of [
       () => this.getServerAddress(),
@@ -801,7 +811,9 @@ export class Config extends EventEmitter {
         // Skip a throwing/unparseable address rather than fail the guard.
       }
     }
-    return [...hosts];
+    const resolved = [...hosts];
+    this.selfNavigationHostsMemo = { key, hosts: resolved };
+    return resolved;
   }
 
   /**

--- a/src/network-security.spec.ts
+++ b/src/network-security.spec.ts
@@ -132,6 +132,34 @@ describe('Network Security', () => {
         .to.be.false;
       expect(isBlockedNavigationUrl('not-a-url', null)).to.be.false;
     });
+
+    it('allows an otherwise-blocked host when it is in allowedHosts, port-specific', () => {
+      const allowed = ['0.0.0.0:3000', 'localhost:3000'];
+      // The server's own origin (host:port) is allowed even though the host is
+      // in the blocklist — lets the browser load browserless's own pages.
+      expect(
+        isBlockedNavigationUrl(
+          'http://0.0.0.0:3000/function/index.html',
+          RANGES,
+          allowed,
+        ),
+      ).to.be.false;
+      expect(
+        isBlockedNavigationUrl(
+          'ws://0.0.0.0:3000/function/connect/x',
+          RANGES,
+          allowed,
+        ),
+      ).to.be.false;
+      expect(isBlockedNavigationUrl('http://localhost:3000/', RANGES, allowed))
+        .to.be.false;
+      // A different port on the same loopback host stays blocked.
+      expect(isBlockedNavigationUrl('http://0.0.0.0:5432/', RANGES, allowed)).to
+        .be.true;
+      // allowedHosts never overrides a metadata/private destination elsewhere.
+      expect(isBlockedNavigationUrl('http://169.254.169.254/', RANGES, allowed))
+        .to.be.true;
+    });
   });
 
   describe('isBlockedNavigationIP', () => {

--- a/src/network-security.ts
+++ b/src/network-security.ts
@@ -64,10 +64,16 @@ const isBlockedNavigationHost = (
  *
  * Returns `false` when `ranges` is `null` (blocking disabled). Returns `true`
  * (blocked) for unparseable URLs as a safety measure.
+ *
+ * `allowedHosts` is an optional set of `host[:port]` values (matched against the
+ * URL's `host`, so it is port-specific) that are never blocked — used to let the
+ * browser reach the server's own origin (see `Config.getSelfNavigationHosts()`)
+ * even when it binds an address the range set would otherwise reject.
  */
 export const isBlockedNavigationUrl = (
   rawUrl: string,
   ranges: NetworkRangeSet | null,
+  allowedHosts?: readonly string[],
 ): boolean => {
   if (!ranges) return false;
   const normalized = normalizeUrlForBlocklist(rawUrl);
@@ -75,7 +81,9 @@ export const isBlockedNavigationUrl = (
     return true;
   }
   try {
-    return isBlockedNavigationHost(new URL(normalized).hostname, ranges);
+    const { host, hostname } = new URL(normalized);
+    if (allowedHosts?.includes(host)) return false;
+    return isBlockedNavigationHost(hostname, ranges);
   } catch {
     return true;
   }
@@ -114,9 +122,10 @@ export const findBlockedNavigationUrl = (
   url: string,
   patterns: string[],
   ranges: NetworkRangeSet | null,
+  allowedHosts?: readonly string[],
 ): string | null =>
   findBlockedUrlInMessage({ url }, patterns) ??
-  (isBlockedNavigationUrl(url, ranges) ? url : null);
+  (isBlockedNavigationUrl(url, ranges, allowedHosts) ? url : null);
 
 /**
  * Whether a wire-protocol method initiates a navigation, across the CDP and
@@ -142,6 +151,7 @@ const isNavigationMethod = (method: string): boolean =>
 export const findBlockedNavigationInMessage = (
   message: unknown,
   ranges: NetworkRangeSet | null,
+  allowedHosts?: readonly string[],
 ): string | null => {
   if (!ranges || !message || typeof message !== 'object') return null;
   const { method, params } = message as {
@@ -152,7 +162,7 @@ export const findBlockedNavigationInMessage = (
     typeof method === 'string' &&
     isNavigationMethod(method) &&
     typeof params?.url === 'string' &&
-    isBlockedNavigationUrl(params.url, ranges)
+    isBlockedNavigationUrl(params.url, ranges, allowedHosts)
   ) {
     return params.url;
   }
@@ -169,9 +179,10 @@ export const assertNavigationAllowed = (
   url: string | undefined,
   patterns: string[],
   ranges: NetworkRangeSet | null,
+  allowedHosts?: readonly string[],
 ): void => {
   if (!url) return;
-  const blocked = findBlockedNavigationUrl(url, patterns, ranges);
+  const blocked = findBlockedNavigationUrl(url, patterns, ranges, allowedHosts);
   if (blocked) {
     throw new Forbidden(`Navigation to "${blocked}" is not allowed`);
   }


### PR DESCRIPTION
## Description

The opt-in private-network navigation guard (`Config.getBlockedNetworkRanges()`) lets a consumer block loopback / `0.0.0.0` / `localhost` and other private ranges for in-browser navigation. When enabled, it also (incorrectly) blocks the browser from loading **browserless's own pages** — most visibly the `/function` runtime page and its same-origin WebSocket, which `getServerAddress()` resolves to the local bind (commonly `0.0.0.0` or `localhost`).

With the guard enabled, the CDP request/response backstop in `browsers.cdp.ts` saw those internal loads and tore the session down mid-navigation, so `/function` failed with `Navigating frame was detached`. The guard is **off by default**, so only consumers who opt in via `getBlockedNetworkRanges()` are affected.

### Fix

- Add `Config.getSelfNavigationHosts()` — the server's own `host[:port]` values, derived from the HTTP + WebSocket server addresses.
- Add an optional `allowedHosts` parameter to the navigation matcher (`isBlockedNavigationUrl` / `findBlockedNavigationUrl` / `findBlockedNavigationInMessage` / `assertNavigationAllowed`); a URL whose `host` is in `allowedHosts` is never blocked.
- The CDP backstop passes `config.getSelfNavigationHosts()`, so browserless can always load its own pages.

The allowance is **port-specific** (matched against the URL's `host`, which includes the port), so other services sharing the loopback host stay blocked. No behavior change when the guard is disabled (the default).

### Tests

- `network-security.spec.ts`: the server's own `host:port` passes through an otherwise-blocking range set; a different port on the same host stays blocked; metadata/private destinations are still blocked.
- `config.spec.ts`: `getSelfNavigationHosts()` returns the deduped server `host:port` and is port-specific.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for an explicit `host:port` allowlist to navigation blocking checks, including exemptions for the server’s own HTTP/WS origins.

* **Bug Fixes**
  * Navigation blocking now reliably avoids terminating or rejecting the server’s own runtime pages, while still blocking redirects, subresource navigations, and other disallowed destinations.

* **Tests**
  * Added unit and end-to-end coverage to validate port-specific allowlist behavior and confirm blocked ranges still apply to other targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->