### PR TITLE
fix: record HTTP client disconnects as errors

### DIFF
--- a/src/router.spec.ts
+++ b/src/router.spec.ts
@@ -3,7 +3,9 @@ import * as http from 'http';
 import * as stream from 'stream';
 import {
   APITags,
+  BrowserHTTPRoute,
   BrowserManager,
+  ChromiumCDP,
   Config,
   HTTPRoute,
   Hooks,
@@ -35,6 +37,31 @@ class TestHTTPRoute extends HTTPRoute {
   public method = Methods.get;
   public name = 'test-http';
   public path: string | string[] = '/__test__';
+  public tags: APITags[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(public override handler: any) {
+    super(
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+      null as never,
+    );
+  }
+}
+
+class TestBrowserHTTPRoute extends BrowserHTTPRoute {
+  public accepts = [contentTypes.any];
+  public auth = false;
+  public browser = ChromiumCDP;
+  public contentTypes = [contentTypes.text];
+  public description = 'test';
+  public method = Methods.get;
+  public name = 'test-browser-http';
+  public path: string | string[] = '/__test_browser__';
   public tags: APITags[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -131,7 +158,7 @@ const buildRouter = () => {
 
   const router = new Router(config, browserManager, limiter, Logger, hooks);
 
-  return { router, hooks, limiter, config, metrics };
+  return { router, hooks, limiter, config, metrics, browserManager };
 };
 
 // Resolves when the Limiter dispatches its next 'end' event. Used to wait
@@ -176,6 +203,46 @@ describe('Router', () => {
         'status',
         'successful',
       );
+    });
+
+    it('fires after() with status "error" when the response closes during browser startup', async () => {
+      const { router, hooks, limiter, browserManager } = buildRouter();
+      const response = makeResponse();
+      const browser = {} as never;
+      const inner = spy(async () => 'ok');
+      const route = new TestBrowserHTTPRoute(inner);
+      route.concurrency = true;
+
+      browserManager.getBrowserForRequest.callsFake(async () => {
+        (response.socket as { writable: boolean }).writable = false;
+        return browser;
+      });
+
+      router.registerHTTPRoute(route);
+
+      const ended = limiterEnded(limiter);
+      let caught: unknown;
+      try {
+        await (
+          route.handler as (
+            req: Request,
+            res: http.ServerResponse,
+          ) => Promise<unknown>
+        )(makeRequest(), response);
+      } catch (err) {
+        caught = err;
+      }
+      await ended;
+
+      expect(caught).to.be.instanceOf(Error);
+      expect((caught as Error).message).to.equal(
+        'Request closed prior to writing results',
+      );
+      expect(inner.called).to.be.false;
+      expect(browserManager.complete.calledOnceWith(browser)).to.be.true;
+      expect(hooks.after.callCount).to.equal(1);
+      expect(hooks.after.firstCall.args[0]).to.have.property('status', 'error');
+      expect(hooks.after.firstCall.args[0]).to.have.property('error', caught);
     });
 
     it('fires after() once with status "successful" for concurrency=false routes', async () => {
@@ -308,6 +375,96 @@ describe('Router', () => {
 
       expect(inner.called).to.be.false;
       expect(hooks.after.callCount).to.equal(0);
+    });
+
+    it('skips after() when the response closed before limiter admission', async () => {
+      const { router, hooks } = buildRouter();
+      const inner = spy(async () => 'ok');
+      const route = new TestHTTPRoute(inner);
+      route.concurrency = true;
+      router.registerHTTPRoute(route);
+
+      const closedRes = makeResponse();
+      (closedRes.socket as { writable: boolean }).writable = false;
+
+      await (
+        route.handler as (
+          req: Request,
+          res: http.ServerResponse,
+        ) => Promise<unknown>
+      )(makeRequest(), closedRes);
+      await flushMicrotasks();
+
+      expect(inner.called).to.be.false;
+      expect(hooks.after.callCount).to.equal(0);
+    });
+
+    it('fires after() with status "error" when the response closes in the limiter queue', async () => {
+      const { router, hooks, limiter, config } = buildRouter();
+      config.setConcurrent(1);
+
+      let startFirst!: () => void;
+      const firstStarted = new Promise<void>((resolve) => {
+        startFirst = resolve;
+      });
+      let finishFirst!: () => void;
+      const firstFinished = new Promise<void>((resolve) => {
+        finishFirst = resolve;
+      });
+      const inner = spy(async () => {
+        if (inner.callCount === 1) {
+          startFirst();
+          await firstFinished;
+        }
+        return 'ok';
+      });
+      const route = new TestHTTPRoute(inner);
+      route.concurrency = true;
+      router.registerHTTPRoute(route);
+
+      const ended = limiterEnded(limiter);
+      const first = (
+        route.handler as (
+          req: Request,
+          res: http.ServerResponse,
+        ) => Promise<unknown>
+      )(makeRequest(), makeResponse());
+      await firstStarted;
+
+      const queuedResponse = makeResponse();
+      let queuedError: unknown;
+      const queued = (
+        route.handler as (
+          req: Request,
+          res: http.ServerResponse,
+        ) => Promise<unknown>
+      )(makeRequest(), queuedResponse).catch((err) => {
+        queuedError = err;
+      });
+      (queuedResponse.socket as { writable: boolean }).writable = false;
+      finishFirst();
+
+      await Promise.all([first, queued]);
+      await ended;
+
+      expect(queuedError).to.be.instanceOf(Error);
+      expect((queuedError as Error).message).to.equal(
+        'Request closed prior to writing results',
+      );
+      expect(inner.callCount).to.equal(1);
+      expect(hooks.after.callCount).to.equal(2);
+      expect(hooks.after.firstCall.args[0]).to.have.property(
+        'status',
+        'successful',
+      );
+      expect(hooks.after.secondCall.args[0]).to.have.property(
+        'status',
+        'error',
+      );
+      expect(hooks.after.secondCall.args[0]).to.have.property(
+        'error',
+        queuedError,
+      );
     });
   });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -23,9 +23,9 @@ import { EventEmitter } from 'events';
 import micromatch from 'micromatch';
 import stream from 'stream';
 
-// Returned by wrapHTTPHandler / wrapWebSocketHandler when the connection was
-// already closed before any work could run. wrapWithAfterHook checks for it so
-// after() isn't fired for a request that never executed.
+// Returned when the connection was already closed before any route lifecycle
+// or limiter work could begin, so after() isn't fired for a request that never
+// executed.
 const ROUTE_DID_NOT_RUN = Symbol('route-did-not-run');
 
 const safeStringify = (value: unknown): string | undefined => {
@@ -184,7 +184,7 @@ export class Router extends EventEmitter {
     return async (req: Request, res: Response) => {
       if (!isConnected(res)) {
         this.log.warn(`HTTP Request has closed prior to running`);
-        return ROUTE_DID_NOT_RUN;
+        throw new Error(`Request closed prior to writing results`);
       }
       const logger = new this.logger(route.name, req);
       if (
@@ -201,7 +201,7 @@ export class Router extends EventEmitter {
         if (!isConnected(res)) {
           this.log.warn(`HTTP Request has closed prior to running`);
           this.browserManager.complete(browser);
-          return ROUTE_DID_NOT_RUN;
+          throw new Error(`Request closed prior to writing results`);
         }
 
         if (!browser) {
@@ -288,7 +288,7 @@ export class Router extends EventEmitter {
 
     // Invariant: exactly one of limiter.limit / wrapWithAfterHook wraps the
     // handler, so hooks.after() fires exactly once per request.
-    route.handler = route.concurrency
+    const handler = route.concurrency
       ? this.limiter.limit(
           wrapped,
           this.onQueueFullHTTP.bind(this),
@@ -298,6 +298,16 @@ export class Router extends EventEmitter {
           route,
         )
       : this.wrapWithAfterHook(wrapped, route);
+
+    route.handler = async (req: Request, res: Response) => {
+      if (!isConnected(res)) {
+        this.log.warn(`HTTP Request has closed prior to running`);
+        return ROUTE_DID_NOT_RUN;
+      }
+
+      return handler(req, res);
+    };
+
     route.path = Array.isArray(route.path) ? route.path : [route.path];
     this.compilePathMatchers(route);
     const registeredPaths = this.httpRoutes.map((r) => r.path).flat();


### PR DESCRIPTION
## Summary

- skip HTTP requests whose clients disconnected before route lifecycle admission
- reject disconnects after limiter execution begins so metrics and after hooks classify the request as failed
- clean up a browser acquired during startup before reporting the disconnect

## Test plan

- `npm run build:ts`
- `npx mocha --no-config --no-package build/router.spec.js`
- `npx eslint src/router.ts`
- built and ran a local Chromium Docker image
  - a normal `/content` request returned HTTP 200
  - a client abort during delayed browser startup emitted one error lifecycle event and one failed limiter stat
  - post-request pressure returned to `running: 0` and `queued: 0`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/browserless/browserless/pull/5518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests whose connection closes before processing begins or while waiting.
  * Prevented route handlers from running when a response is already disconnected.
  * Ensured completed and interrupted requests receive consistent lifecycle status and error reporting.
  * Improved browser-startup behavior when the requesting connection closes, including clearer error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->