### PR TITLE
fix(ci): isolate per-image manifest merges so one image can't block latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -384,12 +384,17 @@ jobs:
       # per-arch digest means its build failed, so fail this tag rather than
       # publish a single-arch manifest under a name that promises both arches.
       - name: Verify ${{ matrix.image }} per-arch digests are complete
-        working-directory: ${{ runner.temp }}/digests
         env:
           IMAGE: ${{ matrix.image }}
           EXPECTED: ${{ matrix.arches }}
+          DIGESTS: ${{ runner.temp }}/digests
         run: |
-          found=$(find . -maxdepth 1 -type f | wc -l | tr -d '[:space:]')
+          # mkdir instead of a `working-directory:` on this path so the
+          # descriptive error below still fires when ALL of this image's build
+          # legs failed and download-artifact left no digests directory behind
+          # (a missing working-directory aborts the step before the check runs).
+          mkdir -p "${DIGESTS}"
+          found=$(find "${DIGESTS}" -maxdepth 1 -type f | wc -l | tr -d '[:space:]')
           echo "Found ${found} digest(s) for ${IMAGE}, expected ${EXPECTED}."
           if [ "${found}" -ne "${EXPECTED}" ]; then
             echo "::error::Refusing to publish ${IMAGE}:${TAG} -- incomplete build (${found}/${EXPECTED} arches present). This image's build failed; other images publish unaffected."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -333,6 +333,16 @@ jobs:
     name: Merge ${{ matrix.image }} manifest
     runs-on: ubuntu-24.04
     needs: images-build
+    # Run even when some images-build legs failed. images-build is one matrix
+    # job, so a single failed leg (one image on one arch) marks the whole job
+    # "failed"; a plain `needs:` would then SKIP every merge leg and leave the
+    # published tags (including :latest) pointing at the previous release for
+    # ALL images -- not just the one that failed. !cancelled() lets the good
+    # images publish anyway, while `result != 'skipped'` still bails out when
+    # the upstream base never built. Each leg below refuses to publish unless
+    # it has the full set of per-arch digests for its OWN image, so a partial
+    # build fails that one tag loudly instead of shipping a single-arch image.
+    if: ${{ !cancelled() && needs.images-build.result != 'skipped' }}
     # TAG is passed via env rather than interpolated into run: scripts to avoid
     # template/shell injection from the caller-supplied tag.
     env:
@@ -340,15 +350,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - chromium
-          - chrome
-          - edge
-          - firefox
-          - webkit
-          - webkit-heavy
-          - multi
-          - multi-heavy
+        # `arches` is the number of per-arch digests this image is built for
+        # (chrome and edge are amd64-only); the merge step asserts that many
+        # digests are present before publishing.
+        include:
+          - { image: chromium, arches: 2 }
+          - { image: chrome, arches: 1 }
+          - { image: edge, arches: 1 }
+          - { image: firefox, arches: 2 }
+          - { image: webkit, arches: 2 }
+          - { image: webkit-heavy, arches: 2 }
+          - { image: multi, arches: 2 }
+          - { image: multi-heavy, arches: 2 }
     steps:
       - name: Download ${{ matrix.image }} digests
         uses: actions/download-artifact@v8
@@ -365,6 +378,23 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_PASSWORD }}
+
+      # Guard the decoupling above: now that this leg runs even when a sibling
+      # image failed, make sure THIS image is whole before tagging. Missing a
+      # per-arch digest means its build failed, so fail this tag rather than
+      # publish a single-arch manifest under a name that promises both arches.
+      - name: Verify ${{ matrix.image }} per-arch digests are complete
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ matrix.image }}
+          EXPECTED: ${{ matrix.arches }}
+        run: |
+          found=$(find . -maxdepth 1 -type f | wc -l | tr -d '[:space:]')
+          echo "Found ${found} digest(s) for ${IMAGE}, expected ${EXPECTED}."
+          if [ "${found}" -ne "${EXPECTED}" ]; then
+            echo "::error::Refusing to publish ${IMAGE}:${TAG} -- incomplete build (${found}/${EXPECTED} arches present). This image's build failed; other images publish unaffected."
+            exit 1
+          fi
 
       - name: Create and push ${{ matrix.image }} manifest list
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
## Problem

The `images-merge` job in the reusable `docker-publish.yml` pipeline depended on `images-build` with a plain `needs:`. `images-build` is a single matrix job, so a failure in **one** leg (one image on one arch) marks the whole job `failed`, and a plain `needs:` then **skips `images-merge` entirely — for every image**.

`images-merge` is the stage that runs `docker buildx imagetools create -t …:<tag>` and actually (re)points the published tags, including `:latest`. So one image's flake left `:latest` pointing at the **previous** release for **all** images.

### This is exactly what produced #5457

In the `docker-publish-latest` run for the 2.54.0 release:
- every per-arch **chromium** build succeeded and was pushed by digest, but
- **`Build multi (linux/amd64)` failed**, which marked `images-build` failed and **skipped the merge stage for all 8 images**.

Result: `ghcr.io/browserless/chromium:latest` stayed on the prior **2.53.1** digest (`sha256:18d3e547…`), even though the per-arch 2.54.0 chromium digests existed in the registry. The versioned `v2.54.0` tag was fine because the separate `docker-publish-stable` run's `multi` leg happened to succeed.

## Fix

Decouple the merges so one image/arch failure can't block the others:

- **Run the merge even when some builds failed** — `if: ${{ !cancelled() && needs.images-build.result != 'skipped' }}`. Images that built fully still publish; the run still bails on cancellation and when the base image never built.
- **Guard each leg's completeness** — a per-image step asserts the expected number of per-arch digests is present (chrome/edge are amd64-only → 1, the rest → 2) before tagging. Without this, decoupling would introduce a *new* bug: a partially built image could silently publish a **single-arch** manifest under a name that promises both arches. Now a partial build fails *that one tag* loudly while the others publish unaffected.

The happy path (all builds succeed) is byte-for-byte unchanged; only failure handling differs.

## Validation

- `actionlint .github/workflows/docker-publish.yml` → clean.
- Simulated the guard's shell logic: complete (2/2, 1/1) → publishes; partial (1/2) and empty (0/2) → fail with a clear `::error::`.

## Notes / out of scope
- The underlying `multi/amd64` build failure looked transient (the concurrent stable run built `multi` fine one minute later). A retry on the heavy `multi`/`webkit-heavy` builds could be a sensible follow-up but isn't included here.
- `:latest` for the affected images is currently still stale and won't self-heal until a human-merged push to `main` re-triggers the workflow. It can be repaired immediately without a rebuild by retagging from the good versioned manifests, e.g. `docker buildx imagetools create -t ghcr.io/browserless/chromium:latest ghcr.io/browserless/chromium:v2.54.0` (per image). Happy to do that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image publishing workflow to continue publishing per-image manifest lists even if some matrix builds fail.
  * Improved publishing logic to avoid globally skipping the merge step due to a single failed build leg.
  * Added an extra verification step to confirm the expected number of per-architecture digests is present before publishing each image tag, preventing incomplete multi-arch coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->