### PR TITLE
fix: log expected request/response conditions at debug, not warn

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -354,7 +354,10 @@ export class HTTPServer extends EventEmitter {
             )
             .join('\n');
 
-          this.logger.warn(`HTTP body validation failed:${errorDetails}`);
+          // Client error: the request body failed schema validation and we
+          // return 400 below with the details. Not operator-actionable, so
+          // log at debug rather than warn.
+          this.logger.debug(`HTTP body validation failed:${errorDetails}`);
 
           writeResponse(
             res,

--- a/src/shared/utils/function/handler.ts
+++ b/src/shared/utils/function/handler.ts
@@ -137,7 +137,18 @@ export default (config: Config, logger: Logger, options: HandlerOptions = {}) =>
 
     page.on('response', (res) => {
       if (!res.ok()) {
-        logger.warn(`Received a non-200 response for request "${res.url()}"`);
+        const status = res.status();
+        const msg = `Received a ${status} response for request "${res.url()}"`;
+        // Keep actionable failures at warn — server errors (5xx) and
+        // blocking/rate-limit responses (403, 429: target down or
+        // bot-detection). Routine sub-resource misses (favicon 404s,
+        // redirects, etc.) are expected during a page load and just noise,
+        // so log those at debug (the sibling page.on handlers above use trace).
+        if (status >= 500 || status === 403 || status === 429) {
+          logger.warn(msg);
+        } else {
+          logger.debug(msg);
+        }
       }
     });
 


### PR DESCRIPTION
## Why

Two `warn`-level logs fire on expected, non-actionable conditions and produce a large volume of low-signal warnings.

### 1. `/function` response handler — `src/shared/utils/function/handler.ts`

`page.on('response')` logged a `warn` for **every** non-OK response — favicon 404s, redirects, and other routine sub-resource misses during a normal page load. These are expected and not actionable, and inconsistent with the sibling `page.on(...)` handlers (which log at `trace`).

Now logged **by status**:

| status | level |
|---|---|
| 5xx (server error), 403 (forbidden / blocked), 429 (rate-limited) | `warn` |
| everything else (404s, redirects, …) | `debug` |

Server errors and blocking/rate-limit responses are the actionable cases (target down, bot-detection) and stay visible; routine misses drop to `debug`. The status code is now included in the message.

### 2. HTTP body validation failures — `src/server.ts`

A request body that fails schema validation is a **client error** — the handler already returns `400` to the caller with the details (`writeResponse(res, 400, …)`). Logging it server-side at `warn` is noise an operator can't act on, so it's lowered to `debug`.

## Not changed

The `"… disconnected unexpectedly"` warn in `browsers.cdp.ts` stays at `warn` — it's deliberate crash detection (Chrome OOM/segfault/SIGKILL), a genuine signal.
