### PR TITLE
fix: contain browser scratch in a per-session TMPDIR

### DIFF
--- a/src/browsers/browsers.cdp.spec.ts
+++ b/src/browsers/browsers.cdp.spec.ts
@@ -1,0 +1,37 @@
+import { Config, Logger } from '@browserless.io/browserless';
+import { expect } from 'chai';
+
+import { ChromiumCDP, disableComponentUpdaterArg } from './browsers.cdp.js';
+
+describe('ChromiumCDP launch args', function () {
+  let browser: ChromiumCDP | undefined;
+
+  afterEach(async () => {
+    await browser?.close();
+    browser = undefined;
+  });
+
+  const launch = async (args: string[] = []) => {
+    browser = new ChromiumCDP({
+      blockAds: false,
+      config: new Config(),
+      logger: new Logger('browsers.cdp.spec'),
+      userDataDir: null,
+    });
+    await browser.launch({ options: { args } } as never);
+    return browser.process()?.spawnargs ?? [];
+  };
+
+  it('disables the component updater', async function () {
+    const spawnargs = await launch();
+
+    expect(spawnargs).to.include(disableComponentUpdaterArg);
+  });
+
+  it('keeps disabling it when the caller supplies its own args', async function () {
+    const spawnargs = await launch(['--window-size=800,600']);
+
+    expect(spawnargs).to.include(disableComponentUpdaterArg);
+    expect(spawnargs).to.include('--window-size=800,600');
+  });
+});

--- a/src/browsers/browsers.cdp.spec.ts
+++ b/src/browsers/browsers.cdp.spec.ts
@@ -1,37 +1,66 @@
-import { Config, Logger } from '@browserless.io/browserless';
+import {
+  BrowserLauncherOptions,
+  Config,
+  Logger,
+  availableBrowsers,
+} from '@browserless.io/browserless';
 import { expect } from 'chai';
 
