### PR TITLE
fix: replace unmaintained puppeteer-extra stealth chain with @zorilla forks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "2.54.2",
       "license": "SSPL",
       "dependencies": {
+        "@zorilla/puppeteer-extra": "^1.0.2",
+        "@zorilla/puppeteer-extra-plugin-stealth": "^1.0.4",
         "ajv": "^8.20.0",
         "debug": "^4.4.1",
         "del": "^8.0.1",
@@ -24,8 +26,6 @@
         "playwright-1.60": "npm:playwright-core@1.60.0",
         "playwright-core": "1.61.1",
         "puppeteer-core": "25.3.0",
-        "puppeteer-extra": "^3.3.6",
-        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "queue": "^7.0.0",
         "systeminformation": "^5.31.16",
         "tar-fs": "^3.1.3",
@@ -2221,6 +2221,136 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@zorilla/puppeteer-extra": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zorilla/puppeteer-extra/-/puppeteer-extra-1.0.2.tgz",
+      "integrity": "sha512-cAF8rgpJgDEUVNp17ivMCtveIpmXPGptCg+HRKx9b7uZZzTy/N+eyIXWpNiASXmNIrLu+LOAm5vl+Qt9uQVaUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "debug": "^4.4.3",
+        "deepmerge": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "puppeteer": "*",
+        "puppeteer-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer": {
+          "optional": true
+        },
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zorilla/puppeteer-extra-plugin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zorilla/puppeteer-extra-plugin/-/puppeteer-extra-plugin-1.0.2.tgz",
+      "integrity": "sha512-NvGcSzeMlm5zu3+eD3QU6fV3r2SKyAZT+HcJ1t7ZgU5F8N1W+jSNQVUljEShMPhDL0iS7lljHklbg6dULqYEJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "debug": "^4.4.3",
+        "merge-deep": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zorilla/puppeteer-extra-plugin-stealth": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@zorilla/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-1.0.4.tgz",
+      "integrity": "sha512-gvGZxC9sqSICrx3AfHhqzPhyNUk6+2P+vjl4/VTmsg/nt2sCY7ANrwZDwjrDL/MjoSVf3Ym/TwaDiJXVXNkUHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zorilla/puppeteer-extra-plugin": "1.0.2",
+        "@zorilla/puppeteer-extra-plugin-user-preferences": "1.0.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zorilla/puppeteer-extra-plugin-user-data-dir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zorilla/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-1.0.2.tgz",
+      "integrity": "sha512-Sjew0yLJs6s12IbKcnIPDcdf10qrO+nRaYoo9ibY/bIy/hC7TImis1UBaxaXLAykIUC3J1T7LZSO7PWmiZYWxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zorilla/puppeteer-extra-plugin": "1.0.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@zorilla/puppeteer-extra-plugin-user-preferences": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@zorilla/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-1.0.2.tgz",
+      "integrity": "sha512-CJNqrYrwXk8kWxneJeq9wZWlyowQlQEFZMJBSS51zL1Rh5p2kUBPVbSsoX9/TCtxos+6EKVd7+hhp1FOAJQ8ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@zorilla/puppeteer-extra-plugin": "1.0.2",
+        "@zorilla/puppeteer-extra-plugin-user-data-dir": "1.0.2",
+        "debug": "^4.4.3",
+        "deepmerge": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "playwright-extra": "*",
+        "puppeteer-extra": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright-extra": {
+          "optional": true
+        },
+        "puppeteer-extra": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2807,12 +2937,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -3645,26 +3769,6 @@
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
     },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC"
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3930,21 +4034,11 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/intl-messageformat": {
@@ -4250,18 +4344,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5120,15 +5202,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5475,142 +5548,6 @@
       "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
       "license": "Apache-2.0"
     },
