### PR TITLE
feat: expose browserless Chromium disabled-features as an overridable Config seam

### DIFF
--- a/src/browsers/browsers.playwright.spec.ts
+++ b/src/browsers/browsers.playwright.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   Config,
   Logger,
+  browserlessChromiumDisabledFeatures,
   findBlockedUrlInMessage,
   normalizeUrlForBlocklist,
   wsFrameToString,
@@ -10,7 +11,6 @@ import {
   ChromiumPlaywright,
   FirefoxPlaywright,
   WebKitPlaywright,
-  browserlessChromiumDisabledFeatures,
   parseDisableFeatures,
   withMergedChromiumDisableFeatures,
 } from './browsers.playwright.js';
@@ -987,6 +987,23 @@ describe('BasePlaywright --disable-features merging (issue #5450)', () => {
       expect(features).to.include('CustomFeatureX'); // from the override
       expect(features).to.include('LocalNetworkAccessChecks'); // additions still merged
       expect(features).to.not.include('RenderDocument'); // default list replaced
+    });
+
+    it('merges Config#getBrowserlessChromiumDisabledFeatures (overridable)', () => {
+      class CustomConfig extends Config {
+        public getBrowserlessChromiumDisabledFeatures(): readonly string[] {
+          return [
+            ...super.getBrowserlessChromiumDisabledFeatures(),
+            'DeploymentFeatureX',
+          ];
+        }
+      }
+      const features = parseDisableFeatures(
+        launchArgs(ChromiumPlaywright, [], new CustomConfig()),
+      );
+      expect(features).to.include('DeploymentFeatureX'); // added by the override
+      expect(features).to.include('LocalNetworkAccessChecks'); // base list kept
+      expect(features).to.include('RenderDocument'); // version mirror kept
     });
 
     it('does not add chromium --disable-features to Firefox or WebKit', () => {

--- a/src/browsers/browsers.playwright.ts
+++ b/src/browsers/browsers.playwright.ts
@@ -16,6 +16,7 @@ import playwright, { Page } from 'playwright-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
 import type { IncomingMessage } from 'http';
+import { browserlessChromiumDisabledFeatures } from '../config.js';
 import path from 'path';
 
 enum PlaywrightBrowserTypes {
@@ -23,16 +24,6 @@ enum PlaywrightBrowserTypes {
   firefox = 'firefox',
   webkit = 'webkit',
 }
-
-/**
- * Features browserless disables on top of the launched Playwright version's
- * defaults. Chrome For Test (used by Playwright 1.57+) enforces Local Network
- * Access checks that block WebSocket connections to localhost, which browserless
- * relies on. See https://github.com/browserless/browserless/issues/5450
- */
-export const browserlessChromiumDisabledFeatures: readonly string[] = [
-  'LocalNetworkAccessChecks',
-];
 
 const DISABLE_FEATURES_FLAG = '--disable-features';
 
@@ -63,11 +54,12 @@ export const parseDisableFeatures = (args: readonly string[]): string[] =>
 export const withMergedChromiumDisableFeatures = (
   args: readonly string[],
   playwrightDisabledFeatures: readonly string[],
+  browserlessDisabledFeatures: readonly string[] = browserlessChromiumDisabledFeatures,
 ): string[] => {
   const merged = [
     ...new Set([
       ...playwrightDisabledFeatures,
-      ...browserlessChromiumDisabledFeatures,
+      ...browserlessDisabledFeatures,
       ...parseDisableFeatures(args),
     ]),
   ];
@@ -147,6 +139,7 @@ class BasePlaywright extends EventEmitter {
         ...withMergedChromiumDisableFeatures(
           args,
           this.config.getChromiumDisabledFeatures(pwVersion),
+          this.config.getBrowserlessChromiumDisabledFeatures(),
         ),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,6 +194,19 @@ const chromiumDisabledFeaturesByPwVersion: Readonly<
   '1.59': playwright158And159DisabledFeatures,
 };
 
+/**
+ * Features browserless disables on the Playwright launch path on top of the
+ * launched version's defaults. Chrome For Test (Playwright 1.57+) enforces Local
+ * Network Access checks that block WebSocket connections to localhost, which
+ * browserless relies on. Exposed as an overridable seam via
+ * `Config#getBrowserlessChromiumDisabledFeatures` so subclasses can disable
+ * additional features without forking the launcher.
+ * See https://github.com/browserless/browserless/issues/5450
+ */
+export const browserlessChromiumDisabledFeatures: readonly string[] = [
+  'LocalNetworkAccessChecks',
+];
+
 export class Config extends EventEmitter {
   protected readonly debug = getDebug();
   protected readonly host = process.env.HOST ?? 'localhost';
@@ -323,6 +336,17 @@ export class Config extends EventEmitter {
       (pwVersion && chromiumDisabledFeaturesByPwVersion[pwVersion]) ||
       defaultChromiumDisabledFeatures
     );
+  }
+
+  /**
+   * Chromium features browserless disables on the Playwright launch path, on top
+   * of the launched version's defaults (`getChromiumDisabledFeatures`). Override
+   * — extending via `super` — to disable additional features. Unlike the version
+   * list this is not validated against Playwright, so browserless- or
+   * deployment-specific features can be added here.
+   */
+  public getBrowserlessChromiumDisabledFeatures(): readonly string[] {
+    return browserlessChromiumDisabledFeatures;
   }
 
   /**


### PR DESCRIPTION
## Problem

`makeLaunchOptions` builds the Chromium-over-Playwright `--disable-features` flag
in `withMergedChromiumDisableFeatures`, merging three inputs:

1. the launched Playwright version's defaults — `Config.getChromiumDisabledFeatures(pwVersion)`
   (overridable, but it's the per-version mirror and is validated against the
   real Playwright by the drift test, so it can't carry extra features);
2. `browserlessChromiumDisabledFeatures` — a hardcoded module const;
3. any caller-supplied `--disable-features` already in `args`.

A consumer that subclasses `Config` and needs browserless to disable an
*additional* Chromium feature on the Playwright path has no clean seam: (1) is
drift-locked, (2) is a const with no override, and (3) means threading the flag
through launch args on every call. The only option today is forking the launcher.

## Change

- Move `browserlessChromiumDisabledFeatures` into `config.ts` and expose it via a
  new overridable method `Config.getBrowserlessChromiumDisabledFeatures()`, which
  returns that list by default.
- `makeLaunchOptions` passes `this.config.getBrowserlessChromiumDisabledFeatures()`
  into `withMergedChromiumDisableFeatures` (now a third parameter that defaults to
  the const, so the standalone helper is unchanged).
- Subclasses disable additional features by overriding the method and extending
  via `super` — symmetric with the existing `getChromiumDisabledFeatures` seam,
  and not subject to the drift test (these are browserless additions, not
  Playwright defaults):

```ts
class MyConfig extends Config {
  public getBrowserlessChromiumDisabledFeatures(): readonly string[] {
    return [...super.getBrowserlessChromiumDisabledFeatures(), 'SomeFeature'];
  }
}
```

## Backward compatibility

No behavior change for existing setups: base `Config` returns the same list,
`makeLaunchOptions` emits identical args, and `browserlessChromiumDisabledFeatures`
is still exported from the package entry point (now sourced from `config.ts`).
Existing two-argument `withMergedChromiumDisableFeatures` calls keep working via
the default parameter.

## Tests

- New spec: overriding `getBrowserlessChromiumDisabledFeatures` adds the feature
  to the merged flag while keeping the version mirror and the built-in list.
- Existing `--disable-features` merge and drift specs are unchanged and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable override point for Chromium `--disable-features`, allowing additional browserless-specific disabled features to be merged with the existing baseline set.
* **Refactor**
  * Centralized the browserless Chromium disabled-features list in configuration and updated the launch-time merge behavior to use the overridable values.
* **Tests**
  * Added a Playwright regression test to verify overridden and baseline `--disable-features` are merged correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->