### PR TITLE
chore(deps): ignore typescript majors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
+    ignore:
+      # TypeScript 7 (native/Go compiler) ships without a JS API; blocked until
+      # typescript-eslint and typescript-json-schema support it.
+      # See https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: typescript
+        update-types: ['version-update:semver-major']
     groups:
       types:
         patterns:


### PR DESCRIPTION
## Why

Dependabot opened #5495 bumping typescript 6.0.3 → 7.0.2. All CI jobs fail at `npm clean-install` with ERESOLVE: `@typescript-eslint/eslint-plugin@8.63.0` peers on `typescript >=4.8.4 <6.1.0`.

This is unfixable on our side for now:

- TypeScript 7 (native/Go compiler) intentionally ships **without a JS API**; a new API is expected in TS 7.1 ([announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0))
- typescript-eslint closed TS 7 support as not-planned until that API exists ([#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)); tracking issue [#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) is locked
- `typescript-json-schema` (core to our schema generation build step) uses the compiler API directly and hasn't formalized TS 6 support yet ([#633](https://github.com/YousefED/typescript-json-schema/issues/633))

## What

Add dependabot ignore rule for `typescript` semver-major updates. Minor/patch 6.x bumps keep flowing. #5495 was closed via `@dependabot ignore this major version`; this rule makes the block visible in-repo and survives dependabot state resets.

Remove when typescript-eslint + typescript-json-schema support TS 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to defer major TypeScript upgrades until ecosystem support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->