-    "node_modules/puppeteer-extra": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
-      "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.1.0",
-        "debug": "^4.1.1",
-        "deepmerge": "^4.2.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "@types/puppeteer": "*",
-        "puppeteer": "*",
-        "puppeteer-core": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/puppeteer": {
-          "optional": true
-        },
-        "puppeteer": {
-          "optional": true
-        },
-        "puppeteer-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
-      "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/debug": "^4.1.0",
-        "debug": "^4.1.1",
-        "merge-deep": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=9.11.2"
-      },
-      "peerDependencies": {
-        "playwright-extra": "*",
-        "puppeteer-extra": "*"
-      },
-      "peerDependenciesMeta": {
-        "playwright-extra": {
-          "optional": true
-        },
-        "puppeteer-extra": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-stealth": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
-      "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "puppeteer-extra-plugin": "^3.2.3",
-        "puppeteer-extra-plugin-user-preferences": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "playwright-extra": "*",
-        "puppeteer-extra": "*"
-      },
-      "peerDependenciesMeta": {
-        "playwright-extra": {
-          "optional": true
-        },
-        "puppeteer-extra": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-user-data-dir": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
-      "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^10.0.0",
-        "puppeteer-extra-plugin": "^3.2.3",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "playwright-extra": "*",
-        "puppeteer-extra": "*"
-      },
-      "peerDependenciesMeta": {
-        "playwright-extra": {
-          "optional": true
-        },
-        "puppeteer-extra": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-extra-plugin-user-preferences": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
-      "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "deepmerge": "^4.2.2",
-        "puppeteer-extra-plugin": "^3.2.3",
-        "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "playwright-extra": "*",
-        "puppeteer-extra": "*"
-      },
-      "peerDependenciesMeta": {
-        "playwright-extra": {
-          "optional": true
-        },
-        "puppeteer-extra": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -5786,71 +5723,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/robots-parser": {
       "version": "3.0.1",
@@ -6787,15 +6659,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "tsconfig.json"
   ],
   "dependencies": {
+    "@zorilla/puppeteer-extra": "^1.0.2",
+    "@zorilla/puppeteer-extra-plugin-stealth": "^1.0.4",
     "ajv": "^8.20.0",
     "debug": "^4.4.1",
     "del": "^8.0.1",
@@ -72,8 +74,6 @@
     "playwright-1.60": "npm:playwright-core@1.60.0",
     "playwright-core": "1.61.1",
     "puppeteer-core": "25.3.0",
-    "puppeteer-extra": "^3.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "queue": "^7.0.0",
     "systeminformation": "^5.31.16",
     "tar-fs": "^3.1.3",

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -15,14 +15,22 @@ import {
 import puppeteer, { Browser, Page, Target } from 'puppeteer-core';
 import { Duplex } from 'stream';
 import { EventEmitter } from 'events';
-import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import StealthPlugin from '@zorilla/puppeteer-extra-plugin-stealth';
+import { addExtra } from '@zorilla/puppeteer-extra';
 import getPort from 'get-port';
 import httpProxy from 'http-proxy';
 import path from 'path';
 import playwright from 'playwright-core';
-import puppeteerStealth from 'puppeteer-extra';
 
-puppeteerStealth.use(StealthPlugin());
+// @zorilla/puppeteer-extra's types still expect puppeteer's long-removed
+// createBrowserFetcher and re-declare their own plugin interface; at runtime
+// only launch/connect/defaultArgs/executablePath are used, so the casts are safe.
+const puppeteerStealth = addExtra(
+  puppeteer as unknown as Parameters<typeof addExtra>[0],
+);
+puppeteerStealth.use(
+  StealthPlugin() as unknown as Parameters<typeof puppeteerStealth.use>[0],
+);
 
 export class ChromiumCDP extends EventEmitter {
   protected config: Config;


### PR DESCRIPTION
## Problem

A fresh `npm ci` (what Docker/CI run) emits three deprecation warnings:

```
npm warn deprecated inflight@1.0.6  — not supported, leaks memory
npm warn deprecated rimraf@3.0.2    — versions prior to v4 no longer supported
npm warn deprecated glob@7.2.3      — known security vulnerabilities
```

All three come from one production chain:

```
puppeteer-extra-plugin-stealth → …-user-preferences → …-user-data-dir → rimraf@3 → glob@7 → inflight
```

Upstream (`berstend/puppeteer-extra`) has been quiet since 2023, so bumping it can't clear the warnings.

## Fix

Substitute the whole chain with the maintained [@zorilla](https://github.com/zorillajs/zorilla) hard fork of puppeteer-extra. Its `user-data-dir` fork uses Node's built-in `fs` instead of rimraf, so the deprecated packages leave the tree at the root — no override, no `node_modules` patch.

- **deps:** `puppeteer-extra` + `puppeteer-extra-plugin-stealth` → `@zorilla/puppeteer-extra` + `@zorilla/puppeteer-extra-plugin-stealth`
- **`browsers.cdp.ts`:** bind the plugin engine with `addExtra(puppeteer)` instead of the legacy singleton default import (which lazily `require`d `puppeteer` — a package we don't ship; we ship `puppeteer-core`). Two `as unknown as Parameters<…>` casts bridge zorilla's types, which still reference puppeteer's long-removed `createBrowserFetcher`; runtime is unaffected.

## Dependency delta

`522 → 510` packages. 17 removed, 5 added:

```
REMOVED: puppeteer-extra(+plugin/-stealth/-user-data-dir/-user-preferences),
         rimraf, glob@7, inflight, fs-extra, jsonfile, universalify,
         concat-map, fs.realpath, path-is-absolute, + rimraf's nested minimatch chain
ADDED:   @zorilla/{puppeteer-extra, -plugin, -plugin-stealth, -user-data-dir, -user-preferences}
```

Nothing in `src/` imported any removed package directly.

## Validation (local)

- Fresh `npm ci`: **zero** warnings (was 3)
- `tsc` / lint / build / prettier: clean
- Docker `base` + `chromium` images built with the exact CI recipe (Ubuntu 24.04, Node v24.18.0) — `npm clean-install` layer warning-free
- **Live container probe:** `?stealth=true` → `navigator.webdriver=false`; `?stealth=false` → `true`; no error on session teardown (the old rimraf-crash path)
- `npm test`: 666 pass / 0 fail on this branch
- `npm pack`: tarball ships the compiled zorilla imports + correct runtime deps

## Review note

Zorilla enables **17** stealth evasions by default vs the current **16** — worth a glance to confirm the extra one is wanted. Otherwise a drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser automation compatibility and reliability.
  - Updated stealth browsing integration to work with the supported Puppeteer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->