-import { ChromiumCDP, disableComponentUpdaterArg } from './browsers.cdp.js';
+import { ChromiumCDP } from './browsers.cdp.js';
 
 describe('ChromiumCDP launch args', function () {
   let browser: ChromiumCDP | undefined;
+
+  // Single-browser images (chrome, edge, firefox, webkit) ship no chromium
+  // binary, so this suite has nothing to launch there.
+  before(async function () {
+    const installed = await availableBrowsers;
+    if (!installed.includes(ChromiumCDP)) {
+      this.skip();
+    }
+  });
 
   afterEach(async () => {
     await browser?.close();
     browser = undefined;
   });
 
-  const launch = async (args: string[] = []) => {
+  const launch = async ({
+    args = [],
+    stealth = false,
+  }: { args?: string[]; stealth?: boolean } = {}) => {
     browser = new ChromiumCDP({
       blockAds: false,
       config: new Config(),
       logger: new Logger('browsers.cdp.spec'),
       userDataDir: null,
     });
-    await browser.launch({ options: { args } } as never);
+    const launchOptions: BrowserLauncherOptions = {
+      options: { args },
+      stealth,
+    };
+    await browser.launch(launchOptions);
     return browser.process()?.spawnargs ?? [];
   };
 
   it('disables the component updater', async function () {
     const spawnargs = await launch();
 
-    expect(spawnargs).to.include(disableComponentUpdaterArg);
+    expect(spawnargs).to.include('--disable-component-update');
   });
 
   it('keeps disabling it when the caller supplies its own args', async function () {
-    const spawnargs = await launch(['--window-size=800,600']);
+    const spawnargs = await launch({ args: ['--window-size=800,600'] });
 
-    expect(spawnargs).to.include(disableComponentUpdaterArg);
+    expect(spawnargs).to.include('--disable-component-update');
     expect(spawnargs).to.include('--window-size=800,600');
+  });
+
+  // puppeteer-extra's stealth launcher is a separate code path that rebuilds the
+  // argv, so the switch has to be asserted through it too.
+  it('disables the component updater on the stealth launcher', async function () {
+    const spawnargs = await launch({ stealth: true });
+
+    expect(spawnargs).to.include('--disable-component-update');
   });
 });

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -32,6 +32,23 @@ puppeteerStealth.use(
   StealthPlugin() as unknown as Parameters<typeof puppeteerStealth.use>[0],
 );
 
+/**
+ * Chrome's component updater fetches into scratch directories under
+ * `base::GetTempDir()` — the shared system temp dir, not the session's
+ * user-data dir. Every session launches on a cold profile, so the whole
+ * component set (CRLSet, Safe Browsing, Subresource Filter, First-Party Sets,
+ * …) is re-downloaded per launch, and the scratch is only unlinked by
+ * `ScopedTempDir`'s destructor — which never runs when Chrome exits on SIGKILL,
+ * as it does whenever `puppeteer.close()` escalates. The orphans land outside
+ * both getDataDir() and getDownloadsDir(), so nothing reclaims them: a busy
+ * deployment filled 125GB of /tmp in two hours this way.
+ *
+ * Not expressible through `--disable-features`; the updater is gated on this
+ * top-level switch. Puppeteer's `defaultArgs` covers the sibling case
+ * (`--disable-background-networking`) but not this one.
+ */
+export const disableComponentUpdaterArg = '--disable-component-update';
+
 export class ChromiumCDP extends EventEmitter {
   protected config: Config;
   protected userDataDir: string | null;
@@ -256,6 +273,7 @@ export class ChromiumCDP extends EventEmitter {
         // Playwright 1.57+ uses Chrome For Test, which has stricter security than Chromium.
         // This is needed to allow WebSocket connections to localhost.
         `--disable-features=LocalNetworkAccessChecks`,
+        disableComponentUpdaterArg,
         ...(options.args || []),
         this.userDataDir ? `--user-data-dir=${this.userDataDir}` : '',
       ].filter((_) => !!_),

--- a/src/browsers/browsers.cdp.ts
+++ b/src/browsers/browsers.cdp.ts
@@ -35,13 +35,21 @@ puppeteerStealth.use(
 /**
  * Chrome's component updater fetches into scratch directories under
  * `base::GetTempDir()` — the shared system temp dir, not the session's
- * user-data dir. Every session launches on a cold profile, so the whole
- * component set (CRLSet, Safe Browsing, Subresource Filter, First-Party Sets,
- * …) is re-downloaded per launch, and the scratch is only unlinked by
- * `ScopedTempDir`'s destructor — which never runs when Chrome exits on SIGKILL,
- * as it does whenever `puppeteer.close()` escalates. The orphans land outside
- * both getDataDir() and getDownloadsDir(), so nothing reclaims them: a busy
+ * user-data dir. A session on a fresh data dir finds no component cache and
+ * re-downloads the whole set (CRLSet, Safe Browsing, Subresource Filter,
+ * First-Party Sets, …), and that scratch is only unlinked by `ScopedTempDir`'s
+ * destructor — which never runs when Chrome exits on SIGKILL, as it does
+ * whenever `puppeteer.close()` escalates. The orphans land outside both
+ * getDataDir() and getDownloadsDir(), so nothing reclaims them: a busy
  * deployment filled 125GB of /tmp in two hours this way.
+ *
+ * Applied unconditionally, including when a caller supplies its own
+ * `userDataDir`. Component refresh is not something a session should be doing:
+ * it spends bandwidth mid-run and makes the browser's behaviour vary between
+ * otherwise identical automation runs. Updated component data reaches
+ * deployments through a new browser build in a new image, which is the only
+ * refresh channel that is reproducible. Persistent profiles are also the
+ * longest-lived sessions, so exempting them would leak the most scratch.
  *
  * Not expressible through `--disable-features`; the updater is gated on this
  * top-level switch. Puppeteer's `defaultArgs` covers the sibling case

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -28,6 +28,7 @@ import {
   convertIfBase64,
   exists,
   generateDataDir,
+  generateScratchDir,
   getFinalPathSegment,
   makeExternalURL,
   noop,
@@ -67,8 +68,9 @@ export class BrowserManager {
     WebKitPlaywright.name,
   ];
 
-  // user-data-dirs whose deletion exhausted its retries; retried on an
-  // interval so a transient handle-hold doesn't permanently leak disk.
+  // Session-owned dirs (user-data and scratch) whose deletion exhausted its
+  // retries; retried on an interval so a transient handle-hold doesn't
+  // permanently leak disk.
   protected orphanedDataDirs: Set<string> = new Set();
   protected orphanedDataDirSweeper: NodeJS.Timeout;
 
@@ -100,10 +102,10 @@ export class BrowserManager {
       try {
         await deleteAsync(dir, { force: true });
         this.orphanedDataDirs.delete(dir);
-        this.log.info(`Reclaimed previously-orphaned user-data-dir "${dir}"`);
+        this.log.info(`Reclaimed previously-orphaned session dir "${dir}"`);
       } catch (err) {
         this.log.debug(
-          `Orphaned user-data-dir "${dir}" still undeletable: ${err}`,
+          `Orphaned session dir "${dir}" still undeletable: ${err}`,
         );
       }
     }
@@ -129,25 +131,28 @@ export class BrowserManager {
     }
   }
 
-  protected async removeUserDataDir(userDataDir: string | null) {
-    if (!userDataDir || !(await exists(userDataDir))) return;
-    this.log.debug(`Deleting data directory "${userDataDir}"`);
+  /**
+   * Remove a session-owned directory, retrying with backoff to absorb the
+   * transient EBUSY/ENOTEMPTY window that `del` sometimes hits while Chrome is
+   * still releasing handles. Without retries this manifests as a single logged
+   * error and a leaked dir. A directory that outlasts every attempt is queued
+   * for the background sweep rather than abandoned.
+   */
+  protected async removeSessionDir(dir: string | null, label: string) {
+    if (!dir || !(await exists(dir))) return;
+    this.log.debug(`Deleting ${label} "${dir}"`);
 
-    // Retry with backoff to absorb the transient EBUSY/ENOTEMPTY window
-    // that `del` sometimes hits while Chrome is still releasing handles
-    // on the profile directory. Without retries this manifests as a
-    // single logged error and a leaked dir.
     const totalAttempts = REMOVE_RETRY_BACKOFF_MS.length + 1;
     for (let attempt = 0; attempt < totalAttempts; attempt++) {
       try {
-        await deleteAsync(userDataDir, { force: true });
+        await deleteAsync(dir, { force: true });
         return;
       } catch (err) {
         if (attempt === totalAttempts - 1) {
           this.log.error(
-            `Failed to remove user-data-dir "${userDataDir}" after ${totalAttempts} attempts: ${err}; queueing for background retry`,
+            `Failed to remove ${label} "${dir}" after ${totalAttempts} attempts: ${err}; queueing for background retry`,
           );
-          this.orphanedDataDirs.add(userDataDir);
+          this.orphanedDataDirs.add(dir);
           return;
         }
         await new Promise((resolve) =>
@@ -155,6 +160,14 @@ export class BrowserManager {
         );
       }
     }
+  }
+
+  protected async removeUserDataDir(userDataDir: string | null) {
+    return this.removeSessionDir(userDataDir, 'user-data-dir');
+  }
+
+  protected async removeScratchDir(scratchDir: string | null) {
+    return this.removeSessionDir(scratchDir, 'scratch-dir');
   }
 
   protected async onNewPage(req: Request, page: Page) {
@@ -486,6 +499,10 @@ export class BrowserManager {
           this.log.debug(`Deleting "${session.userDataDir}" user-data-dir`);
           await this.removeUserDataDir(session.userDataDir);
         }
+        // Unconditional: the scratch dir is browserless-owned even when the
+        // caller brought their own data dir. Ordered after browser.close() for
+        // the same reason as the data dir — Chrome releases its handles first.
+        await this.removeScratchDir(session.scratchDir);
       }
     }
   }
@@ -718,6 +735,20 @@ export class BrowserManager {
         ? await generateDataDir(undefined, this.config)
         : null);
 
+    // Give the browser its own TMPDIR so the scratch it abandons on SIGKILL is
+    // inside a directory this session owns, instead of loose in the shared temp
+    // dir where nothing can reclaim it. TMPDIR is applied last: `launch` is a
+    // caller passthrough, and a session must not redirect its own scratch back
+    // into the shared temp dir.
+    const scratchDir = await generateScratchDir(undefined, this.config);
+    if (scratchDir) {
+      (launchOptions as BrowserServerOptions).env = {
+        ...process.env,
+        ...(launchOptions as BrowserServerOptions).env,
+        TMPDIR: scratchDir,
+      };
+    }
+
     const proxyServerArg = launchOptions.args?.find((arg) =>
       arg.includes('--proxy-server='),
     );
@@ -783,6 +814,9 @@ export class BrowserManager {
       if (!manualUserDataDir && userDataDir) {
         await this.removeUserDataDir(userDataDir);
       }
+      // Owned by browserless regardless of who supplied the data dir, so it is
+      // reclaimed unconditionally.
+      await this.removeScratchDir(scratchDir);
       throw err;
     }
 
@@ -796,6 +830,7 @@ export class BrowserManager {
       numbConnected: 1,
       resolver: noop,
       routePath: router.path,
+      scratchDir,
       startedOn: Date.now(),
       trackingId,
       ttl: 0,

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -740,14 +740,21 @@ export class BrowserManager {
     // dir where nothing can reclaim it. TMPDIR is applied last: `launch` is a
     // caller passthrough, and a session must not redirect its own scratch back
     // into the shared temp dir.
+    //
+    // Kept out of `launchOptions`, which is stored on the session and served
+    // by /sessions: this merge carries the whole server environment, so
+    // writing it there would publish TOKEN and any host credentials. It is
+    // handed to `launch` alone. The spread of `process.env` is required
+    // because both launchers replace the child environment wholesale when
+    // `env` is given rather than merging it over their own default.
     const scratchDir = await generateScratchDir(undefined, this.config);
-    if (scratchDir) {
-      (launchOptions as BrowserServerOptions).env = {
-        ...process.env,
-        ...(launchOptions as BrowserServerOptions).env,
-        TMPDIR: scratchDir,
-      };
-    }
+    const browserEnv = scratchDir
+      ? {
+          ...process.env,
+          ...(launchOptions as BrowserServerOptions).env,
+          TMPDIR: scratchDir,
+        }
+      : (launchOptions as BrowserServerOptions).env;
 
     const proxyServerArg = launchOptions.args?.find((arg) =>
       arg.includes('--proxy-server='),
@@ -792,7 +799,7 @@ export class BrowserManager {
 
     try {
       await browser.launch({
-        options: launchOptions as BrowserServerOptions,
+        options: { ...launchOptions, env: browserEnv } as BrowserServerOptions,
         pwVersion,
         req,
         stealth: launchOptions?.stealth,

--- a/src/browsers/index.ts
+++ b/src/browsers/index.ts
@@ -747,14 +747,22 @@ export class BrowserManager {
     // handed to `launch` alone. The spread of `process.env` is required
     // because both launchers replace the child environment wholesale when
     // `env` is given rather than merging it over their own default.
-    const scratchDir = await generateScratchDir(undefined, this.config);
-    const browserEnv = scratchDir
-      ? {
-          ...process.env,
-          ...(launchOptions as BrowserServerOptions).env,
-          TMPDIR: scratchDir,
-        }
-      : (launchOptions as BrowserServerOptions).env;
+    let scratchDir: string;
+    try {
+      scratchDir = await generateScratchDir(undefined, this.config);
+    } catch (err) {
+      // CDP's auto-generated data dir already exists at this point, but no
+      // BrowserlessSession exists yet to route through the normal close path.
+      if (!manualUserDataDir && userDataDir) {
+        await this.removeUserDataDir(userDataDir);
+      }
+      throw err;
+    }
+    const browserEnv = {
+      ...process.env,
+      ...(launchOptions as BrowserServerOptions).env,
+      TMPDIR: scratchDir,
+    };
 
     const proxyServerArg = launchOptions.args?.find((arg) =>
       arg.includes('--proxy-server='),

--- a/src/browsers/scratch-dirs.spec.ts
+++ b/src/browsers/scratch-dirs.spec.ts
@@ -1,0 +1,95 @@
+import {
+  Browserless,
+  ChromiumCDP,
+  Config,
+  Metrics,
+  availableBrowsers,
+} from '@browserless.io/browserless';
+import { expect } from 'chai';
+import fs from 'fs/promises';
+import os from 'os';
+import puppeteer from 'puppeteer-core';
+
+/**
+ * Scratch the Chromium family writes to the *shared* temp dir rather than to the
+ * session's own directories. All of it is unlinked from a destructor that never
+ * runs when the process exits on SIGKILL — which is how a browser ignoring
+ * SIGTERM is ended — so each pattern here is a way for one session to
+ * permanently cost the host disk.
+ *
+ * Matched by prefix, never by the random suffix, so a rename of the suffix
+ * scheme in a browser bump still trips this.
+ */
+const SCRATCH_PATTERNS = [
+  /^\.?(org\.chromium\.Chromium|com\.google\.Chrome|com\.microsoft\.Edge)\./,
+  /^scoped_dir/,
+  /^(chrome_crashpad|Crashpad)/,
+  /^puppeteer_dev_chrome_profile-/,
+];
+
+const listTemp = async (dir: string) => fs.readdir(dir).catch(() => []);
+
+const scratchIn = async (dir: string, before: Set<string>) =>
+  (await listTemp(dir))
+    .filter((entry) => !before.has(entry))
+    .filter((entry) => SCRATCH_PATTERNS.some((p) => p.test(entry)))
+    .sort();
+
+describe('Browser scratch directories', function () {
+  let browserless: Browserless;
+  const config = new Config();
+
+  before(async function () {
+    const installed = await availableBrowsers;
+    if (!installed.includes(ChromiumCDP)) {
+      this.skip();
+    }
+  });
+
+  beforeEach(() => {
+    config.setToken('6R0W53R135510');
+    browserless = new Browserless({ config, metrics: new Metrics() });
+    return browserless.start();
+  });
+
+  afterEach(async () => {
+    await browserless.stop();
+  });
+
+  const session = async () => {
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `ws://localhost:3000/chromium?token=6R0W53R135510`,
+    });
+    const page = await browser.newPage();
+    await page.goto('about:blank');
+    await browser.close();
+  };
+
+  it('leaves no browser scratch in the shared temp dir', async () => {
+    const before = new Set(await listTemp(os.tmpdir()));
+
+    await session();
+
+    expect(await scratchIn(os.tmpdir(), before)).to.deep.equal([]);
+  });
+
+  it('removes the session scratch dir once the session ends', async () => {
+    const scratchRoot = config.getScratchDir();
+    const before = new Set(await listTemp(scratchRoot));
+
+    await session();
+
+    // The client's close() resolves when the socket does; the server-side
+    // teardown that reclaims the dir runs after that, so poll rather than
+    // asserting on the instant the connection drops.
+    let left: string[] = [];
+    const deadline = Date.now() + 10_000;
+    do {
+      left = (await listTemp(scratchRoot)).filter((e) => !before.has(e));
+      if (!left.length) break;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    } while (Date.now() < deadline);
+
+    expect(left).to.deep.equal([]);
+  });
+});

--- a/src/browsers/scratch-dirs.spec.ts
+++ b/src/browsers/scratch-dirs.spec.ts
@@ -56,10 +56,13 @@ describe('Browser scratch directories', function () {
     await browserless.stop();
   });
 
-  const session = async () => {
-    const browser = await puppeteer.connect({
+  const connect = () =>
+    puppeteer.connect({
       browserWSEndpoint: `ws://localhost:3000/chromium?token=6R0W53R135510`,
     });
+
+  const session = async () => {
+    const browser = await connect();
     const page = await browser.newPage();
     await page.goto('about:blank');
     await browser.close();
@@ -91,5 +94,36 @@ describe('Browser scratch directories', function () {
     } while (Date.now() < deadline);
 
     expect(left).to.deep.equal([]);
+  });
+
+  /**
+   * The TMPDIR override is merged over `process.env`, since both launchers
+   * replace the child environment wholesale rather than merging. That merged
+   * object must never reach the session record: /sessions serves
+   * `launchOptions` verbatim, so storing it there would publish TOKEN and every
+   * other host credential to anyone who can read the endpoint.
+   */
+  it('does not publish the browser environment through /sessions', async () => {
+    process.env.SCRATCH_SPEC_SECRET = 'must-not-be-served';
+    const browser = await connect();
+
+    try {
+      const res = await fetch(
+        'http://localhost:3000/sessions?token=6R0W53R135510',
+      );
+      const body = await res.text();
+      const sessions = JSON.parse(body) as Array<{
+        launchOptions?: Record<string, unknown>;
+      }>;
+
+      expect(sessions).to.have.length.greaterThan(0);
+      for (const s of sessions) {
+        expect(s.launchOptions ?? {}).to.not.have.property('env');
+      }
+      expect(body).to.not.include('must-not-be-served');
+    } finally {
+      delete process.env.SCRATCH_SPEC_SECRET;
+      await browser.close();
+    }
   });
 });

--- a/src/browsers/scratch-dirs.spec.ts
+++ b/src/browsers/scratch-dirs.spec.ts
@@ -4,6 +4,7 @@ import {
   Config,
   Metrics,
   availableBrowsers,
+  generateScratchDir,
 } from '@browserless.io/browserless';
 import { expect } from 'chai';
 import fs from 'fs/promises';
@@ -138,15 +139,24 @@ describe('Browser scratch directories', function () {
     );
 
     try {
-      let error: unknown;
+      let scratchError: Error | undefined;
+      await generateScratchDir(undefined, config).catch((err) => {
+        scratchError = err;
+      });
+      expect(scratchError).to.be.instanceOf(Error);
+      expect(scratchError?.message).to.include(
+        'Error creating scratch directory',
+      );
+
+      let connectionError: unknown;
       await connect().catch((err) => {
-        error = err;
+        connectionError = err;
       });
       createdDataDirs = (await fs.readdir(dataRoot)).filter(
         (entry) => !before.has(entry),
       );
 
-      expect(error).to.not.equal(undefined);
+      expect(connectionError).to.not.equal(undefined);
       expect(createdDataDirs).to.deep.equal([]);
     } finally {
       (config as unknown as { scratchDir: string }).scratchDir =

--- a/src/browsers/scratch-dirs.spec.ts
+++ b/src/browsers/scratch-dirs.spec.ts
@@ -8,6 +8,7 @@ import {
 import { expect } from 'chai';
 import fs from 'fs/promises';
 import os from 'os';
+import path from 'path';
 import puppeteer from 'puppeteer-core';
 
 /**
@@ -63,9 +64,12 @@ describe('Browser scratch directories', function () {
 
   const session = async () => {
     const browser = await connect();
-    const page = await browser.newPage();
-    await page.goto('about:blank');
-    await browser.close();
+    try {
+      const page = await browser.newPage();
+      await page.goto('about:blank');
+    } finally {
+      await browser.close();
+    }
   };
 
   it('leaves no browser scratch in the shared temp dir', async () => {
@@ -79,21 +83,81 @@ describe('Browser scratch directories', function () {
   it('removes the session scratch dir once the session ends', async () => {
     const scratchRoot = config.getScratchDir();
     const before = new Set(await listTemp(scratchRoot));
+    const browser = await connect();
+    let scratchDir: string;
 
-    await session();
+    try {
+      const page = await browser.newPage();
+      await page.goto('about:blank');
+
+      const created = (await fs.readdir(scratchRoot)).filter(
+        (entry) => !before.has(entry),
+      );
+      expect(created).to.have.length(1);
+      scratchDir = path.join(scratchRoot, created[0]);
+      await fs.access(scratchDir);
+    } finally {
+      await browser.close();
+    }
 
     // The client's close() resolves when the socket does; the server-side
     // teardown that reclaims the dir runs after that, so poll rather than
     // asserting on the instant the connection drops.
-    let left: string[] = [];
+    let removed = false;
     const deadline = Date.now() + 10_000;
     do {
-      left = (await listTemp(scratchRoot)).filter((e) => !before.has(e));
-      if (!left.length) break;
+      try {
+        await fs.access(scratchDir!);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw err;
+        }
+        removed = true;
+        break;
+      }
       await new Promise((resolve) => setTimeout(resolve, 250));
     } while (Date.now() < deadline);
 
-    expect(left).to.deep.equal([]);
+    expect(removed).to.equal(true);
+  });
+
+  it('removes the generated data dir when scratch creation fails', async () => {
+    const dataRoot = await config.getDataDir();
+    const before = new Set(await fs.readdir(dataRoot));
+    const originalScratchRoot = config.getScratchDir();
+    const blockerRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'scratch-blocker-'),
+    );
+    const blocker = path.join(blockerRoot, 'file');
+    let createdDataDirs: string[] = [];
+
+    await fs.writeFile(blocker, '');
+    (config as unknown as { scratchDir: string }).scratchDir = path.join(
+      blocker,
+      'nested',
+    );
+
+    try {
+      let error: unknown;
+      await connect().catch((err) => {
+        error = err;
+      });
+      createdDataDirs = (await fs.readdir(dataRoot)).filter(
+        (entry) => !before.has(entry),
+      );
+
+      expect(error).to.not.equal(undefined);
+      expect(createdDataDirs).to.deep.equal([]);
+    } finally {
+      (config as unknown as { scratchDir: string }).scratchDir =
+        originalScratchRoot;
+      await Promise.all(
+        createdDataDirs.map((entry) =>
+          fs.rm(path.join(dataRoot, entry), { recursive: true, force: true }),
+        ),
+      );
+      await fs.rm(blockerRoot, { recursive: true, force: true });
+    }
   });
 
   /**
@@ -104,10 +168,12 @@ describe('Browser scratch directories', function () {
    * other host credential to anyone who can read the endpoint.
    */
   it('does not publish the browser environment through /sessions', async () => {
-    process.env.SCRATCH_SPEC_SECRET = 'must-not-be-served';
-    const browser = await connect();
+    const originalSecret = process.env.SCRATCH_SPEC_SECRET;
+    let browser: Awaited<ReturnType<typeof connect>> | undefined;
 
     try {
+      process.env.SCRATCH_SPEC_SECRET = 'must-not-be-served';
+      browser = await connect();
       const res = await fetch(
         'http://localhost:3000/sessions?token=6R0W53R135510',
       );
@@ -122,8 +188,12 @@ describe('Browser scratch directories', function () {
       }
       expect(body).to.not.include('must-not-be-served');
     } finally {
-      delete process.env.SCRATCH_SPEC_SECRET;
-      await browser.close();
+      if (originalSecret === undefined) {
+        delete process.env.SCRATCH_SPEC_SECRET;
+      } else {
+        process.env.SCRATCH_SPEC_SECRET = originalSecret;
+      }
+      await browser?.close();
     }
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -229,6 +229,10 @@ export class Config extends EventEmitter {
     ? untildify(process.env.DATA_DIR)
     : path.join(tmpdir(), 'browserless-data-dirs');
 
+  protected scratchDir = process.env.SCRATCH_DIR
+    ? untildify(process.env.SCRATCH_DIR)
+    : path.join(tmpdir(), 'browserless-scratch-dirs');
+
   protected metricsJSONPath = process.env.METRICS_JSON_PATH
     ? untildify(process.env.METRICS_JSON_PATH)
     : path.join(tmpdir(), 'browserless-metrics.json');
@@ -520,6 +524,25 @@ export class Config extends EventEmitter {
     }
 
     return this.downloadsDir;
+  }
+
+  /**
+   * Root under which each session gets its own directory to use as TMPDIR.
+   *
+   * Chromium writes its scratch — ScopedTempDir, component-updater fetches,
+   * crashpad — into `base::GetTempDir()`, and abandons all of it when the
+   * process exits on SIGKILL, which is how a browser that ignores SIGTERM is
+   * ended. In the shared temp dir that scratch is unreclaimable: it sits outside
+   * both getDataDir() and getDownloadsDir(), so nothing knows it exists and it
+   * survives every restart.
+   *
+   * Deliberately a sibling of the data-dir root rather than a child of the
+   * session's user-data dir: a caller-supplied user-data dir is the caller's to
+   * manage and is never removed here, so scratch nested inside one would
+   * accumulate there for the life of that profile.
+   */
+  public getScratchDir(): string {
+    return this.scratchDir;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,6 +434,13 @@ export interface BrowserServerOptions {
   chromiumSandbox?: boolean;
   devtools?: boolean;
   downloadsPath?: string;
+  /**
+   * Environment for the browser process. Honored by both puppeteer.launch and
+   * playwright.launchServer. Set server-side to give the session its own TMPDIR
+   * (see generateScratchDir); a caller-supplied value is merged under it, since
+   * a session must not be able to point its scratch back at the shared temp dir.
+   */
+  env?: Record<string, string | undefined>;
   headless?: boolean;
   ignoreDefaultArgs?: boolean | string[];
   proxy?: {
@@ -459,6 +466,12 @@ export interface BrowserlessSession {
   numbConnected: number;
   resolver(val: unknown): void;
   routePath: string | string[];
+  /**
+   * This session's TMPDIR, removed on close. Unlike userDataDir it is always
+   * browserless-owned, so it is reclaimed whether or not the caller supplied
+   * their own data dir.
+   */
+  scratchDir: string | null;
   startedOn: number;
   trackingId?: string;
   ttl: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -439,6 +439,9 @@ export interface BrowserServerOptions {
    * playwright.launchServer. Set server-side to give the session its own TMPDIR
    * (see generateScratchDir); a caller-supplied value is merged under it, since
    * a session must not be able to point its scratch back at the shared temp dir.
+   *
+   * That merge happens on the object handed to `launch` only. It is kept off
+   * the session's stored `launchOptions`, which /sessions serves verbatim.
    */
   env?: Record<string, string | undefined>;
   headless?: boolean;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -264,6 +264,13 @@ describe('Utils', () => {
 describe('#generateScratchDir', () => {
   const config = new Config();
 
+  before(async () => {
+    const scratchRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'browserless-scratch-spec-'),
+    );
+    (config as unknown as { scratchDir: string }).scratchDir = scratchRoot;
+  });
+
   after(async () => {
     await fs.rm(config.getScratchDir(), { recursive: true, force: true });
   });
@@ -277,7 +284,7 @@ describe('#generateScratchDir', () => {
   });
 
   it('defaults the scratch root to a sibling of the data-dir root', () => {
-    expect(config.getScratchDir()).to.equal(
+    expect(new Config().getScratchDir()).to.equal(
       path.join(os.tmpdir(), 'browserless-scratch-dirs'),
     );
   });
@@ -298,10 +305,13 @@ describe('#generateScratchDir', () => {
     expect(sessionId.replace(/-/g, '')).to.include(segment);
   });
 
-  it('returns null rather than throwing when the root cannot be created', async () => {
+  it('throws when the root cannot be created', async () => {
     const unwritable = new Config();
     // A path under a regular file can never be created.
-    const blocker = path.join(os.tmpdir(), `scratch-blocker-${Date.now()}`);
+    const blockerRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'scratch-blocker-'),
+    );
+    const blocker = path.join(blockerRoot, 'file');
     await fs.writeFile(blocker, '');
     (unwritable as unknown as { scratchDir: string }).scratchDir = path.join(
       blocker,
@@ -309,9 +319,15 @@ describe('#generateScratchDir', () => {
     );
 
     try {
-      expect(await generateScratchDir(undefined, unwritable)).to.equal(null);
+      let error: Error | undefined;
+      await generateScratchDir(undefined, unwritable).catch((err) => {
+        error = err;
+      });
+
+      expect(error).to.be.instanceOf(Error);
+      expect(error?.message).to.include('Error creating scratch directory');
     } finally {
-      await fs.rm(blocker, { force: true });
+      await fs.rm(blockerRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,8 +1,13 @@
 import { expect } from 'chai';
+import fs from 'fs/promises';
 import { ServerResponse } from 'http';
 import { Socket } from 'net';
+import os from 'os';
+import path from 'path';
 import {
+  Config,
   contentTypes,
+  generateScratchDir,
   getFinalPathSegment,
   getPageContent,
   toSetContentOptions,
@@ -253,5 +258,60 @@ describe('Utils', () => {
         }),
       ).to.deep.equal({});
     });
+  });
+});
+
+describe('#generateScratchDir', () => {
+  const config = new Config();
+
+  after(async () => {
+    await fs.rm(config.getScratchDir(), { recursive: true, force: true });
+  });
+
+  it('creates the directory under the configured scratch root', async () => {
+    const scratchDir = await generateScratchDir(undefined, config);
+
+    expect(scratchDir).to.be.a('string');
+    expect(path.dirname(scratchDir!)).to.equal(config.getScratchDir());
+    await fs.access(scratchDir!);
+  });
+
+  it('defaults the scratch root to a sibling of the data-dir root', () => {
+    expect(config.getScratchDir()).to.equal(
+      path.join(os.tmpdir(), 'browserless-scratch-dirs'),
+    );
+  });
+
+  /**
+   * Chrome's process singleton puts a unix socket beneath TMPDIR and appends
+   * ~45 bytes of its own, which sun_path caps at 108 in total. A full 36-char
+   * session id here made Chrome exit at startup with "Socket path too long".
+   */
+  it('shortens the session id so a unix socket still fits beneath it', async () => {
+    const sessionId = 'f0cb34d8-a697-4326-ae72-b71217b69f04';
+    const scratchDir = await generateScratchDir(sessionId, config);
+    const segment = path.basename(scratchDir!);
+
+    expect(segment).to.have.length.of.at.most(16);
+    expect(segment).to.not.equal(sessionId);
+    // Still derived from the session, so scratch stays attributable.
+    expect(sessionId.replace(/-/g, '')).to.include(segment);
+  });
+
+  it('returns null rather than throwing when the root cannot be created', async () => {
+    const unwritable = new Config();
+    // A path under a regular file can never be created.
+    const blocker = path.join(os.tmpdir(), `scratch-blocker-${Date.now()}`);
+    await fs.writeFile(blocker, '');
+    (unwritable as unknown as { scratchDir: string }).scratchDir = path.join(
+      blocker,
+      'nested',
+    );
+
+    try {
+      expect(await generateScratchDir(undefined, unwritable)).to.equal(null);
+    } finally {
+      await fs.rm(blocker, { force: true });
+    }
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -284,9 +284,20 @@ describe('#generateScratchDir', () => {
   });
 
   it('defaults the scratch root to a sibling of the data-dir root', () => {
-    expect(new Config().getScratchDir()).to.equal(
-      path.join(os.tmpdir(), 'browserless-scratch-dirs'),
-    );
+    const originalScratchDir = process.env.SCRATCH_DIR;
+
+    try {
+      delete process.env.SCRATCH_DIR;
+      expect(new Config().getScratchDir()).to.equal(
+        path.join(os.tmpdir(), 'browserless-scratch-dirs'),
+      );
+    } finally {
+      if (originalScratchDir === undefined) {
+        delete process.env.SCRATCH_DIR;
+      } else {
+        process.env.SCRATCH_DIR = originalScratchDir;
+      }
+    }
   });
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,9 +384,9 @@ export const generateDataDir = async (
 
 /**
  * Create this session's scratch directory, to be handed to the browser as
- * TMPDIR. Returns null when it cannot be created: a session that launches with
- * the inherited temp dir leaks its scratch, which is worse than containing it
- * but much better than failing the launch outright.
+ * TMPDIR. Fails the session launch when it cannot be created: falling back to
+ * the inherited shared temp dir would restore the disk leak this isolation is
+ * intended to prevent.
  *
  * The directory name is a short slice of the session id, NOT the whole thing.
  * Chrome's process singleton puts a unix socket beneath TMPDIR and appends ~45
@@ -399,21 +399,19 @@ export const generateDataDir = async (
 export const generateScratchDir = async (
   sessionId: string = id(),
   config: Config,
-): Promise<string | null> => {
+): Promise<string> => {
   const scratchDirPath = path.join(
     config.getScratchDir(),
     sessionId.replace(/-/g, '').slice(0, 12),
   );
 
-  try {
-    await fs.mkdir(scratchDirPath, { recursive: true });
-    return scratchDirPath;
-  } catch (err) {
-    debug(
-      `Error creating scratch directory "${scratchDirPath}", the browser will use the shared temp dir: ${err}`,
+  await fs.mkdir(scratchDirPath, { recursive: true }).catch((err) => {
+    throw new ServerError(
+      `Error creating scratch directory "${scratchDirPath}": ${err}`,
     );
-    return null;
-  }
+  });
+
+  return scratchDirPath;
 };
 
 export const readBody = async (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -382,6 +382,40 @@ export const generateDataDir = async (
   return dataDirPath;
 };
 
+/**
+ * Create this session's scratch directory, to be handed to the browser as
+ * TMPDIR. Returns null when it cannot be created: a session that launches with
+ * the inherited temp dir leaks its scratch, which is worse than containing it
+ * but much better than failing the launch outright.
+ *
+ * The directory name is a short slice of the session id, NOT the whole thing.
+ * Chrome's process singleton puts a unix socket beneath TMPDIR and appends ~45
+ * bytes of its own ("/org.chromium.Chromium.XXXXXX/SingletonSocket"); a full
+ * 36-char uuid here pushes the total past sun_path's 108-byte cap and Chrome
+ * exits at startup with "Socket path too long". 48 bits is ample against
+ * collision between concurrent sessions, which is all this must be unique
+ * across.
+ */
+export const generateScratchDir = async (
+  sessionId: string = id(),
+  config: Config,
+): Promise<string | null> => {
+  const scratchDirPath = path.join(
+    config.getScratchDir(),
+    sessionId.replace(/-/g, '').slice(0, 12),
+  );
+
+  try {
+    await fs.mkdir(scratchDirPath, { recursive: true });
+    return scratchDirPath;
+  } catch (err) {
+    debug(
+      `Error creating scratch directory "${scratchDirPath}", the browser will use the shared temp dir: ${err}`,
+    );
+    return null;
+  }
+};
+
 export const readBody = async (
   req: Request,
   maxSize: number = 10485760,


### PR DESCRIPTION
## The problem

A busy deployment accumulated **2681 orphaned Chrome scratch directories and 125GB of `/tmp` in two hours of uptime**. The temp root held 8849 entries, 2681 of them matching `org.chromium.Chromium.chromium_chrome_url_fetcher_.*` — largest around 194MB — and every one had zero open file descriptors, so they were fully orphaned rather than in use.

Chromium writes its scratch into `base::GetTempDir()`, the shared system temp dir, not the session's own directories. It unlinks that scratch from `ScopedTempDir`'s destructor, which never runs when the process exits on SIGKILL — and SIGKILL is how a browser that ignores SIGTERM gets ended. The abandoned directories then sit outside both `getDataDir()` and `getDownloadsDir()`, so the per-session removal in `BrowserManager.close()` never sees them and they survive every restart.

## Correction to the original version of this PR

This PR first proposed **only** `--disable-component-update`, and described the component updater as the cause. That was wrong, and since the earlier description asserted it confidently it is worth showing the measurement rather than quietly editing it away.

Probing on Linux — fresh profile, browser ended with SIGKILL:

| run | args | orphaned in the shared temp dir |
|---|---|---|
| 1 | none | `org.chromium.Chromium.e2gy9N` |
| 2 | `--disable-component-update --disable-background-networking` | `org.chromium.Chromium.k39BFI` **and `…chromium_chrome_url_fetcher_.3dhSZ0`** |
| 3 | those flags **plus `TMPDIR` redirected** | nothing new |

Run 2 is the point: the switch does not prevent the `url_fetcher` directory being created, and prevents none of it being abandoned. Suppressing the fetches was the wrong lever. Run 3 is the fix.

## The fix: contain the scratch

Each session gets its own directory under a scratch root, handed to the browser as `TMPDIR`, so what Chromium abandons lands inside a directory that session owns.

`BrowserManager` creates it alongside the data dir and removes it in the same `finally`. That placement covers the Playwright launcher for free, since both launchers honor `env`. Unlike the data dir it is removed **unconditionally** — it is browserless-owned even when the caller supplied their own `--user-data-dir`.

The scratch root is a **sibling** of the data-dir root, not a child of the session's user-data dir. A caller-supplied user-data dir is the caller's to manage and is never removed here, so scratch nested inside one would accumulate for the life of that profile and ride along anywhere that profile is copied.

`removeUserDataDir` is generalized to `removeSessionDir`, so scratch reclaim inherits the existing retry-with-backoff and the background sweep for directories that outlast their retries.

## `env` on BrowserServerOptions

Both launchers already forwarded `env`; it simply was not declared. Declaring it lets a downstream image set it without casting. A caller-supplied value is merged **under** `TMPDIR`, so a session cannot redirect its own scratch back into the shared temp dir.

## A trap worth knowing about

The first attempt made Chrome fail to launch outright:

    FATAL:process_singleton_posix.cc:313] Socket path too long:
    /tmp/browserless-scratch-dirs/f0cb34d8-a697-4326-ae72-b71217b69f04/org.chromium.Chromium.tZ5CHk/SingletonSocket

Chrome's process singleton places a unix socket beneath `TMPDIR` and appends around 45 bytes of its own, and `sun_path` caps the total at 108. A full 36-char session id blew the budget. The directory name is now a 12-char slice, with a test pinning it so it does not get "fixed" back to the full id.

## The switch stays, on its own merits

`--disable-component-update` is kept, but as a bandwidth and determinism measure rather than as the fix. Component refresh spends bandwidth mid-run and makes the browser behave differently between otherwise identical automation runs. Updated component data reaches deployments through a new browser build in a new image, which is the only reproducible refresh channel here and is unaffected by the switch. Puppeteer's `defaultArgs` ships the sibling `--disable-background-networking` but not this one, which is why the gap survived.

Worth a maintainer opinion: Chrome has no `--enable-component-update`, so the switch cannot be re-enabled per-session today. If an escape hatch is wanted, the natural shape is a `Config` getter defaulting to disabled rather than a `userDataDir` heuristic. Happy to add that instead.

## Verification

- The integration suite asserts a `/chromium` session leaves no scratch in the shared temp dir, observes its own scratch directory while Chrome is alive, and verifies that exact directory is gone once the session ends.
- Unit tests cover the generator: creation under the configured root, the shortened segment, and rejecting the launch when the root cannot be created so Chromium cannot fall back to shared `/tmp`.
- The launch-args suite is gated on `availableBrowsers`, so it skips on single-browser images rather than failing them, which is what turned the earlier `chrome` / `edge` / `firefox` / `webkit` jobs red.
- 33 passing locally across the utils, CDP, and scratch suites; the scratch suite also passes 5/5 repeated runs.
- The final Chromium image builds locally on Linux/arm64. Runtime probes confirm scratch containment and exact cleanup, no browser environment in `/sessions`, and rejection of an unusable `SCRATCH_DIR` without launching Chrome or leaking the generated data dir.

On `routes/chromium/tests/kill-sessions`: it flakes on an `afterEach` timeout on my machine at roughly 3/5 runs on `main` and 2/5 on this branch, so it is pre-existing rather than fallout from this change. Flagging it so it is not mistaken for a regression here.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chromium sessions now use isolated temporary directories.
  * Added support for configuring the scratch-directory location.
  * Browser process environment settings can be supplied at launch time.

* **Bug Fixes**
  * Disabled Chrome’s component updater during sessions.
  * Temporary session files are automatically cleaned up after browser shutdown.
  * Improved cleanup and recovery when browser launches or directory removal fails.
  * Prevented browser environment variables from appearing in session information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
